### PR TITLE
refactor(parser): assign field name in the parser side

### DIFF
--- a/internal/topo/operator/project_test.go
+++ b/internal/topo/operator/project_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 EMQ Technologies Co., Ltd.
+// Copyright 2022 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -107,7 +107,7 @@ func TestProjectPlan_Apply1(t *testing.T) {
 				Message: xsql.Message{},
 			},
 			result: []map[string]interface{}{{
-				"": "value",
+				"kuiper_field_0": "value",
 			}},
 		},
 		//6
@@ -118,7 +118,7 @@ func TestProjectPlan_Apply1(t *testing.T) {
 				Message: xsql.Message{},
 			},
 			result: []map[string]interface{}{{
-				"": 3.4,
+				"kuiper_field_0": 3.4,
 			}},
 		},
 		//7
@@ -129,7 +129,7 @@ func TestProjectPlan_Apply1(t *testing.T) {
 				Message: xsql.Message{},
 			},
 			result: []map[string]interface{}{{
-				"": 5,
+				"kuiper_field_0": 5,
 			}},
 		},
 		//8

--- a/internal/topo/planner/analyzer.go
+++ b/internal/topo/planner/analyzer.go
@@ -1,4 +1,4 @@
-// Copyright 2021 EMQ Technologies Co., Ltd.
+// Copyright 2022 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import (
 	"github.com/lf-edge/ekuiper/internal/xsql"
 	"github.com/lf-edge/ekuiper/pkg/ast"
 	"github.com/lf-edge/ekuiper/pkg/kv"
-	"strconv"
 	"strings"
 )
 
