### PR TITLE
fix(redis sink plugin): use redis v7 lib in redis sink to consistent with edgeX

### DIFF
--- a/extensions.sum
+++ b/extensions.sum
@@ -62,6 +62,7 @@ github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+
 github.com/go-playground/validator/v10 v10.3.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-playground/validator/v10 v10.6.1/go.mod h1:xm76BBt941f7yWdGnI2DVPFFg1UK3YY04qifoXU3lOk=
 github.com/go-redis/redis/v7 v7.2.0/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRfnwdHj/Dcg=
+github.com/go-redis/redis/v7 v7.3.0 h1:3oHqd0W7f/VLKBxeYTEpqdMUsmMectngjM9OtoRoIgg=
 github.com/go-redis/redis/v7 v7.3.0/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRfnwdHj/Dcg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-yaml/yaml v2.1.0+incompatible h1:RYi2hDdss1u4YE7GwixGzWwVo47T8UQwnTLB6vQiq+o=

--- a/extensions/go.mod
+++ b/extensions/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/pebbe/zmq4 v1.2.7
 	github.com/taosdata/driver-go v0.0.0-20210525062356-2bd1b495d5f3
-	github.com/go-redis/redis/v8 v8.4.11
+	github.com/go-redis/redis/v7 v7.3.0
 )
 
 replace github.com/lf-edge/ekuiper => ../

--- a/extensions/sinks/redis/redis.go
+++ b/extensions/sinks/redis/redis.go
@@ -19,7 +19,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/go-redis/redis/v8"
+	"github.com/go-redis/redis/v7"
 
 	"github.com/lf-edge/ekuiper/pkg/api"
 	"github.com/lf-edge/ekuiper/pkg/cast"
@@ -143,14 +143,14 @@ func (r *RedisSink) Collect(ctx api.StreamContext, data interface{}) error {
 					}
 
 					if r.dataType == "list" {
-						err := r.cli.LPush(ctx, key, v).Err()
+						err := r.cli.LPush(key, v).Err()
 						if err != nil {
 							logger.Error(err)
 							return err
 						}
 						logger.Debugf("send redis list success, key:%s data: %s", key, string(v))
 					} else {
-						err := r.cli.Set(ctx, key, v, r.expiration*time.Second).Err()
+						err := r.cli.Set(key, v, r.expiration*time.Second).Err()
 						if err != nil {
 							logger.Error(err)
 							return err
@@ -171,14 +171,14 @@ func (r *RedisSink) Collect(ctx api.StreamContext, data interface{}) error {
 				}
 
 				if r.dataType == "list" {
-					err := r.cli.LPush(ctx, key, v).Err()
+					err := r.cli.LPush(key, v).Err()
 					if err != nil {
 						logger.Error(err)
 						return err
 					}
 					logger.Debugf("send redis list success, key:%s data: %s", key, string(v))
 				} else {
-					err := r.cli.Set(ctx, key, v, r.expiration*time.Second).Err()
+					err := r.cli.Set(key, v, r.expiration*time.Second).Err()
 					if err != nil {
 						logger.Error(err)
 						return err
@@ -189,14 +189,14 @@ func (r *RedisSink) Collect(ctx api.StreamContext, data interface{}) error {
 
 		} else if r.key != "" {
 			if r.dataType == "list" {
-				err := r.cli.LPush(ctx, r.key, v).Err()
+				err := r.cli.LPush(r.key, v).Err()
 				if err != nil {
 					logger.Error(err)
 					return err
 				}
 				logger.Debugf("send redis list success, key:%s data: %s", r.key, string(v))
 			} else {
-				err := r.cli.Set(ctx, r.key, v, r.expiration*time.Second).Err()
+				err := r.cli.Set(r.key, v, r.expiration*time.Second).Err()
 				if err != nil {
 					logger.Error(err)
 					return err


### PR DESCRIPTION

fix(redis sink plugin): use redis v7 lib in redis sink to consistent with edgeX

Signed-off-by: Jianxiang Ran <rxan_embedded@163.com>