### PR TITLE
Solve the problem of registering an external service reporting invalid file path

### DIFF
--- a/internal/service/manager.go
+++ b/internal/service/manager.go
@@ -331,7 +331,7 @@ func (m *Manager) Create(r *ServiceCreationRequest) error {
 	if ok, _ := m.serviceKV.Get(name, &serviceInfo{}); ok {
 		return fmt.Errorf("service %s exist", name)
 	}
-	if !httpx.IsValidUrl(uri) || !strings.HasSuffix(uri, ".zip") {
+	if !httpx.IsValidUrl(uri) {
 		return fmt.Errorf("invalid file path %s", uri)
 	}
 	zipPath := path.Join(m.etcDir, name+".zip")


### PR DESCRIPTION
Signed URLs like this will fail to register，But it's a valid URL

http://xxx:8080/AA/functions/ExecJobService.zip?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=minio%2F20230103%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230103T085455Z&X-Amz-Expires=7200&X-Amz-SignedHeaders=host&X-Amz-Signature=3edf9ce46eea9e0da5e60f25b89c0751311f46683a5507639a3dfe7d7601fe43

