### PR TITLE
refactor(mqtt): default to MQTT 3.1.1(4) to connect to NanoMQ

### DIFF
--- a/internal/topo/connection/clients/mqtt/client_mqtt_test.go
+++ b/internal/topo/connection/clients/mqtt/client_mqtt_test.go
@@ -131,7 +131,7 @@ func TestMQTTClient_CfgResult(t *testing.T) {
 	if !reflect.DeepEqual("clientid", ms.clientid) {
 		t.Errorf("result mismatch:\n\n got=%#v\n\n", ms.clientid)
 	}
-	if !reflect.DeepEqual(uint(3), ms.pVersion) {
+	if !reflect.DeepEqual(uint(4), ms.pVersion) {
 		t.Errorf("result mismatch:\n\n got=%#v\n\n", ms.pVersion)
 	}
 

--- a/internal/topo/connection/clients/mqtt/mqtt.go
+++ b/internal/topo/connection/clients/mqtt/mqtt.go
@@ -73,10 +73,10 @@ func (ms *MQTTClient) CfgValidate(props map[string]interface{}) error {
 	} else {
 		ms.clientid = cfg.ClientId
 	}
-
-	ms.pVersion = 3
-	if cfg.PVersion == "3.1.1" {
-		ms.pVersion = 4
+	// Default to MQTT 3.1.1 or NanoMQ cannot connect
+	ms.pVersion = 4
+	if cfg.PVersion == "3.1" {
+		ms.pVersion = 3
 	}
 
 	tlsOpts := cert.TlsConfigurationOptions{
@@ -98,8 +98,10 @@ func (ms *MQTTClient) CfgValidate(props map[string]interface{}) error {
 }
 
 func (ms *MQTTClient) Connect(connHandler MQTT.OnConnectHandler, lostHandler MQTT.ConnectionLostHandler) error {
-
-	opts := MQTT.NewClientOptions().AddBroker(ms.srv).SetProtocolVersion(ms.pVersion)
+	if conf.Config.Basic.Debug {
+		MQTT.DEBUG = conf.Log
+	}
+	opts := MQTT.NewClientOptions().AddBroker(ms.srv).SetProtocolVersion(4)
 
 	opts = opts.SetTLSConfig(ms.tls)
 


### PR DESCRIPTION
also add debug log to paho if debug is enabled
