### PR TITLE
refactor: move custom schema out of core

### DIFF
--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -1,4 +1,4 @@
-// Copyright 2022 EMQ Technologies Co., Ltd.
+// Copyright 2022-2023 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package converter
 import (
 	"fmt"
 	"github.com/lf-edge/ekuiper/internal/converter/binary"
-	"github.com/lf-edge/ekuiper/internal/converter/custom"
 	"github.com/lf-edge/ekuiper/internal/converter/delimited"
 	"github.com/lf-edge/ekuiper/internal/converter/json"
 	"github.com/lf-edge/ekuiper/pkg/ast"
@@ -40,7 +39,6 @@ var ( // init once and read only
 		message.FormatDelimited: func(_ string, _ string, delimiter string) (message.Converter, error) {
 			return delimited.NewConverter(delimiter)
 		},
-		message.FormatCustom: custom.LoadConverter,
 	}
 )
 

--- a/internal/converter/ext_converter.go
+++ b/internal/converter/ext_converter.go
@@ -1,4 +1,4 @@
-// Copyright 2022 EMQ Technologies Co., Ltd.
+// Copyright 2022-2023 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 //go:build schema || !core
-// +build schema !core
 
 package converter
 
 import (
+	"github.com/lf-edge/ekuiper/internal/converter/custom"
 	"github.com/lf-edge/ekuiper/internal/converter/protobuf"
 	"github.com/lf-edge/ekuiper/internal/pkg/def"
 	"github.com/lf-edge/ekuiper/internal/schema"
@@ -32,4 +32,5 @@ func init() {
 		}
 		return protobuf.NewConverter(ffs.SchemaFile, ffs.SoFile, schemaMessageName)
 	}
+	converters[message.FormatCustom] = custom.LoadConverter
 }

--- a/internal/schema/ext_inferer_custom.go
+++ b/internal/schema/ext_inferer_custom.go
@@ -1,4 +1,4 @@
-// Copyright 2022 EMQ Technologies Co., Ltd.
+// Copyright 2022-2023 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build schema || !core
+
 package schema
 
 import (
@@ -23,6 +25,10 @@ import (
 	"github.com/lf-edge/ekuiper/pkg/message"
 	"plugin"
 )
+
+func init() {
+	inferes[message.FormatCustom] = InferCustom
+}
 
 func InferCustom(schemaFile string, messageName string) (ast.StreamFields, error) {
 	conf.Log.Infof("Load custom schema from file %s, for symbol Get%s", schemaFile, messageName)

--- a/internal/schema/ext_inferer_custom_test.go
+++ b/internal/schema/ext_inferer_custom_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 EMQ Technologies Co., Ltd.
+// Copyright 2022-2023 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,11 +16,16 @@ package schema
 
 import (
 	"github.com/lf-edge/ekuiper/internal/conf"
+	"github.com/lf-edge/ekuiper/internal/testx"
 	"github.com/lf-edge/ekuiper/pkg/ast"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+func init() {
+	testx.InitEnv()
+}
 
 func TestInferCustom(t *testing.T) {
 	// Prepare test schema file

--- a/internal/schema/inferer.go
+++ b/internal/schema/inferer.go
@@ -1,4 +1,4 @@
-// Copyright 2022 EMQ Technologies Co., Ltd.
+// Copyright 2022-2023 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,16 +17,13 @@ package schema
 import (
 	"fmt"
 	"github.com/lf-edge/ekuiper/pkg/ast"
-	"github.com/lf-edge/ekuiper/pkg/message"
 	"strings"
 )
 
 type inferer func(schemaFileName string, SchemaMessageName string) (ast.StreamFields, error)
 
 var ( // init once and read only
-	inferes = map[string]inferer{
-		message.FormatCustom: InferCustom,
-	}
+	inferes = map[string]inferer{}
 )
 
 func InferFromSchemaFile(schemaType string, schemaId string) (ast.StreamFields, error) {


### PR DESCRIPTION
It depends on plugin framework which will add 2MB+ to the core binary

Signed-off-by: Jiyong Huang <huangjy@emqx.io>