### PR TITLE
fix(operator): join tuple must exclude default stream

### DIFF
--- a/internal/topo/operator/join_operator.go
+++ b/internal/topo/operator/join_operator.go
@@ -73,6 +73,10 @@ func (jp *JoinOp) getStreamNames(join *ast.Join) ([]string, error) {
 	ast.WalkFunc(join, func(node ast.Node) bool {
 		if f, ok := node.(*ast.FieldRef); ok {
 			for _, v := range f.RefSources() {
+				// Exclude default stream as it is a virtual stream name.
+				if v == ast.DefaultStream {
+					continue
+				}
 				if _, ok := keys[v]; !ok {
 					srcs = append(srcs, string(v))
 					keys[v] = true

--- a/internal/topo/operator/join_test.go
+++ b/internal/topo/operator/join_test.go
@@ -35,7 +35,7 @@ func TestLeftJoinPlan_Apply(t *testing.T) {
 		result interface{}
 	}{
 		{ //0
-			sql: "SELECT id1 FROM src1 left join src2 on src1.id1 = src2.id2",
+			sql: "SELECT id1 FROM src1 left join src2 on id1 = id2",
 			data: xsql.WindowTuplesSet{
 				Content: []xsql.WindowTuples{
 					{


### PR DESCRIPTION
In schemaless mode, the analyzer cannot deduce the stream of a field so that the ref source of a fieldRef could be $$default, which means it could be any of the stream. And that is not a real stream to form a join tuple so we should exclude it.

Signed-off-by: Jiyong Huang <huangjy@emqx.io>