### PR TITLE
feat(topo): run analytic functions at the beginning

### DIFF
--- a/internal/binder/function/function.go
+++ b/internal/binder/function/function.go
@@ -46,6 +46,19 @@ func init() {
 //	"count":   "",
 //}
 
+var analyticFuncs = map[string]struct{}{
+	"lag":         {},
+	"changed_col": {},
+	"had_changed": {},
+}
+
+const AnalyticPrefix = "$$a"
+
+func IsAnalyticFunc(name string) bool {
+	_, ok := analyticFuncs[name]
+	return ok
+}
+
 type funcExecutor struct{}
 
 func (f *funcExecutor) ValidateWithName(args []ast.Expr, name string) error {

--- a/internal/topo/operator/analyticfuncs_operator.go
+++ b/internal/topo/operator/analyticfuncs_operator.go
@@ -1,0 +1,61 @@
+// Copyright 2022 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"fmt"
+	"github.com/lf-edge/ekuiper/internal/xsql"
+	"github.com/lf-edge/ekuiper/pkg/api"
+	"github.com/lf-edge/ekuiper/pkg/ast"
+)
+
+type AnalyticFuncsOp struct {
+	Funcs []*ast.Call
+}
+
+func (p *AnalyticFuncsOp) Apply(ctx api.StreamContext, data interface{}, fv *xsql.FunctionValuer, _ *xsql.AggregateFunctionValuer) interface{} {
+	ctx.GetLogger().Debugf("AnalyticFuncsOp receive: %s", data)
+	switch input := data.(type) {
+	case error:
+		return input
+	case xsql.TupleRow:
+		ve := &xsql.ValuerEval{Valuer: xsql.MultiValuer(input, fv)}
+		for _, f := range p.Funcs {
+			result := ve.Eval(f)
+			if e, ok := result.(error); ok {
+				return e
+			}
+			input.Set(f.CachedField, result)
+		}
+	case xsql.SingleCollection:
+		err := input.RangeSet(func(_ int, row xsql.Row) (bool, error) {
+			ve := &xsql.ValuerEval{Valuer: xsql.MultiValuer(row, &xsql.WindowRangeValuer{WindowRange: input.GetWindowRange()}, fv, &xsql.WildcardValuer{Data: row})}
+			for _, f := range p.Funcs {
+				result := ve.Eval(f)
+				if e, ok := result.(error); ok {
+					return false, e
+				}
+				row.Set(f.CachedField, result)
+			}
+			return true, nil
+		})
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("run analytic funcs op error: invalid input %[1]T(%[1]v)", input)
+	}
+	return data
+}

--- a/internal/topo/operator/analyticfuncs_operator_test.go
+++ b/internal/topo/operator/analyticfuncs_operator_test.go
@@ -1,0 +1,197 @@
+// Copyright 2022 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"fmt"
+	"github.com/lf-edge/ekuiper/internal/conf"
+	"github.com/lf-edge/ekuiper/internal/topo/context"
+	"github.com/lf-edge/ekuiper/internal/topo/state"
+	"github.com/lf-edge/ekuiper/internal/xsql"
+	"github.com/lf-edge/ekuiper/pkg/api"
+	"github.com/lf-edge/ekuiper/pkg/ast"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+func TestAnalyticFuncs(t *testing.T) {
+	var tests = []struct {
+		funcs  []*ast.Call
+		data   []interface{}
+		result [][]map[string]interface{}
+	}{
+		{ // 0 Lag test
+			funcs: []*ast.Call{
+				{
+					Name: "lag",
+					Args: []ast.Expr{
+						&ast.FieldRef{Name: "a"},
+					},
+					FuncId:      0,
+					CachedField: "$$a_lag_0",
+				},
+				{
+					Name: "lag",
+					Args: []ast.Expr{
+						&ast.FieldRef{Name: "b"},
+					},
+					FuncId:      1,
+					CachedField: "$$a_lag_1",
+				},
+			},
+			data: []interface{}{
+				&xsql.Tuple{
+					Emitter: "test",
+					Message: xsql.Message{
+						"a": "a1",
+						"b": "b1",
+						"c": "c1",
+					},
+				},
+				&xsql.Tuple{
+					Emitter: "test",
+					Message: xsql.Message{
+						"a": "a1",
+						"b": "b2",
+						"c": "c1",
+					},
+				},
+				&xsql.Tuple{
+					Emitter: "test",
+					Message: xsql.Message{
+						"a": "a1",
+						"c": "c1",
+					},
+				},
+				&xsql.Tuple{
+					Emitter: "test",
+					Message: xsql.Message{
+						"a": "a1",
+						"b": "b2",
+						"c": "c2",
+					},
+				},
+			},
+			result: [][]map[string]interface{}{{{
+				"$$a_lag_0": nil,
+				"$$a_lag_1": nil,
+				"a":         "a1", "b": "b1", "c": "c1",
+			}}, {{
+				"$$a_lag_0": "a1", "$$a_lag_1": "b1", "a": "a1", "b": "b2", "c": "c1",
+			}}, {{
+				"$$a_lag_0": "a1", "$$a_lag_1": "b2", "a": "a1", "c": "c1",
+			}}, {{
+				"$$a_lag_0": "a1", "$$a_lag_1": interface{}(nil), "a": "a1", "b": "b2", "c": "c2",
+			}}},
+		},
+		{ // 1 changed test
+			funcs: []*ast.Call{
+				{
+					Name: "changed_col",
+					Args: []ast.Expr{
+						&ast.BooleanLiteral{Val: false},
+						&ast.FieldRef{Name: "a"},
+					},
+					FuncId:      0,
+					CachedField: "$$a_changed_col_0",
+				},
+				{
+					Name: "lag",
+					Args: []ast.Expr{
+						&ast.FieldRef{Name: "b"},
+					},
+					FuncId:      1,
+					CachedField: "$$a_lag_1",
+				},
+				{
+					Name: "had_changed",
+					Args: []ast.Expr{
+						&ast.BooleanLiteral{Val: true},
+						&ast.FieldRef{Name: "c"},
+					},
+					FuncId:      0,
+					CachedField: "$$a_had_changed_0",
+				},
+			},
+			data: []interface{}{
+				&xsql.Tuple{
+					Emitter: "test",
+					Message: xsql.Message{
+						"a": "a1",
+						"b": "b1",
+					},
+				},
+				&xsql.Tuple{
+					Emitter: "test",
+					Message: xsql.Message{
+						"a": "a1",
+						"c": "c1",
+					},
+				},
+				&xsql.Tuple{
+					Emitter: "test",
+					Message: xsql.Message{
+						"a": "a1",
+						"c": "c1",
+					},
+				},
+				&xsql.Tuple{
+					Emitter: "test",
+					Message: xsql.Message{
+						"a": "a1",
+						"b": "b2",
+						"c": "c2",
+					},
+				},
+			},
+			result: [][]map[string]interface{}{
+				{{
+					"$$a_changed_col_0": "a1", "$$a_had_changed_0": false, "$$a_lag_1": nil, "a": "a1", "b": "b1",
+				}}, {{
+					"$$a_changed_col_0": nil, "$$a_had_changed_0": true, "$$a_lag_1": "b1", "a": "a1", "c": "c1",
+				}}, {{
+					"$$a_changed_col_0": nil, "$$a_had_changed_0": false, "$$a_lag_1": nil, "a": "a1", "c": "c1",
+				}}, {{
+					"$$a_changed_col_0": nil, "$$a_had_changed_0": true, "$$a_lag_1": nil, "a": "a1", "b": "b2", "c": "c2",
+				}},
+			},
+		},
+	}
+	fmt.Printf("The test bucket size is %d.\n\n", len(tests))
+	contextLogger := conf.Log.WithField("rule", "TestChangedFuncs_Apply1")
+
+	for i, tt := range tests {
+		tempStore, _ := state.CreateStore("mockRule"+strconv.Itoa(i), api.AtMostOnce)
+		ctx := context.WithValue(context.Background(), context.LoggerKey, contextLogger).WithMeta("mockRule"+strconv.Itoa(i), "project", tempStore)
+
+		pp := &AnalyticFuncsOp{Funcs: tt.funcs}
+		fv, afv := xsql.NewFunctionValuersForOp(ctx)
+		r := make([][]map[string]interface{}, 0, len(tt.data))
+		for _, d := range tt.data {
+			opResult := pp.Apply(ctx, d, fv, afv)
+			result, err := parseResult(opResult, false)
+			if err != nil {
+				t.Errorf("parse result error： %s", err)
+				continue
+			}
+			r = append(r, result)
+		}
+
+		if !reflect.DeepEqual(tt.result, r) {
+			t.Errorf("%d.\n\nresult mismatch:\n\nexp=%#v\n\ngot=%#v\n\n", i, tt.result, r)
+		}
+	}
+}

--- a/internal/topo/planner/analyticFuncsPlan.go
+++ b/internal/topo/planner/analyticFuncsPlan.go
@@ -1,0 +1,40 @@
+// Copyright 2022 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package planner
+
+import "github.com/lf-edge/ekuiper/pkg/ast"
+
+type AnalyticFuncsPlan struct {
+	baseLogicalPlan
+	funcs []*ast.Call
+}
+
+func (p AnalyticFuncsPlan) Init() *AnalyticFuncsPlan {
+	p.baseLogicalPlan.self = &p
+	return &p
+}
+
+// PushDownPredicate this op must run before any filters
+func (p *AnalyticFuncsPlan) PushDownPredicate(condition ast.Expr) (ast.Expr, LogicalPlan) {
+	return condition, p
+}
+
+func (p *AnalyticFuncsPlan) PruneColumns(fields []ast.Expr) error {
+	for _, f := range p.funcs {
+		ff := getFields(f)
+		fields = append(fields, ff...)
+	}
+	return p.baseLogicalPlan.PruneColumns(fields)
+}

--- a/internal/topo/topotest/rule_test.go
+++ b/internal/topo/topotest/rule_test.go
@@ -573,7 +573,7 @@ func TestSingleSQL(t *testing.T) {
 		},
 		{
 			Name: `TestLagAlias`,
-			Sql:  "SELECT lag(size) as lastSize, size, lastSize/size as changeRate FROM demo",
+			Sql:  "SELECT lag(size) as lastSize, size, lastSize/size as changeRate FROM demo WHERE size > 2",
 			R: [][]map[string]interface{}{
 				{{
 					"size": float64(3),
@@ -584,30 +584,15 @@ func TestSingleSQL(t *testing.T) {
 					"changeRate": float64(0),
 				}},
 				{{
-					"lastSize":   float64(6),
-					"size":       float64(2),
-					"changeRate": float64(3),
-				}},
-				{{
 					"lastSize":   float64(2),
 					"size":       float64(4),
 					"changeRate": float64(0),
 				}},
-				{{
-					"lastSize":   float64(4),
-					"size":       float64(1),
-					"changeRate": float64(4),
-				}},
 			},
 			M: map[string]interface{}{
-				"op_2_project_0_exceptions_total":   int64(0),
-				"op_2_project_0_process_latency_us": int64(0),
-				"op_2_project_0_records_in_total":   int64(5),
-				"op_2_project_0_records_out_total":  int64(5),
-
 				"sink_mockSink_0_exceptions_total":  int64(0),
-				"sink_mockSink_0_records_in_total":  int64(5),
-				"sink_mockSink_0_records_out_total": int64(5),
+				"sink_mockSink_0_records_in_total":  int64(3),
+				"sink_mockSink_0_records_out_total": int64(3),
 
 				"source_demo_0_exceptions_total":  int64(0),
 				"source_demo_0_records_in_total":  int64(5),

--- a/internal/xsql/valuer.go
+++ b/internal/xsql/valuer.go
@@ -270,6 +270,15 @@ func (v *ValuerEval) Eval(expr ast.Expr) interface{} {
 		}
 		return &BracketEvalResult{Start: ii, End: ii}
 	case *ast.Call:
+		// The analytic function are calculated prior to all ops, so just get the cached field value
+		if expr.Cached {
+			val, ok := v.Valuer.Value(expr.CachedField, "")
+			if ok {
+				return val
+			} else {
+				return fmt.Errorf("call %s error: %v", expr.Name, val)
+			}
+		}
 		if _, ok := implicitValueFuncs[expr.Name]; ok {
 			if vv, ok := v.Valuer.(FuncValuer); ok {
 				val, ok := vv.FuncValue(expr.Name)

--- a/pkg/ast/expr.go
+++ b/pkg/ast/expr.go
@@ -136,6 +136,11 @@ type Call struct {
 	FuncId   int
 	FuncType FuncType
 	Args     []Expr
+	// This is used for analytic functions.
+	// In planner, all analytic functions are planned to calculate in analytic_op which produce a new field.
+	// This cachedField cached the new field name and when evaluating, just return the field access evaluated value.
+	CachedField string
+	Cached      bool
 }
 
 func (c *Call) expr()    {}


### PR DESCRIPTION
Analytic function are run right after source so that they are not affected by predicates in WHERE clause, join conditions in JOIN clause, or grouping expressions in GROUP BY clause of the current query

Signed-off-by: Jiyong Huang <huangjy@emqx.io>