### PR TITLE
fix(sdk): disable req resend

### DIFF
--- a/sdk/go/connection/connection.go
+++ b/sdk/go/connection/connection.go
@@ -1,4 +1,4 @@
-// Copyright 2021 EMQ Technologies Co., Ltd.
+// Copyright 2022 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -93,6 +93,7 @@ func CreateControlChannel(pluginName string) (ControlChannel, error) {
 		return nil, fmt.Errorf("can't get new req socket: %s", err)
 	}
 	setSockOptions(sock)
+	sock.SetOption(mangos.OptionRetryTime, 0)
 	url := fmt.Sprintf("ipc:///tmp/plugin_%s.ipc", pluginName)
 	if err = sock.Dial(url); err != nil {
 		return nil, fmt.Errorf("can't dial on req socket: %s", err.Error())
@@ -125,6 +126,7 @@ func CreateFuncChannel(symbolName string) (DataInOutChannel, error) {
 		return nil, fmt.Errorf("can't get new req socket: %s", err)
 	}
 	setSockOptions(sock)
+	sock.SetOption(mangos.OptionRetryTime, 0)
 	url := fmt.Sprintf("ipc:///tmp/func_%s.ipc", symbolName)
 	if err = sock.Dial(url); err != nil {
 		return nil, fmt.Errorf("can't dial on req socket: %s", err.Error())


### PR DESCRIPTION
By default, the request will be resent after 1 minute. This makes the timeline in chaos when not receiving data in more than 1 minute.