@@ -70,10 +69,6 @@ func decorateStmt(s *ast.SelectStatement, store kv.KeyValue) ([]*ast.StreamStmt,
 		})
 		if walkErr != nil {
 			return nil, walkErr
-		}
-		// assign name for anonymous select expression
-		if f.Name == "" && f.AName == "" {
-			s.Fields[i].Name = fieldsMap.getDefaultName()
 		}
 		if f.AName != "" {
 			aliasFields = append(aliasFields, &s.Fields[i])
@@ -235,17 +230,6 @@ func (f *fieldsMap) bind(fr *ast.FieldRef) error {
 		return fmt.Errorf("%s%s", err, fr.Name)
 	}
 	return nil
-}
-
-func (f *fieldsMap) getDefaultName() string {
-	for i := 0; i < 2048; i++ {
-		key := xsql.DEFAULT_FIELD_NAME_PREFIX + strconv.Itoa(i)
-		if _, ok := f.content[key]; !ok {
-			f.content[key] = nil
-			return key
-		}
-	}
-	return ""
 }
 
 type streamFieldStore interface {

--- a/internal/topo/planner/planner_test.go
+++ b/internal/topo/planner/planner_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 EMQ Technologies Co., Ltd.
+// Copyright 2022 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -416,7 +416,7 @@ func Test_createLogicalPlan(t *testing.T) {
 				fields: []ast.Field{
 					{
 						Expr:  &ast.Wildcard{Token: ast.ASTERISK},
-						Name:  "kuiper_field_0",
+						Name:  "",
 						AName: ""},
 				},
 				isAggregate: false,
@@ -1446,7 +1446,7 @@ func Test_createLogicalPlanSchemaless(t *testing.T) {
 				fields: []ast.Field{
 					{
 						Expr:  &ast.Wildcard{Token: ast.ASTERISK},
-						Name:  "kuiper_field_0",
+						Name:  "",
 						AName: ""},
 				},
 				isAggregate: false,

--- a/internal/xsql/parser.go
+++ b/internal/xsql/parser.go
@@ -1,4 +1,4 @@
-// Copyright 2021 EMQ Technologies Co., Ltd.
+// Copyright 2022 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ type Parser struct {
 		lit string
 	}
 	inmeta bool
+	f      int // anonymous field index number
 }
 
 func (p *Parser) parseCondition() (ast.Expr, error) {
@@ -445,6 +446,10 @@ func (p *Parser) parseField() (*ast.Field, error) {
 		if alias != "" {
 			field.AName = alias
 		}
+	}
+	if field.Name == "" && field.AName == "" {
+		field.Name = DEFAULT_FIELD_NAME_PREFIX + strconv.Itoa(p.f)
+		p.f += 1
 	}
 
 	return field, nil

--- a/internal/xsql/parser_test.go
+++ b/internal/xsql/parser_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 EMQ Technologies Co., Ltd.
+// Copyright 2022 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -459,7 +459,7 @@ func TestParser_ParseStatement(t *testing.T) {
 		{
 			s: `SELECT "abc" FROM tbl`,
 			stmt: &ast.SelectStatement{
-				Fields:  []ast.Field{{AName: "", Name: "", Expr: &ast.StringLiteral{Val: "abc"}}},
+				Fields:  []ast.Field{{AName: "", Name: "kuiper_field_0", Expr: &ast.StringLiteral{Val: "abc"}}},
 				Sources: []ast.Source{&ast.Table{Name: "tbl"}},
 			},
 		},
@@ -598,7 +598,7 @@ func TestParser_ParseStatement(t *testing.T) {
 				Fields: []ast.Field{
 					{
 						AName: "",
-						Name:  "",
+						Name:  "kuiper_field_0",
 						Expr: &ast.BinaryExpr{
 							LHS: &ast.FieldRef{Name: "abc", StreamName: ast.DefaultStream},
 							OP:  ast.ADD,
@@ -616,7 +616,7 @@ func TestParser_ParseStatement(t *testing.T) {
 				Fields: []ast.Field{
 					{
 						AName: "",
-						Name:  "",
+						Name:  "kuiper_field_0",
 						Expr: &ast.BinaryExpr{
 							LHS: &ast.FieldRef{StreamName: ast.StreamName("t1"), Name: "abc"},
 							OP:  ast.ADD,
@@ -634,7 +634,7 @@ func TestParser_ParseStatement(t *testing.T) {
 				Fields: []ast.Field{
 					{
 						AName: "",
-						Name:  "",
+						Name:  "kuiper_field_0",
 						Expr: &ast.BinaryExpr{
 							LHS: &ast.FieldRef{Name: "abc", StreamName: ast.DefaultStream},
 							OP:  ast.ADD,
@@ -652,7 +652,7 @@ func TestParser_ParseStatement(t *testing.T) {
 				Fields: []ast.Field{
 					{
 						AName: "",
-						Name:  "",
+						Name:  "kuiper_field_0",
 						Expr: &ast.BinaryExpr{
 							LHS: &ast.BinaryExpr{
 								LHS: &ast.FieldRef{Name: "abc", StreamName: ast.DefaultStream},
@@ -756,7 +756,7 @@ func TestParser_ParseStatement(t *testing.T) {
 				Fields: []ast.Field{
 					{
 						AName: "",
-						Name:  "",
+						Name:  "kuiper_field_0",
 						Expr:  &ast.NumberLiteral{Val: 0.2},
 					},
 				},
@@ -770,7 +770,7 @@ func TestParser_ParseStatement(t *testing.T) {
 				Fields: []ast.Field{
 					{
 						AName: "",
-						Name:  "",
+						Name:  "kuiper_field_0",
 						Expr:  &ast.NumberLiteral{Val: 0.2},
 					},
 				},
@@ -1394,7 +1394,7 @@ func TestParser_ParseStatement(t *testing.T) {
 				Fields: []ast.Field{
 					{
 						AName: "",
-						Name:  "",
+						Name:  "kuiper_field_0",
 						Expr: &ast.BinaryExpr{
 							OP: ast.SUB,
 							LHS: &ast.Call{
@@ -1704,7 +1704,7 @@ func TestParser_ParseJsonExpr(t *testing.T) {
 							OP:  ast.SUBSET,
 							RHS: &ast.IndexExpr{Index: &ast.IntegerLiteral{Val: 0}},
 						},
-						Name:  "",
+						Name:  "kuiper_field_0",
 						AName: ""},
 				},
 				Sources: []ast.Source{&ast.Table{Name: "demo"}},
@@ -1726,7 +1726,7 @@ func TestParser_ParseJsonExpr(t *testing.T) {
 							RHS: &ast.JsonFieldRef{Name: "first"},
 						},
 
-						Name:  "",
+						Name:  "kuiper_field_0",
 						AName: ""},
 				},
 				Sources: []ast.Source{&ast.Table{Name: "demo"}},
@@ -1748,7 +1748,7 @@ func TestParser_ParseJsonExpr(t *testing.T) {
 							RHS: &ast.IndexExpr{Index: &ast.IntegerLiteral{Val: 2}},
 						},
 
-						Name:  "",
+						Name:  "kuiper_field_0",
 						AName: ""},
 				},
 				Sources: []ast.Source{&ast.Table{Name: "demo"}},
@@ -1774,7 +1774,7 @@ func TestParser_ParseJsonExpr(t *testing.T) {
 							RHS: &ast.JsonFieldRef{Name: "test"},
 						},
 
-						Name:  "",
+						Name:  "kuiper_field_0",
 						AName: ""},
 				},
 				Sources: []ast.Source{&ast.Table{Name: "demo"}},
@@ -1791,7 +1791,7 @@ func TestParser_ParseJsonExpr(t *testing.T) {
 							OP:  ast.SUBSET,
 							RHS: &ast.ColonExpr{Start: &ast.IntegerLiteral{Val: 0}, End: &ast.IntegerLiteral{Val: 1}},
 						},
-						Name:  "",
+						Name:  "kuiper_field_0",
 						AName: ""},
 				},
 				Sources: []ast.Source{&ast.Table{Name: "demo"}},
@@ -1808,7 +1808,7 @@ func TestParser_ParseJsonExpr(t *testing.T) {
 							OP:  ast.SUBSET,
 							RHS: &ast.ColonExpr{Start: &ast.IntegerLiteral{Val: 0}, End: &ast.IntegerLiteral{Val: 1}},
 						},
-						Name:  "",
+						Name:  "kuiper_field_0",
 						AName: ""},
 				},
 				Sources: []ast.Source{&ast.Table{Name: "demo"}},
@@ -1825,7 +1825,7 @@ func TestParser_ParseJsonExpr(t *testing.T) {
 							OP:  ast.SUBSET,
 							RHS: &ast.ColonExpr{Start: &ast.IntegerLiteral{Val: 0}, End: &ast.IntegerLiteral{Val: math.MinInt32}},
 						},
-						Name:  "",
+						Name:  "kuiper_field_0",
 						AName: ""},
 				},
 				Sources: []ast.Source{&ast.Table{Name: "demo"}},
@@ -1928,7 +1928,7 @@ func TestParser_ParseJsonExpr(t *testing.T) {
 							OP:  ast.SUBSET,
 							RHS: &ast.ColonExpr{Start: &ast.IntegerLiteral{Val: 0}, End: &ast.IntegerLiteral{Val: 1}},
 						},
-						Name:  "",
+						Name:  "kuiper_field_0",
 						AName: ""},
 				},
 				Sources: []ast.Source{&ast.Table{Name: "demo"}},
@@ -1959,7 +1959,7 @@ func TestParser_ParseJsonExpr(t *testing.T) {
 							OP:  ast.SUBSET,
 							RHS: &ast.IndexExpr{Index: &ast.FieldRef{Name: "index", StreamName: ast.DefaultStream}},
 						},
-						Name:  "",
+						Name:  "kuiper_field_0",
 						AName: ""},
 				},
 				Sources: []ast.Source{&ast.Table{Name: "demo"}},

--- a/pkg/ast/expr.go
+++ b/pkg/ast/expr.go
@@ -1,4 +1,4 @@
-// Copyright 2021 EMQ Technologies Co., Ltd.
+// Copyright 2022 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -172,7 +172,6 @@ const (
 //  1.1 Explicit field "stream.col"
 //  1.2 Implicit field "col"  -> only exist in schemaless stream. Otherwise, explicit stream name will be bound
 //  1.3 Alias field "expr as c" -> refer to an Expression or column
-// 2. Json Expression field like a->b
 type FieldRef struct {
 	// optional, bind in analyzer, empty means alias, default means not set
 	// MUST have after binding for SQL fields. For 1.2,1.3 and 1.4, use special constant as stream name


### PR DESCRIPTION
All fields now will have either a field name or an alias name