### PR TITLE
Fix resubscription failure when reconnecting

### DIFF
--- a/internal/topo/source/mqtt_source.go
+++ b/internal/topo/source/mqtt_source.go
@@ -146,6 +146,7 @@ func (ms *MQTTSource) Open(ctx api.StreamContext, consumer chan<- api.SourceTupl
 	opts.SetOnConnectHandler(func(client MQTT.Client) {
 		if reconn {
 			log.Infof("The connection is %s re-established successfully.", ms.srv+": "+ms.clientid)
+			subscribe(ms.tpc, client, ctx, consumer, ms.model, ms.format)
 		}
 	})
 


### PR DESCRIPTION
When the MQTT client reconnects, the subscription function may be executed before the connection, resulting in the following error:
**Found error: not currently connected and ResumeSubs not set**
In order to avoid subscription failure, it is best to initiate a subscription after the connection is successful

Of course there might be a better way to do this, but I'm just offering an idea