### PR TITLE
fix(parser): meta(*) arg must have a stream name

### DIFF
--- a/internal/xsql/parser.go
+++ b/internal/xsql/parser.go
@@ -662,7 +662,7 @@ func (p *Parser) parseCall(name string) (ast.Expr, error) {
 				return nil, fmt.Errorf("found %q, expected right paren.", lit2)
 			} else {
 				if p.inmeta {
-					args = append(args, &ast.MetaRef{StreamName: "", Name: "*"})
+					args = append(args, &ast.MetaRef{StreamName: ast.DefaultStream, Name: "*"})
 				} else {
 					args = append(args, &ast.Wildcard{Token: ast.ASTERISK})
 				}

--- a/internal/xsql/parser_test.go
+++ b/internal/xsql/parser_test.go
@@ -1431,6 +1431,27 @@ func TestParser_ParseStatement(t *testing.T) {
 			stmt: nil,
 			err:  "found \"-\", expected expression.",
 		},
+		{
+			s: `SELECT meta(*) FROM tbl`,
+			stmt: &ast.SelectStatement{
+				Fields: []ast.Field{
+					{
+						AName: "",
+						Name:  "meta",
+						Expr: &ast.Call{
+							Name: "meta",
+							Args: []ast.Expr{
+								&ast.MetaRef{
+									Name:       "*",
+									StreamName: ast.DefaultStream,
+								},
+							},
+						},
+					},
+				},
+				Sources: []ast.Source{&ast.Table{Name: "tbl"}},
+			},
+		},
 	}
 
 	fmt.Printf("The test bucket size is %d.\n\n", len(tests))


### PR DESCRIPTION
analyzer and planner rely on the stream name, so must set defaultStream as the default

closes: #972