### PR TITLE
fix(docs): update edgex tutorial redis kv storage only work in none-ecure mode

### DIFF
--- a/docs/en_US/edgex/edgex_rule_engine_tutorial.md
+++ b/docs/en_US/edgex/edgex_rule_engine_tutorial.md
@@ -118,6 +118,7 @@ Users can add these in ``environment`` part and make sure the image is ``1.4.0``
     KUIPER__STORE__REDIS__PORT: 6379
     KUIPER__STORE__REDIS__PASSWORD: ""
   ```
+*Note*: This feature only works when redis in ``no-secty`` mode
 
 #### Run with native
 

--- a/docs/zh_CN/edgex/edgex_rule_engine_tutorial.md
+++ b/docs/zh_CN/edgex/edgex_rule_engine_tutorial.md
@@ -115,7 +115,7 @@ d4b236a7b561   redis:6.2.4-alpine                                              "
     KUIPER__STORE__REDIS__PORT: 6379
     KUIPER__STORE__REDIS__PASSWORD: ""
   ```
-
+*注意*: 这个功能仅适用于 redis 工作在非安全模式时
 
 ### 原生 (native) 方式运行
 


### PR DESCRIPTION

Signed-off-by: Jianxiang Ran <rxan_embedded@163.com>