### PR TITLE
fix(portable): clean up portable plugin instance

### DIFF
--- a/sdk/go/runtime/plugin.go
+++ b/sdk/go/runtime/plugin.go
@@ -47,12 +47,8 @@ func initVars(args []string, conf *PluginConfig) {
 		if err != nil {
 			panic(fmt.Sprintf("fail to parse args %v", args))
 		}
-		connection.Options = map[string]interface{}{
-			mangos.OptionSendDeadline: pc.SendTimeout,
-		}
+		connection.SockOptions[mangos.OptionSendDeadline] = pc.SendTimeout
 		logger.Infof("config parsed to %v", pc)
-	} else {
-		connection.Options = make(map[string]interface{})
 	}
 }
 


### PR DESCRIPTION
1. Make sure control channel closed in error
2. Separate handshake timeout and receive timeout
3. Do not pose timeout after handshake, to design later

Signed-off-by: Jiyong Huang <huangjy@emqx.io>