### PR TITLE
feat(source): file source add support for lines format

### DIFF
--- a/internal/topo/mock/test_source.go
+++ b/internal/topo/mock/test_source.go
@@ -16,7 +16,10 @@ package mock
 
 import (
 	"fmt"
+	"github.com/lf-edge/ekuiper/internal/converter"
+	"github.com/lf-edge/ekuiper/internal/topo/context"
 	"github.com/lf-edge/ekuiper/pkg/api"
+	"github.com/lf-edge/ekuiper/pkg/ast"
 	"reflect"
 	"sync/atomic"
 	"testing"
@@ -32,6 +35,8 @@ func TestSourceOpen(r api.Source, exp []api.SourceTuple, t *testing.T) {
 		c = 0
 	}
 	ctx, cancel := NewMockContext(fmt.Sprintf("rule%d", c), "op1").WithCancel()
+	cv, _ := converter.GetOrCreateConverter(&ast.Options{FORMAT: "json"})
+	ctx = context.WithValue(ctx.(*context.DefaultContext), context.DecodeKey, cv)
 	count.Store(c.(int) + 1)
 	consumer := make(chan api.SourceTuple)
 	errCh := make(chan error)

--- a/internal/topo/source/file_source_test.go
+++ b/internal/topo/source/file_source_test.go
@@ -76,6 +76,8 @@ func TestJsonFolder(t *testing.T) {
 		return
 	}
 	mock.TestSourceOpen(r, exp, t)
+	// wait for the move to finish
+	time.Sleep(100 * time.Millisecond)
 	files, err := os.ReadDir(moveToFolder)
 	if err != nil {
 		t.Error(err)
@@ -188,6 +190,32 @@ func TestCSVFile(t *testing.T) {
 	}
 	r := &FileSource{}
 	err = r.Configure("a.csv", p)
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+	mock.TestSourceOpen(r, exp, t)
+}
+
+func TestJsonLines(t *testing.T) {
+	path, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta := map[string]interface{}{
+		"file": filepath.Join(path, "test", "test.lines"),
+	}
+	exp := []api.SourceTuple{
+		api.NewDefaultSourceTuple(map[string]interface{}{"id": float64(1), "name": "John Doe"}, meta),
+		api.NewDefaultSourceTuple(map[string]interface{}{"id": float64(2), "name": "Jane Doe"}, meta),
+		api.NewDefaultSourceTuple(map[string]interface{}{"id": float64(3), "name": "John Smith"}, meta),
+	}
+	p := map[string]interface{}{
+		"path":     filepath.Join(path, "test"),
+		"fileType": "lines",
+	}
+	r := &FileSource{}
+	err = r.Configure("test.lines", p)
 	if err != nil {
 		t.Errorf(err.Error())
 		return

--- a/internal/topo/source/test/test.lines
+++ b/internal/topo/source/test/test.lines
@@ -1,0 +1,3 @@
+{"id": 1,"name": "John Doe"}
+{"id": 2,"name": "Jane Doe"}
+{"id": 3,"name": "John Smith"}


### PR DESCRIPTION
Typical usage json lines file.
Also support binary lines file like protobuf serialization lines

Signed-off-by: Jiyong Huang <huangjy@emqx.io>