### PR TITLE
feat(rule): separate context method for template and jsonPath

### DIFF
--- a/docs/en_US/extension/native/develop/sink.md
+++ b/docs/en_US/extension/native/develop/sink.md
@@ -57,11 +57,11 @@ The [Memory Sink](https://github.com/lf-edge/ekuiper/blob/master/extensions/sink
 
 For customized sink plugins, users may still want to support [dynamic properties](../../../rules/overview.md#dynamic-properties) like the built-in ones.
 
-In the context object, a function `ParseDynamicProp` is provided to support the parsing of the dynamic property syntax. In the customized sink, developers can specify some properties to be dynamic according to the business logic. And in the plugin code, use this function to parse the user input in the collect function or elsewhere.
+In the context object, a function `ParseTemplate` is provided to support the parsing of the dynamic property with the go template syntax. In the customized sink, developers can specify some properties to be dynamic according to the business logic. And in the plugin code, use this function to parse the user input in the collect function or elsewhere.
 
 ```go
-// Parse the prop of jsonpath syntax against the current data.
-value, err := ctx.ParseDynamicProp(s.prop, data)
+// Parse the prop of go template syntax against the current data.
+value, err := ctx.ParseTemplate(s.prop, data)
 // Use the parsed value for the following business logic.
 ```
 

--- a/docs/zh_CN/extension/native/develop/sink.md
+++ b/docs/zh_CN/extension/native/develop/sink.md
@@ -58,11 +58,11 @@ func MySink() api.Sink {
 
 #### 解析动态属性
 
-在自定义的 sink 插件中，用户可能仍然想要像内置的 sink 一样支持[动态属性](../../../rules/overview.md#动态属性)。 我们在 context 对象中提供了 `ParseDynamicProp` 方法使得开发者可以方便地解析动态属性并应用于插件中。开发组应当根据业务逻辑，设计那些属性支持动态值。然后在代码编写时，使用此方法解析用户传入的属性值。
+在自定义的 sink 插件中，用户可能仍然想要像内置的 sink 一样支持[动态属性](../../../rules/overview.md#动态属性)。 我们在 context 对象中提供了 `ParseTemplate` 方法使得开发者可以方便地解析动态属性并应用于插件中。开发组应当根据业务逻辑，设计那些属性支持动态值。然后在代码编写时，使用此方法解析用户传入的属性值。
 
 ```go
-// Parse the prop of jsonpath syntax against the current data.
-value, err := ctx.ParseDynamicProp(s.prop, data)
+// Parse the prop of go template syntax against the current data.
+value, err := ctx.ParseTemplate(s.prop, data)
 // Use the parsed value for the following business logic.
 ```
 

--- a/internal/binder/function/funcs_misc.go
+++ b/internal/binder/function/funcs_misc.go
@@ -551,6 +551,9 @@ func toFixed(num float64, precision int) float64 {
 }
 
 func jsonCall(ctx api.StreamContext, args []interface{}) (interface{}, error) {
-	// TO BE REMOVED prefix { to avoid conflict with regular string
-	return ctx.ParseDynamicProp("{"+args[1].(string), args[0])
+	jp, ok := args[1].(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid jsonPath, must be a string but got %v", args[1])
+	}
+	return ctx.ParseJsonPath(jp, args[0])
 }

--- a/internal/topo/memory/sink.go
+++ b/internal/topo/memory/sink.go
@@ -1,4 +1,4 @@
-// Copyright 2021 EMQ Technologies Co., Ltd.
+// Copyright 2021-2022 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ func (s *sink) Configure(props map[string]interface{}) error {
 
 func (s *sink) Collect(ctx api.StreamContext, data interface{}) error {
 	ctx.GetLogger().Debugf("receive %+v", data)
-	tpc, err := ctx.ParseDynamicProp(s.topic, data)
+	tpc, err := ctx.ParseTemplate(s.topic, data)
 	if err != nil {
 		return err
 	}

--- a/internal/topo/sink/mqtt_sink.go
+++ b/internal/topo/sink/mqtt_sink.go
@@ -1,4 +1,4 @@
-// Copyright 2021 EMQ Technologies Co., Ltd.
+// Copyright 2021-2022 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -92,7 +92,7 @@ func (ms *MQTTSink) Collect(ctx api.StreamContext, item interface{}) error {
 	}
 
 	logger.Debugf("%s publish %s", ctx.GetOpId(), jsonBytes)
-	tpc, err := ctx.ParseDynamicProp(ms.tpc, item)
+	tpc, err := ctx.ParseTemplate(ms.tpc, item)
 	if err != nil {
 		return err
 	}

--- a/internal/topo/sink/rest_sink.go
+++ b/internal/topo/sink/rest_sink.go
@@ -261,7 +261,7 @@ func (ms *RestSink) Collect(ctx api.StreamContext, item interface{}) error {
 }
 
 func (ms *RestSink) Send(ctx api.StreamContext, v interface{}, logger api.Logger) (*http.Response, error) {
-	temp, err := ctx.ParseDynamicProp(ms.bodyType, v)
+	temp, err := ctx.ParseTemplate(ms.bodyType, v)
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +269,7 @@ func (ms *RestSink) Send(ctx api.StreamContext, v interface{}, logger api.Logger
 	if !ok {
 		return nil, fmt.Errorf("the value %v of dynamic prop %s for bodyType is not a string", ms.bodyType, temp)
 	}
-	temp, err = ctx.ParseDynamicProp(ms.method, v)
+	temp, err = ctx.ParseTemplate(ms.method, v)
 	if err != nil {
 		return nil, err
 	}
@@ -277,7 +277,7 @@ func (ms *RestSink) Send(ctx api.StreamContext, v interface{}, logger api.Logger
 	if !ok {
 		return nil, fmt.Errorf("the value %v of dynamic prop %s for method is not a string", ms.method, temp)
 	}
-	temp, err = ctx.ParseDynamicProp(ms.url, v)
+	temp, err = ctx.ParseTemplate(ms.url, v)
 	if err != nil {
 		return nil, err
 	}
@@ -289,7 +289,7 @@ func (ms *RestSink) Send(ctx api.StreamContext, v interface{}, logger api.Logger
 	if ms.headers != nil {
 		headers = ms.headers
 	} else if ms.headersTemplate != "" {
-		temp, err = ctx.ParseDynamicProp(ms.headersTemplate, v)
+		temp, err = ctx.ParseTemplate(ms.headersTemplate, v)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/api/stream.go
+++ b/pkg/api/stream.go
@@ -1,4 +1,4 @@
-// Copyright 2021 EMQ Technologies Co., Ltd.
+// Copyright 2021-2022 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -70,9 +70,9 @@ type Closable interface {
 }
 
 type Source interface {
-	//Should be sync function for normal case. The container will run it in go func
+	// Open Should be sync function for normal case. The container will run it in go func
 	Open(ctx StreamContext, consumer chan<- SourceTuple, errCh chan<- error)
-	//Called during initialization. Configure the source with the data source(e.g. topic for mqtt) and the properties
+	// Configure Called during initialization. Configure the source with the data source(e.g. topic for mqtt) and the properties
 	//read from the yaml
 	Configure(datasource string, props map[string]interface{}) error
 	Closable
@@ -81,17 +81,17 @@ type Source interface {
 type TableSource interface {
 	// Load the data at batch
 	Load(ctx StreamContext) ([]SourceTuple, error)
-	//Called during initialization. Configure the source with the data source(e.g. topic for mqtt) and the properties
+	// Configure Called during initialization. Configure the source with the data source(e.g. topic for mqtt) and the properties
 	//read from the yaml
 	Configure(datasource string, props map[string]interface{}) error
 }
 
 type Sink interface {
-	//Should be sync function for normal case. The container will run it in go func
+	// Open Should be sync function for normal case. The container will run it in go func
 	Open(ctx StreamContext) error
-	//Called during initialization. Configure the sink with the properties from rule action definition
+	// Configure Called during initialization. Configure the sink with the properties from rule action definition
 	Configure(props map[string]interface{}) error
-	//Called when each row of data has transferred to this sink
+	// Collect Called when each row of data has transferred to this sink
 	Collect(ctx StreamContext, data interface{}) error
 	Closable
 }
@@ -143,17 +143,19 @@ type StreamContext interface {
 	WithInstance(instanceId int) StreamContext
 	WithCancel() (StreamContext, context.CancelFunc)
 	SetError(e error)
-	// State handling
+	// IncrCounter State handling
 	IncrCounter(key string, amount int) error
 	GetCounter(key string) (int, error)
 	PutState(key string, value interface{}) error
 	GetState(key string) (interface{}, error)
 	DeleteState(key string) error
-	// Connection related methods
+	// GetClient Connection related methods
 	GetClient(clientType string, config map[string]interface{}) (MessageClient, error)
-	// Properties processing, prop is a json path
-	ParseDynamicProp(prop string, data interface{}) (interface{}, error)
-	// Transform output according to the properties like syntax
+	// ParseTemplate parse the template string with the given data
+	ParseTemplate(template string, data interface{}) (interface{}, error)
+	// ParseJsonPath parse the jsonPath string with the given data
+	ParseJsonPath(jsonPath string, data interface{}) (interface{}, error)
+	// TransformOutput Transform output according to the properties including dataTemplate, sendSingle
 	TransformOutput(data interface{}) ([]byte, bool, error)
 }
 
@@ -171,12 +173,12 @@ type FunctionContext interface {
 }
 
 type Function interface {
-	//The argument is a list of xsql.Expr
+	// Validate The argument is a list of xsql.Expr
 	Validate(args []interface{}) error
-	//Execute the function, return the result and if execution is successful.
+	// Exec Execute the function, return the result and if execution is successful.
 	//If execution fails, return the error and false.
 	Exec(args []interface{}, ctx FunctionContext) (interface{}, bool)
-	//If this function is an aggregate function. Each parameter of an aggregate function will be a slice
+	// IsAggregate If this function is an aggregate function. Each parameter of an aggregate function will be a slice
 	IsAggregate() bool
 }
 


### PR DESCRIPTION
Put these conversion functions in context to be able to save the parsed result instead of do the parsing everytime. And the cache parsed result can be auto managed as part of the context lifecycle.
