### PR TITLE
Memory leak when use http pull source

### DIFF
--- a/internal/topo/source/httppull_source.go
+++ b/internal/topo/source/httppull_source.go
@@ -176,11 +176,11 @@ func (hps *HTTPPullSource) initTimerPull(ctx api.StreamContext, consumer chan<- 
 					logger.Warnf("Found error http return code: %d when trying to reach %v ", resp.StatusCode, hps)
 					break
 				}
-				defer resp.Body.Close()
 				c, err := ioutil.ReadAll(resp.Body)
 				if err != nil {
 					logger.Warnf("Found error %s when trying to reach %v ", err, hps)
 				}
+				resp.Body.Close()
 				if hps.incremental {
 					nmd5 := getMD5Hash(c)
 					if omd5 == nmd5 {
@@ -201,6 +201,8 @@ func (hps *HTTPPullSource) initTimerPull(ctx api.StreamContext, consumer chan<- 
 				select {
 				case consumer <- api.NewDefaultSourceTuple(result, meta):
 					logger.Debugf("send data to device node")
+				case <-ctx.Done():
+					return
 				}
 			}
 		case <-ctx.Done():


### PR DESCRIPTION
fix(source httppull): Memory leak when use http source

Should close http connection after read out the body
Add ctx.Done() check in select statement, else will lead to goroutine leak

Close #888 #925
Signed-off-by: Jianxiang Ran <rxan_embedded@163.com>