### PR TITLE
fix(edgex): add messageType for sink

### DIFF
--- a/docs/en_US/rules/sinks/edgex.md
+++ b/docs/en_US/rules/sinks/edgex.md
@@ -2,21 +2,24 @@
 
 The action is used for publishing output message into EdgeX message bus.  
 
-**Please notice that, if you're using the ZeorMQ message bus, the action will create a NEW EdgeX message bus (with the address where running eKuiper service), but not by leveraging the original message bus (normally it's the address & port exposed by application service). **
+**Please notice that, if you're using the ZeorMQ message bus, the action will create a NEW EdgeX message bus (with the address where running eKuiper service), but not by leveraging the original message bus (normally it's the address & port exposed by application service).**
 
 **Also, you need to expose the port number to host server before running the eKuiper server if you want to have the service available to other hosts.**
 
 | Property name | Optional | Description                                                  |
 | ------------- | -------- | ------------------------------------------------------------ |
-| protocol      | true     | The protocol. If it's not specified, then use default value ``tcp``. |
-| host          | true     | The host of message bus. If not specified, then use default value ``*``. |
-| port          | true     | The port of message bus. If not specified, then use default value ``5563``. |
-| topic         | true     | The topic to be published. If not specified, then use default value ``events``. |
+| type          | true     | The message bus type, three types of message buses are supported, ``zero``, ``mqtt`` and ``redis``, and ``redis`` is the default value. |
+| protocol      | true     | The protocol. If it's not specified, then use default value ``redis``. |
+| host          | true     | The host of message bus. If not specified, then use default value ``localhost``. |
+| port          | true     | The port of message bus. If not specified, then use default value ``6379``. |
+| topic         | true     | The topic to be published. The topic is static across all messages. To use dynamic topic, leave this empty and specify the topicPrefix property. Only one of the topic and topicPrefix properties can be specified. If both are not specified, then use default topic value ``application``. |
+| topicPrefix         | true     | The prefix of a dynamic topic to be published. The topic will become a concatenation of `$topicPrefix/$deviceName/$profileName/$sourceName`. |
 | contentType   | true     | The content type of message to be published. If not specified, then use the default value ``application/json``. |
+| messageType   | true     | The EdgeX message model type. To publish the message as an event like EdgeX application service, use `event`. Otherwise, to publish the message as an event request like EdgeX device service or core data service, use `request`. If not specified, then use the default value ``event``. |
 | metadata      | true     | The property is a field name that allows user to specify a field name of SQL  select clause,  the field name should use ``meta(*) AS xxx``  to select all of EdgeX metadata from message. |
-| deviceName    | true     | Allows user to specify the device name in the event structure that are sent from eKuiper. |
-| profileName    | true     | Allows user to specify the profile name in the event structure that are sent from Kuiper. |
-| type          | true     | The message bus type, two types of message buses are supported, ``zero`` or ``mqtt``, and ``zero`` is the default value. |
+| deviceName    | true     | Allows user to specify the device name in the event structure that are sent from eKuiper. The deviceName in the meta take precedence if specified.  |
+| profileName    | true     | Allows user to specify the profile name in the event structure that are sent from eKuiper. The profileName in the meta take precedence if specified. |
+| sourceName    | true     | Allows user to specify the source name in the event structure that are sent from eKuiper. The sourceName in the meta take precedence if specified. |
 | optional      | true     | If ``mqtt`` message bus type is specified, then some optional values can be specified. Please refer to below for supported optional supported configurations. |
 
 Below optional configurations are supported, please check MQTT specification for the detailed information.
@@ -35,7 +38,110 @@ Below optional configurations are supported, please check MQTT specification for
   - KeyPEMBlock
   - SkipCertVerify
 
