### PR TITLE
fix(portable): if no plugin, list portable plugins should return []

### DIFF
--- a/internal/plugin/portable/registry.go
+++ b/internal/plugin/portable/registry.go
@@ -70,7 +70,8 @@ func (r *registry) GetSymbol(pt plugin.PluginType, symbolName string) (string, b
 func (r *registry) List() []*PluginInfo {
 	r.RLock()
 	defer r.RUnlock()
-	var result []*PluginInfo
+	// return empty slice instead of nil to help json marshal
+	result := make([]*PluginInfo, 0, len(r.plugins))
 	for _, v := range r.plugins {
 		result = append(result, v)
 	}

--- a/internal/plugin/portable/runtime/function.go
+++ b/internal/plugin/portable/runtime/function.go
@@ -135,7 +135,7 @@ func (f *PortableFunc) IsAggregate() bool {
 	if fr.State {
 		r, ok := fr.Result.(bool)
 		if !ok {
-			conf.Log.Errorf("IsAggregate result is not bool, got %v", res)
+			conf.Log.Errorf("IsAggregate result is not bool, got %s", string(res))
 			return false
 		} else {
 			return r


### PR DESCRIPTION
1. Currently, nil is return. Change to []
2. Let the function runtime print byte array as string in error

Signed-off-by: Jiyong Huang <huangjy@emqx.io>