### PR TITLE
readme: fix link to quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ eKuiper processing at the edge can greatly reduce system response latency, save 
 
 ## Quick start
 
-- [eKuiper 5 minutes quick start](docs/en_US/quick_start_docker.md)
+- [eKuiper 5 minutes quick start](docs/en_US/getting_started/quick_start_docker.md)
 - [EdgeX rule engine tutorial](docs/en_US/edgex/edgex_rule_engine_tutorial.md)
 
 ## Community


### PR DESCRIPTION
Hi,

I've found the project while studying EdgeX docs and noticed that the quick start link is broken. Here is a fix :)

Have a good day!