### PR TITLE
fix(portable): fix restart rule with multiple portable symbol reference

### DIFF
--- a/internal/plugin/portable/runtime/plugin_ins_manager.go
+++ b/internal/plugin/portable/runtime/plugin_ins_manager.go
@@ -207,7 +207,7 @@ func (p *pluginInsManager) getOrStartProcess(pluginMeta *PluginMeta, pconf *Port
 		p.instances[pluginMeta.Name] = ins
 	}
 	// ins process has not run yet
-	if !pluginCreation && len(ins.commands) != 0 {
+	if !pluginCreation && ins.ctrlChan != nil {
 		return ins, nil
 	}
 	// should only happen for first start, then the ctrl channel will keep running


### PR DESCRIPTION
The instance may be initialized twice as the command list cannot guarentee to be updated before next symbol starting