### PR TITLE
fix(*): reflect.TypeOf must check nil to avoid panic

### DIFF
--- a/internal/plugin/sourceMeta.go
+++ b/internal/plugin/sourceMeta.go
@@ -304,7 +304,7 @@ func recursionDelMap(cf, fields map[string]interface{}, language string) error {
 			delete(auxCf, delKey)
 			continue
 		}
-		if reflect.Map == reflect.TypeOf(v).Kind() {
+		if reflect.TypeOf(v) != nil && reflect.Map == reflect.TypeOf(v).Kind() {
 			var auxCf, auxFields map[string]interface{}
 			if err := cast.MapToStruct(cf[k], &auxCf); nil != err {
 				return fmt.Errorf(`%s%s.%v`, getMsg(language, source, "type_conversion_fail"), k, v)
@@ -364,7 +364,7 @@ func recursionNewFields(template []field, conf map[string]interface{}, ret *[]fi
 		if nil == v {
 			p.Default = v
 		} else {
-			if reflect.Map == reflect.TypeOf(v).Kind() {
+			if reflect.TypeOf(v) != nil && reflect.Map == reflect.TypeOf(v).Kind() {
 				var nextCf map[string]interface{}
 				if tmp, ok := v.(map[interface{}]interface{}); ok {
 					nextCf = cast.ConvertMap(tmp)

--- a/internal/topo/sink/edgex_sink_test.go
+++ b/internal/topo/sink/edgex_sink_test.go
@@ -108,7 +108,8 @@ func TestProduceEvents(t1 *testing.T) {
 							"temperature":{"deviceName":"test device name2","id":"22","origin":24}
 							}
 						},
-						{"h1":100}
+						{"h1":100},
+						{"h2":null}
 					]`,
 			expected: &dtos.Event{
 				Id:          "abc",

--- a/internal/topo/source/mqtt_type.go
+++ b/internal/topo/source/mqtt_type.go
@@ -39,7 +39,7 @@ type modelVersion interface {
 	checkType(map[string]interface{}, string) []string
 }
 
-func modelFactory(version string) modelVersion {
+func modelFactory(_ string) modelVersion {
 	return new(deviceModel)
 }
 func (this *property) getName() string {
@@ -81,8 +81,11 @@ func intToBool(i int) bool {
 }
 func changeType(modelType string, data interface{}) (interface{}, string) {
 	var err error
-	dataType := reflect.TypeOf(data).Kind()
-	switch dataType {
+	dt := reflect.TypeOf(data)
+	if dt == nil {
+		return data, fmt.Sprintf("not support type : %v", nil)
+	}
+	switch dt.Kind() {
 	case reflect.Bool:
 		b, _ := data.(bool)
 		switch modelType {
@@ -138,7 +141,7 @@ func changeType(modelType string, data interface{}) (interface{}, string) {
 			return data, fmt.Sprintf("not support modelType : %s", modelType)
 		}
 	default:
-		return data, fmt.Sprintf("not support type : %v", dataType)
+		return data, fmt.Sprintf("not support type : %v", dt.Kind())
 	}
 	return data, ""
 }

--- a/internal/topo/source/mqtt_type_test.go
+++ b/internal/topo/source/mqtt_type_test.go
@@ -30,6 +30,7 @@ func TestCheckType(t *testing.T) {
 		{"temperature": "1", "humidity": "1"},
 		{"temperature": 1, "humidity": "1"},
 		{"temperature": "1", "humidity": 1},
+		{"temperature": nil, "humidity": "1"},
 	}
 
 	topics := []string{`$ke/events/device/device1/data/update`, `$ke/events/device/device2/data/update`}

--- a/pkg/cast/cast.go
+++ b/pkg/cast/cast.go
@@ -837,10 +837,11 @@ func ToTypedSlice(input interface{}, conv func(interface{}, Strictness) (interfa
 		return nil, fmt.Errorf("cannot convert %[1]T(%[1]v) to %s slice)", input, eleType)
 	}
 	ele, err := conv(s.Index(0).Interface(), sn)
-	if err != nil {
+	et := reflect.TypeOf(ele)
+	if err != nil || et == nil {
 		return nil, fmt.Errorf("cannot convert %[1]T(%[1]v) to %s slice for the %d element: %v", input, eleType, 0, err)
 	}
-	result := reflect.MakeSlice(reflect.SliceOf(reflect.TypeOf(ele)), s.Len(), s.Len())
+	result := reflect.MakeSlice(reflect.SliceOf(et), s.Len(), s.Len())
 	result.Index(0).Set(reflect.ValueOf(ele))
 	for i := 1; i < s.Len(); i++ {
 		ele, err := conv(s.Index(i).Interface(), sn)


### PR DESCRIPTION
A lot of places are using reflect.TypeOf(i).Kind() to check interface types. If i is nil, the TypeOf may return nil so that this will cause a panic. Fix all potential problems.

Closes: #938

Signed-off-by: Jiyong Huang <huangjy@emqx.io>