### PR TITLE
docs(zh_CN): 失效的引用地址，错误的单词拼写

### DIFF
--- a/docs/zh_CN/CONTRIBUTING.md
+++ b/docs/zh_CN/CONTRIBUTING.md
@@ -167,7 +167,7 @@ eKuiper 项目利用 Github actions 来运行单元测试和 FVT（功能验证�
 
 ### Signoff
 
-Sifnoff 是为了证明提交的来源。它是提交给这个项目的必要条件。如果你设置了
+Signoff 是为了证明提交的来源。它是提交给这个项目的必要条件。如果你设置了
 你的`user.name`和`user.email`的 git 配置，你可以用`git commit -s`自动签署你的提交。每次提交都必须签名。
 
 ### 同步

--- a/docs/zh_CN/quick_start_docker.md
+++ b/docs/zh_CN/quick_start_docker.md
@@ -26,7 +26,7 @@
    
    ```
 
-4. 您可以使用任何[ MQTT 客户端工具](https://www.emqx.cn/blog/mqtt-client-tools)来发布传感器数据到服务器 `tcp://broker.emqx.io:1883`的主题 `devices/device_001/messages` 。以下例子使用 `mosquitto_pub`。
+4. 您可以使用任何[ MQTT 客户端工具](https://www.emqx.com/zh/blog/mqtt-client-tools)来发布传感器数据到服务器 `tcp://broker.emqx.io:1883`的主题 `devices/device_001/messages` 。以下例子使用 `mosquitto_pub`。
 
    ```shell
    # mosquitto_pub -h broker.emqx.io -m '{"temperature": 40, "humidity" : 20}' -t devices/device_001/messages


### PR DESCRIPTION
- quick_start_docker.md：推荐使用的 MQTT 客户端工具博客地址失效，修改为正确的访问地址。
- CONTRIBUTING.md: Sifnoff 修改为 Signoff。
#1362 