-## Examples
+## Send to various targets
+
+By setting the combination of the properties, we can send the result to various EdgeX message bus settings.
+
+### Publish to redis message bus like application service
+
+With the default setting, the EdgeX sink will publish to the default redis message bus as application events. In EdgeX, those messages can be consumed like events emitted by application service. 
+
+```json
+{
+  "id": "ruleRedisEvent",
+  "sql": "SELECT temperature * 3 AS t1, humidity FROM events",
+  "actions": [
+    {
+      "edgex": {
+        "protocol": "redis",
+        "host": "localhost",
+        "port": 6379,
+        "topic": "application",
+        "deviceName": "ekuiper",
+        "profileName": "ekuiperProfile",
+        "contentType": "application/json"
+      }
+    }
+  ]
+}
+```
+
+### Publish to redis message bus like device service
+
+By changing the `topicPrefix` and `messageType` properties, we can let EdgeX sink simulates a device. The topic name for device in EdgeX is like `edgex/events/device/$deviceName/$profileName/$sourceName` so we set the `topicPrefix` to `edgex/events/device` to make sure the messages are routing to device events. And by specifying the `metadata` property, we can have a dynamic topic to simulate multiple devices. Check the next section [dynamic metadata](#dynamic-metadata) for details.
+
+```json
+{
+  "id": "ruleRedisDevice",
+  "sql": "SELECT temperature * 3 AS t1, humidity FROM events",
+  "actions": [
+    {
+      "edgex": {
+        "protocol": "redis",
+        "host": "localhost",
+        "port": 6379,
+        "topicPrefix": "edgex/events/device",
+        "messageType": "request",
+        "metadata": "metafield_name",
+        "contentType": "application/json"
+      }
+    }
+  ]
+}
+```
+
+## Publish to MQTT message bus
+
+Below is a rule that send analysis result to MQTT message bus, please notice how to specify ``ClientId`` in ``optional`` configuration. 
+
+```json
+{
+  "id": "ruleMqtt",
+  "sql": "SELECT meta(*) AS edgex_meta, temperature, humidity, humidity*2 as h1 FROM demo WHERE temperature = 20",
+  "actions": [
+    {
+      "edgex": {
+        "protocol": "tcp",
+        "host": "127.0.0.1",
+        "port": 1883,
+        "topic": "result",
+        "type": "mqtt",
+        "metadata": "edgex_meta",
+        "contentType": "application/json",
+        "optional": {
+        	"ClientId": "edgex_message_bus_001"
+        }
+      }
+    }
+  ]
+}
+```
+
+## Publish to zeromq message bus
+
+Below is a rule that send analysis result to zeromq message bus.
+
+```json
+{
+  "id": "ruleZmq",
+  "sql": "SELECT meta(*) AS edgex_meta, temperature, humidity, humidity*2 as h1 FROM demo WHERE temperature = 20",
+  "actions": [
+    {
+      "edgex": {
+        "protocol": "tcp",
+        "host": "*",
+        "port": 5571,
+        "topic": "application",
+        "deviceName": "kuiper",
+        "profileName": "kuiperProfile",
+        "contentType": "application/json"
+      }
+    }
+  ]
+}
+```
+
+## Dynamic metadata
 
 ### Publish result to a new EdgeX message bus without keeping original metadata
 In this case, the original metadata value (such as ``id, deviceName, profileName, sourceName, origin, tags`` in ``Events`` structure, and ``id, deviceName, profileName, origin, valueType`` in ``Reading`` structure will not be kept). eKuiper acts as another EdgeX micro service here, and it has own ``device name`` and ``profile name``. ``deviceName`` and ``profileName`` properties are provided, and allows user to specify the device name of eKuiper. The ``SourceName`` will be default to the ``topic`` property. Below is one example,
@@ -60,9 +166,6 @@ In this case, the original metadata value (such as ``id, deviceName, profileName
   "actions": [
     {
       "edgex": {
-        "protocol": "tcp",
-        "host": "*",
-        "port": 5571,
         "topic": "application",
         "deviceName": "kuiper",
         "profileName": "kuiperProfile",
@@ -113,9 +216,6 @@ Below is an example,
   "actions": [
     {
       "edgex": {
-        "protocol": "tcp",
-        "host": "*",
-        "port": 5571,
         "topic": "application",
         "metadata": "edgex_meta",
         "contentType": "application/json"
@@ -146,34 +246,4 @@ Please notice that,
 - If your SQL has aggregated function, then it does not make sense to keep these metadata, but eKuiper will still fill with metadata from a particular message in the time window. For example, with following SQL, 
 ```SELECT avg(temperature) AS temperature, meta(*) AS edgex_meta FROM ... GROUP BY TUMBLINGWINDOW(ss, 10)```. 
 In this case, there are possibly several messages in the window, the metadata value for ``temperature`` will be filled with value from 1st message that received from bus.
-
-## Send result to MQTT message bus
-
-Below is a rule that send analysis result to MQTT message bus, please notice how to specify ``ClientId`` in ``optional`` configuration.
-
-```json
-{
-  "id": "rule1",
-  "sql": "SELECT meta(*) AS edgex_meta, temperature, humidity, humidity*2 as h1 FROM demo WHERE temperature = 20",
-  "actions": [
-    {
-      "edgex": {
-        "protocol": "tcp",
-        "host": "127.0.0.1",
-        "port": 1883,
-        "topic": "result",
-        "type": "mqtt",
-        "metadata": "edgex_meta",
-        "contentType": "application/json",
-        "optional": {
-        	"ClientId": "edgex_message_bus_001"
-        }
-      }
-    },
-    {
-      "log":{}
-    }
-  ]
-}
-```
 

--- a/docs/zh_CN/rules/sinks/edgex.md
+++ b/docs/zh_CN/rules/sinks/edgex.md
@@ -2,21 +2,25 @@
 
 该目标用于将消息发送到 EdgeX 消息总线上。
 
-**请注意，如果你使用的是 ZeorMQ 消息总线，那么该 sink 会创建一个新的 EdgeX 消息总线（绑定到 eKuiper 服务所运行的地址），而不是利用原来既有的消息总线（通常为 application 服务所暴露的地址和端口）。 **
+**请注意，如果你使用的是 ZeorMQ 消息总线，那么该 sink 会创建一个新的 EdgeX 消息总线（绑定到 eKuiper 服务所运行的地址），而不是利用原来既有的消息总线（通常为 application 服务所暴露的地址和端口）。**
 
 **另外，如果你需要在别的主机上对你的端口可以进行访问，你需要在开始运行 eKuiper 服务之前，把端口号映射到主机上。**
 
 | 名称        | 可选 | Description                                                  |
 | ----------- | -------- | ------------------------------------------------------------ |
-| protocol    | true     | 协议，如未指定，使用缺省值 `tcp`.                             |
-| host        | 是    | 消息总线主机地址，使用缺省值 `*`.                      |
-| port        | 是    | 消息总线端口号。 如未指定，使用缺省值 `5563`.              |
-| topic       | 是    | 发布的主题名称，如未指定，使用缺省值 `events`.             |
-| contentType | 是    | 发布消息的内容类型，如未指定，使用缺省值 `application/json`. |
-| metadata    | 是    | 该属性为一个字段名称，该字段是 SQL SELECT 子句的一个字段名称，这个字段应该类似于 `meta(*) AS xxx` ，用于选出消息中所有的 EdgeX 元数据. |
-| deviceName  | 是    | 允许用户指定设备名称，该名称将作为从 eKuiper 中发送出来的 Event 结构体的设备名称. |
-| profileName  | 是    | 允许用户指定设备名称，该名称将作为从 Kuiper 中发送出来的 Event 结构体的 profile 名称. |
-| type          | 是    | 消息总线类型，目前支持两种类型的消息总线， `zero` 或者 `mqtt`，其中 `zero` 为缺省类型。 |
+| type          | 是    | 消息总线类型，目前支持三种类型的消息总线， `redis`, `zero` 或者 `mqtt`，其中 `redis` 为缺省类型。 |
+| protocol    | 是     | 协议，如未指定，使用缺省值 `tcp` 。  |
+| host        | 是    | 消息总线主机地址，使用缺省值 `*` 。                    |
+| port        | 是    | 消息总线端口号。 如未指定，使用缺省值 `5563` 。              |
+| topic       | 是    | 发布的主题名称。该主题为固定值。若不同的消息需要动态指定主题，则将该属性置空，并设置 topicPrefix 属性。这两个属性只能设置一个。若两者都未设置，则使用缺省主题 `application` 。          |
+| topicPrefix | 是     | 发布的主题的前缀。发送的主题将采用动态拼接，格式为`$topicPrefix/$deviceName/$profileName/$sourceName` 。|
+| contentType | 是    | 发布消息的内容类型，如未指定，使用缺省值 `application/json` 。|
+| messageType   | 是   | EdgeX 消息模型类型。若要将消息发送为类似 apllication service 的 event 类型，则应设置为 `event`。否则，若要将消息发送为类似 device service 或者 core data service 的 event request 类型，则应设置为 `request`。如未指定，使用缺省值 ``event`` 。|
+
+| metadata    | 是    | 该属性为一个字段名称，该字段是 SQL SELECT 子句的一个字段名称，这个字段应该类似于 `meta(*) AS xxx` ，用于选出消息中所有的 EdgeX 元数据 。 |
+| deviceName  | 是    | 允许用户指定设备名称，该名称将作为从 eKuiper 中发送出来的 Event 结构体的设备名称。若在 metadata 中设置了 deviceName 将会优先采用。 |
+| profileName  | 是    | 允许用户指定设备名称，该名称将作为从 eKuiper 中发送出来的 Event 结构体的 profile 名称。若在 metadata 中设置了 profileName 将会优先采用。|
+| sourceName    | 是   | 允许用户指定源名称，该名称将作为从 eKuiper 中发送出来的 Event 结构体的源名称。若在 metadata 中设置了 sourceName 将会优先采用。 |
 | optional      | 是    | 如果指定了 `mqtt` 消息总线，那么还可以指定一下可选的值。请参考以下可选的支持的配置类型。 |
 
 以下为支持的可选的配置列表，您可以参考 MQTT 协议规范来获取更详尽的信息。
@@ -35,7 +39,110 @@
   - KeyPEMBlock
   - SkipCertVerify
 
-## 例子
+## 发送到各种目标
+
+通过设置不同的属性组合，我们可以将结果采用不同的格式发送到不同的 EdgeX 消息总线设置中。
+
+### 像 application service 一样发送到 redis 消息总线
+
+使用默认配置，EdgeX sink 会将消息以 event 格式发送到默认的 redis 消息总线中。
+
+```json
+{
+  "id": "ruleRedisEvent",
+  "sql": "SELECT temperature * 3 AS t1, humidity FROM events",
+  "actions": [
+    {
+      "edgex": {
+        "protocol": "redis",
+        "host": "localhost",
+        "port": 6379,
+        "topic": "application",
+        "deviceName": "ekuiper",
+        "profileName": "ekuiperProfile",
+        "contentType": "application/json"
+      }
+    }
+  ]
+}
+```
+
+### 像 device service 一样发送到 redis 消息总线
+
+通过更改 `topicPrefix` 和 `messageType` 属性，我们可以让 EdgeX sink 模拟设备。设备默认情况下会发送消息到 `edgex/events/device/$deviceName/$profileName/$sourceName` 格式的主题中。所以，我们需要设置 `topicPrefix` 属性为 `edgex/events/device` 以确保消息路由为设备消息。此外，通过与 `metadata` 结合，我们可以发送到动态的主题中，从而模拟多个设备。详情参考下一节[动态元数据](#动态元数据)。
+
+```json
+{
+  "id": "ruleRedisDevice",
+  "sql": "SELECT temperature * 3 AS t1, humidity FROM events",
+  "actions": [
+    {
+      "edgex": {
+        "protocol": "redis",
+        "host": "localhost",
+        "port": 6379,
+        "topicPrefix": "edgex/events/device",
+        "messageType": "request",
+        "metadata": "metafield_name",
+        "contentType": "application/json"
+      }
+    }
+  ]
+}
+```
+
+## 发送到 MQTT 消息总线
+
+以下是将分析结果发送到 MQTT 消息总线的规则，请注意在`optional` 中是如何指定 `ClientId` 的。
+
+```json
+{
+  "id": "ruleMqtt",
+  "sql": "SELECT meta(*) AS edgex_meta, temperature, humidity, humidity*2 as h1 FROM demo WHERE temperature = 20",
+  "actions": [
+    {
+      "edgex": {
+        "protocol": "tcp",
+        "host": "127.0.0.1",
+        "port": 1883,
+        "topic": "result",
+        "type": "mqtt",
+        "metadata": "edgex_meta",
+        "contentType": "application/json",
+        "optional": {
+        	"ClientId": "edgex_message_bus_001"
+        }
+      }
+    }
+  ]
+}
+```
+
+## 发送到 zeromq 消息总线
+
+以下是将分析结果发送到 zeromq 消息总线的规则。
+
+```json
+{
+  "id": "ruleZmq",
+  "sql": "SELECT meta(*) AS edgex_meta, temperature, humidity, humidity*2 as h1 FROM demo WHERE temperature = 20",
+  "actions": [
+    {
+      "edgex": {
+        "protocol": "tcp",
+        "host": "*",
+        "port": 5571,
+        "topic": "application",
+        "deviceName": "kuiper",
+        "profileName": "kuiperProfile",
+        "contentType": "application/json"
+      }
+    }
+  ]
+}
+```
+
+## 动态元数据
 
 ### 发布结果到  EdgeX 消息总线，而不保留原有的元数据
 在此情况下，原有的元数据 (例如 `Events` 结构体中的 `id, deviceName, profileName, sourceName, origin, tags`，以及`Reading` 结构体中的  `id, deviceName, profileName, origin, valueType` 不会被保留)。eKuiper 在此情况下作为 EdgeX 的一个单独微服务，它有自己的 `device name`， `profile name` 和 `source name`。 提供了属性 `deviceName` 和 `profileName`， 这两个属性允许用户指定 eKuiper 的设备名称和 profile 名称。而 `sourceName` 默认为 `topic` 属性的值。如下所示，
@@ -61,9 +168,6 @@
   "actions": [
     {
       "edgex": {
-        "protocol": "tcp",
-        "host": "*",
-        "port": 5571,
         "topic": "application",
         "deviceName": "kuiper",
         "profileName": "kuiperProfile",
@@ -115,9 +219,6 @@
   "actions": [
     {
       "edgex": {
-        "protocol": "tcp",
-        "host": "*",
-        "port": 5571,
         "topic": "application",
         "metadata": "edgex_meta",
         "contentType": "application/json"
@@ -149,34 +250,3 @@
 - 如果你的 SQL 包含了聚合函数，那保留原有的元数据就没有意义，但是 eKuiper 还是会使用时间窗口中的某一条记录的元数据。例如，在下面的 SQL 里，
 ```SELECT avg(temperature) AS temperature, meta(*) AS edgex_meta FROM ... GROUP BY TUMBLINGWINDOW(ss, 10)```. 
 这种情况下，在时间窗口中可能有几条数据，eKuiper 会使用窗口中的第一条数据的元数据来填充 `temperature` 的元数据。
-
-## 结果发布到 MQTT 消息总线
-
-以下是将分析结果发送到 MQTT 消息总线的规则，请注意在`optional` 中是如何指定 `ClientId` 的。
-
-```json
-{
-  "id": "rule1",
-  "sql": "SELECT meta(*) AS edgex_meta, temperature, humidity, humidity*2 as h1 FROM demo WHERE temperature = 20",
-  "actions": [
-    {
-      "edgex": {
-        "protocol": "tcp",
-        "host": "127.0.0.1",
-        "port": 1883,
-        "topic": "result",
-        "type": "mqtt",
-        "metadata": "edgex_meta",
-        "contentType": "application/json",
-        "optional": {
-        	"ClientId": "edgex_message_bus_001"
-        }
-      }
-    },
-    {
-      "log":{}
-    }
-  ]
-}
-```
-

--- a/internal/topo/sink/edgex_sink.go
+++ b/internal/topo/sink/edgex_sink.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	v2 "github.com/edgexfoundry/go-mod-core-contracts/v2/common"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos"
+	"github.com/edgexfoundry/go-mod-core-contracts/v2/dtos/requests"
 	"github.com/edgexfoundry/go-mod-messaging/v2/messaging"
 	"github.com/edgexfoundry/go-mod-messaging/v2/pkg/types"
 	"github.com/lf-edge/ekuiper/internal/conf"
@@ -30,120 +31,92 @@ import (
 	"reflect"
 )
 
+type messageType string
+
+const (
+	MessageTypeEvent   messageType = "event"
+	MessageTypeRequest messageType = "request"
+)
+
+type EdgexConf struct {
+	Protocol    string            `json:"protocol"`
+	Host        string            `json:"host"`
+	Port        int               `json:"port"`
+	Topic       string            `json:"topic"`
+	TopicPrefix string            `json:"topicPrefix"`
+	Type        string            `json:"type"`
+	MessageType messageType       `json:"messageType"`
+	ContentType string            `json:"contentType"`
+	DeviceName  string            `json:"deviceName"`
+	ProfileName string            `json:"profileName"`
+	SourceName  string            `json:"sourceName"`
+	Metadata    string            `json:"metadata"`
+	Optional    map[string]string `json:"optional"`
+}
+
 type EdgexMsgBusSink struct {
-	protocol string
-	host     string
-	port     int
-	ptype    string
+	c *EdgexConf
 
-	topic       string
-	contentType string
-
-	deviceName  string
-	profileName string
-	sourceName  string
-	metadata    string
-
-	optional map[string]string
-	client   messaging.MessageClient
+	topic  string
+	conf   *types.MessageBusConfig
+	client messaging.MessageClient
 }
 
 func (ems *EdgexMsgBusSink) Configure(ps map[string]interface{}) error {
-	ems.host = "*"
-	ems.protocol = "tcp"
-	ems.port = 5573
-	ems.topic = "events"
-	ems.contentType = "application/json"
-	ems.ptype = messaging.ZeroMQ
-
-	if host, ok := ps["host"]; ok {
-		ems.host = host.(string)
-	} else {
-		conf.Log.Infof("Not find host conf, will use default value '*'.")
+	c := &EdgexConf{
+		Protocol:    "redis",
+		Host:        "localhost",
+		Port:        6379,
+		Type:        messaging.Redis,
+		MessageType: MessageTypeEvent,
+		ContentType: "application/json",
+		DeviceName:  "ekuiper",
+		ProfileName: "ekuiperProfile",
+		// SourceName is set in open as the rule id
+	}
+	err := cast.MapToStruct(ps, c)
+	if err != nil {
+		return fmt.Errorf("read properties %v fail with error: %v", ps, err)
 	}
 
-	if pro, ok := ps["protocol"]; ok {
-		ems.protocol = pro.(string)
-	} else {
-		conf.Log.Infof("Not find protocol conf, will use default value 'tcp'.")
+	if c.Port < 0 {
+		return fmt.Errorf("specified wrong port value, expect positive integer but got %d", c.Port)
 	}
 
-	if port, ok := ps["port"]; ok {
-		if pv, ok := port.(float64); ok {
-			ems.port = int(pv)
-		} else if pv, ok := port.(float32); ok {
-			ems.port = int(pv)
-		} else {
-			conf.Log.Infof("Not valid port value, will use default value '5563'.")
-		}
-
-	} else {
-		conf.Log.Infof("Not find port conf, will use default value '5563'.")
+	if c.Type != messaging.ZeroMQ && c.Type != messaging.MQTT && c.Type != messaging.Redis {
+		return fmt.Errorf("specified wrong type value %s", c.Type)
 	}
 
-	if topic, ok := ps["topic"]; ok {
-		ems.topic = topic.(string)
-	} else {
-		conf.Log.Infof("Not find topic conf, will use default value 'events'.")
+	if c.MessageType != MessageTypeEvent && c.MessageType != MessageTypeRequest {
+		return fmt.Errorf("specified wrong messageType value %s", c.MessageType)
 	}
 
-	if contentType, ok := ps["contentType"]; ok {
-		ems.contentType = contentType.(string)
-	} else {
-		conf.Log.Infof("Not find contentType conf, will use default value 'application/json'.")
+	if c.MessageType == MessageTypeEvent && c.ContentType != "application/json" {
+		return fmt.Errorf("specified wrong contentType value %s: only 'application/json' is supported if messageType is event", c.ContentType)
 	}
 
-	if ptype, ok := ps["type"]; ok {
-		ems.ptype = ptype.(string)
-		if ems.ptype != messaging.ZeroMQ && ems.ptype != messaging.MQTT && ems.ptype != messaging.Redis {
-			conf.Log.Infof("Specified wrong message type value %s, will use zeromq messagebus.\n", ems.ptype)
-			ems.ptype = messaging.ZeroMQ
-		}
+	if c.Topic != "" && c.TopicPrefix != "" {
+		return fmt.Errorf("not allow to specify both topic and topicPrefix, please set one only")
 	}
 
-	if dname, ok := ps["deviceName"]; ok {
-		ems.deviceName = dname.(string)
+	ems.c = c
+	ems.conf = &types.MessageBusConfig{
+		PublishHost: types.HostInfo{
+			Host:     c.Host,
+			Port:     c.Port,
+			Protocol: c.Protocol,
+		},
+		Type:     c.Type,
+		Optional: c.Optional,
 	}
 
-	if pname, ok := ps["profileName"]; ok {
-		ems.profileName = pname.(string)
-	}
-
-	if metadata, ok := ps["metadata"]; ok {
-		ems.metadata = metadata.(string)
-	}
-
-	if optIntf, ok := ps["optional"]; ok {
-		if opt, ok1 := optIntf.(map[string]interface{}); ok1 {
-			optional := make(map[string]string)
-			for k, v := range opt {
-				if sv, ok2 := v.(string); ok2 {
-					optional[k] = sv
-				} else {
-					info := fmt.Sprintf("Only string value is allowed for optional value, the value for key %s is not a string.", k)
-					conf.Log.Infof(info)
-					return fmt.Errorf(info)
-				}
-			}
-			ems.optional = optional
-		}
-	}
 	return nil
 }
 
 func (ems *EdgexMsgBusSink) Open(ctx api.StreamContext) error {
 	log := ctx.GetLogger()
-	conf := types.MessageBusConfig{
-		PublishHost: types.HostInfo{
-			Host:     ems.host,
-			Port:     ems.port,
-			Protocol: ems.protocol,
-		},
-		Type:     ems.ptype,
-		Optional: ems.optional,
-	}
-	log.Infof("Using configuration for EdgeX message bus sink: %+v", conf)
-	if msgClient, err := messaging.NewMessageClient(conf); err != nil {
+	log.Infof("Using configuration for EdgeX message bus sink: %+v", ems.c)
+	if msgClient, err := messaging.NewMessageClient(*ems.conf); err != nil {
 		return err
 	} else {
 		if ec := msgClient.Connect(); ec != nil {
@@ -151,6 +124,19 @@ func (ems *EdgexMsgBusSink) Open(ctx api.StreamContext) error {
 		} else {
 			ems.client = msgClient
 		}
+	}
+	if ems.c.SourceName == "" {
+		ems.c.SourceName = ctx.GetRuleId()
+	}
+
+	if ems.c.Topic == "" && ems.c.TopicPrefix == "" {
+		ems.topic = "application"
+	} else if ems.c.Topic != "" {
+		ems.topic = ems.c.Topic
+	} else if ems.c.Metadata == "" { // If meta data are static, the "dynamic" topic is static
+		ems.topic = fmt.Sprintf("%s/%s/%s/%s", ems.c.TopicPrefix, ems.c.DeviceName, ems.c.ProfileName, ems.c.SourceName)
+	} else {
+		ems.topic = "" // calculate dynamically
 	}
 	return nil
 }
@@ -161,19 +147,19 @@ func (ems *EdgexMsgBusSink) produceEvents(ctx api.StreamContext, result []byte) 
 		m1 := ems.getMeta(m)
 		event := m1.createEvent()
 		//Override the devicename if user specified the value
-		if ems.deviceName != "" {
-			event.DeviceName = ems.deviceName
+		if event.DeviceName == "" {
+			event.DeviceName = ems.c.DeviceName
 		}
-		if ems.profileName != "" {
-			event.ProfileName = ems.profileName
+		if event.ProfileName == "" {
+			event.ProfileName = ems.c.ProfileName
 		}
 		if event.SourceName == "" {
-			event.SourceName = ems.topic
+			event.SourceName = ems.c.SourceName
 		}
 		for _, v := range m {
 			for k1, v1 := range v {
 				// Ignore nil values
-				if k1 == ems.metadata || v1 == nil {
+				if k1 == ems.c.Metadata || v1 == nil {
 					continue
 				} else {
 					var (
@@ -381,12 +367,12 @@ func getValueByType(v interface{}, vt string) (interface{}, error) {
 }
 
 func (ems *EdgexMsgBusSink) getMeta(result []map[string]interface{}) *meta {
-	if ems.metadata == "" {
+	if ems.c.Metadata == "" {
 		return newMetaFromMap(nil)
 	}
 	//Try to get the meta field
 	for _, v := range result {
-		if m, ok := v[ems.metadata]; ok {
+		if m, ok := v[ems.c.Metadata]; ok {
 			if m1, ok1 := m.(map[string]interface{}); ok1 {
 				return newMetaFromMap(m1)
 			} else {
@@ -405,14 +391,32 @@ func (ems *EdgexMsgBusSink) Collect(ctx api.StreamContext, item interface{}) err
 		if err != nil {
 			return fmt.Errorf("Failed to convert to EdgeX event: %s.", err.Error())
 		}
-		data, err := json.Marshal(evt)
-		if err != nil {
-			return fmt.Errorf("unexpected error MarshalEvent %v", err)
+		var (
+			data  []byte
+			topic string
+		)
+		if ems.c.MessageType == MessageTypeRequest {
+			req := requests.NewAddEventRequest(*evt)
+			data, _, err = req.Encode()
+			if err != nil {
+				return fmt.Errorf("unexpected error encode event %v", err)
+			}
+		} else {
+			data, err = json.Marshal(evt)
+			if err != nil {
+				return fmt.Errorf("unexpected error MarshalEvent %v", err)
+			}
 		}
-		env := types.NewMessageEnvelope([]byte(data), ctx)
-		env.ContentType = ems.contentType
+		env := types.NewMessageEnvelope(data, ctx)
+		env.ContentType = ems.c.ContentType
 
-		if e := ems.client.Publish(env, ems.topic); e != nil {
+		if ems.topic == "" { // dynamic topic
+			topic = fmt.Sprintf("%s/%s/%s/%s", ems.c.TopicPrefix, evt.DeviceName, evt.ProfileName, evt.SourceName)
+		} else {
+			topic = ems.topic
+		}
+
+		if e := ems.client.Publish(env, topic); e != nil {
 			logger.Errorf("Found error %s when publish to EdgeX message bus.\n", e)
 			return e
 		}
@@ -481,9 +485,7 @@ type meta struct {
 
 func newMetaFromMap(m1 map[string]interface{}) *meta {
 	result := &meta{
-		eventMeta: eventMeta{
-			profileName: "kuiperProfile",
-		},
+		eventMeta: eventMeta{},
 	}
 	for k, v := range m1 {
 		switch k {

--- a/internal/topo/source/edgex_source.go
+++ b/internal/topo/source/edgex_source.go
@@ -60,9 +60,9 @@ const (
 func (es *EdgexSource) Configure(_ string, props map[string]interface{}) error {
 	c := &EdgexConf{
 		Format:      message.FormatJson,
-		Protocol:    "tcp",
+		Protocol:    "redis",
 		Server:      "localhost",
-		Port:        5563,
+		Port:        6379,
 		Type:        messaging.Redis,
 		MessageType: MessageTypeEvent,
 	}
@@ -74,8 +74,12 @@ func (es *EdgexSource) Configure(_ string, props map[string]interface{}) error {
 		return fmt.Errorf("edgex source only supports `json` format")
 	}
 
+	if c.MessageType != MessageTypeEvent && c.MessageType != MessageTypeRequest {
+		return fmt.Errorf("specified wrong messageType value %s", c.MessageType)
+	}
+
 	if c.Type != messaging.ZeroMQ && c.Type != messaging.MQTT && c.Type != messaging.Redis {
-		return fmt.Errorf("Specified wrong message type value %s, will use zeromq messagebus.\n", c.Type)
+		return fmt.Errorf("specified wrong type value %s", c.Type)
 	}
 
 	mbconf := types.MessageBusConfig{SubscribeHost: types.HostInfo{Protocol: c.Protocol, Host: c.Server, Port: c.Port}, Type: c.Type}

--- a/test/edgex_mqtt_sink_rule.jmx
+++ b/test/edgex_mqtt_sink_rule.jmx
@@ -165,6 +165,7 @@
         &quot;type&quot;: &quot;mqtt&quot;,&#xd;
         &quot;metadata&quot;: &quot;edgex_meta&quot;,&#xd;
         &quot;contentType&quot;: &quot;application/json&quot;,&#xd;
+        &quot;messageType&quot;: &quot;request&quot;,&#xd;
         &quot;optional&quot;: {&#xd;
         	&quot;ClientId&quot;: &quot;edgex_message_bus_001&quot;&#xd;
         }&#xd;
@@ -468,7 +469,7 @@
         </SystemSampler>
         <hashTree>
           <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="device Assertion" enabled="true">
-            <stringProp name="JSON_PATH">$.deviceName</stringProp>
+            <stringProp name="JSON_PATH">$.event.deviceName</stringProp>
             <stringProp name="EXPECTED_VALUE">demo1</stringProp>
             <boolProp name="JSONVALIDATION">true</boolProp>
             <boolProp name="EXPECT_NULL">false</boolProp>
@@ -477,7 +478,7 @@
           </JSONPathAssertion>
           <hashTree/>
           <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="reading_0 Assertion" enabled="true">
-            <stringProp name="JSON_PATH">$.readings[0].value</stringProp>
+            <stringProp name="JSON_PATH">$.event.readings[0].value</stringProp>
             <stringProp name="EXPECTED_VALUE">30</stringProp>
             <boolProp name="JSONVALIDATION">false</boolProp>
             <boolProp name="EXPECT_NULL">false</boolProp>
@@ -486,7 +487,7 @@
           </JSONPathAssertion>
           <hashTree/>
           <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="reading_1 Assertion" enabled="true">
-            <stringProp name="JSON_PATH">$.readings[1].value</stringProp>
+            <stringProp name="JSON_PATH">$.event.readings[1].value</stringProp>
             <stringProp name="EXPECTED_VALUE">20</stringProp>
             <boolProp name="JSONVALIDATION">false</boolProp>
             <boolProp name="EXPECT_NULL">false</boolProp>
@@ -495,7 +496,7 @@
           </JSONPathAssertion>
           <hashTree/>
           <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="reading_2 Assertion" enabled="true">
-            <stringProp name="JSON_PATH">$.readings[2].value</stringProp>
+            <stringProp name="JSON_PATH">$.event.readings[2].value</stringProp>
             <stringProp name="EXPECTED_VALUE">20</stringProp>
             <boolProp name="JSONVALIDATION">false</boolProp>
             <boolProp name="EXPECT_NULL">false</boolProp>

--- a/test/edgex_sink_rule.jmx
+++ b/test/edgex_sink_rule.jmx
@@ -156,6 +156,7 @@
         &quot;protocol&quot;: &quot;tcp&quot;,&#xd;
         &quot;host&quot;: &quot;*&quot;,&#xd;
         &quot;port&quot;: 5571,&#xd;
+        &quot;type&quot;: &quot;zero&quot;,&#xd;
         &quot;topic&quot;: &quot;application&quot;,&#xd;
         &quot;metadata&quot;: &quot;metadt&quot;,&#xd;
         &quot;contentType&quot;: &quot;application/json&quot;&#xd;


### PR DESCRIPTION
- Add messageType for edgeX sink to support send message to message bus like a device
- Change the default configuration to match edgex v2

Closes: #947 #939