### PR TITLE
feat(func): add compress function

### DIFF
--- a/internal/binder/function/funcs_misc.go
+++ b/internal/binder/function/funcs_misc.go
@@ -326,6 +326,10 @@ func registerMiscFunc() {
 		},
 		val: ValidateOneStrArg,
 	}
+	builtinStatfulFuncs["compress"] = func() api.Function {
+		conf.Log.Infof("initializing compress function")
+		return &compressFunc{}
+	}
 	builtins["isnull"] = builtinFunc{
 		fType: ast.FuncTypeScalar,
 		exec: func(ctx api.FunctionContext, args []interface{}) (interface{}, bool) {

--- a/internal/binder/function/funcs_stateful.go
+++ b/internal/binder/function/funcs_stateful.go
@@ -1,0 +1,81 @@
+// Copyright 2023 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"fmt"
+	"github.com/lf-edge/ekuiper/internal/compressor"
+	"github.com/lf-edge/ekuiper/pkg/api"
+	"github.com/lf-edge/ekuiper/pkg/ast"
+	"github.com/lf-edge/ekuiper/pkg/cast"
+	"github.com/lf-edge/ekuiper/pkg/message"
+)
+
+type compressFunc struct {
+	compressType string
+	compressor   message.Compressor
+}
+
+func (c *compressFunc) Validate(args []interface{}) error {
+	var eargs []ast.Expr
+	for _, arg := range args {
+		if t, ok := arg.(ast.Expr); ok {
+			eargs = append(eargs, t)
+		} else {
+			// should never happen
+			return fmt.Errorf("receive invalid arg %v", arg)
+		}
+	}
+	return ValidateTwoStrArg(nil, eargs)
+}
+
+func (c *compressFunc) Exec(args []interface{}, ctx api.FunctionContext) (interface{}, bool) {
+	if args[0] == nil {
+		return nil, true
+	}
+	arg0, err := cast.ToBytes(args[0], cast.CONVERT_SAMEKIND)
+	if err != nil {
+		return fmt.Errorf("require string or bytea parameter, but got %v", args[0]), false
+	}
+	arg1 := cast.ToStringAlways(args[1])
+	if c.compressor != nil {
+		if c.compressType != arg1 {
+			return fmt.Errorf("compress type must be consistent, previous %s, now %s", c.compressType, arg1), false
+		}
+	} else {
+		ctx.GetLogger().Infof("creating compressor %s", arg1)
+		c.compressor, err = compressor.GetCompressor(arg1)
+		if err != nil {
+			return err, false
+		}
+		c.compressType = arg1
+	}
+	r, e := c.compressor.Compress(arg0)
+	if e != nil {
+		return e, false
+	}
+	return r, true
+}
+
+func (c *compressFunc) IsAggregate() bool {
+	return false
+}
+
+func (c *compressFunc) Close(ctx api.StreamContext) error {
+	if c.compressor != nil {
+		return c.compressor.Close(ctx)
+	}
+	return nil
+}

--- a/internal/binder/function/funcs_stateful_test.go
+++ b/internal/binder/function/funcs_stateful_test.go
@@ -1,0 +1,79 @@
+// Copyright 2023 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"fmt"
+	"github.com/lf-edge/ekuiper/internal/conf"
+	kctx "github.com/lf-edge/ekuiper/internal/topo/context"
+	"github.com/lf-edge/ekuiper/internal/topo/state"
+	"github.com/lf-edge/ekuiper/pkg/api"
+	"reflect"
+	"testing"
+)
+
+func TestCompressExec(t *testing.T) {
+	ff, ok := builtinStatfulFuncs["compress"]
+	if !ok {
+		t.Fatal("builtin not found")
+	}
+	f := ff()
+	contextLogger := conf.Log.WithField("rule", "testCompressExec")
+	ctx := kctx.WithValue(kctx.Background(), kctx.LoggerKey, contextLogger)
+	tempStore, _ := state.CreateStore("mockRule0", api.AtMostOnce)
+	fctx := kctx.NewDefaultFuncContext(ctx.WithMeta("mockRule0", "test", tempStore), 2)
+	var tests = []struct {
+		args   []interface{}
+		result interface{}
+	}{
+		{ // 0
+			args: []interface{}{
+				"foo",
+				"bar",
+			},
+			result: fmt.Errorf("unsupported compressor: bar"),
+		}, { // 1
+			args: []interface{}{
+				"hello world",
+				"zlib",
+			},
+			result: []byte{0x78, 0x9c, 0xca, 0x48, 0xcd, 0xc9, 0xc9, 0x57, 0x28, 0xcf, 0x2f, 0xca, 0x49, 0x01, 0x00, 0x00, 0x00, 0xff, 0xff},
+		}, { // 2
+			args: []interface{}{
+				`{"name":"John Doe","age":30,"email":"john.doe@example.com"}`,
+				"zlib",
+			},
+			result: []byte{120, 156, 170, 86, 202, 75, 204, 77, 85, 178, 82, 242, 202, 207, 200, 83, 112, 201, 79, 85, 210, 81, 74, 76, 79, 85, 178, 50, 54, 208, 81, 74, 205, 77, 204, 204, 81, 178, 82, 202, 202, 207, 200, 211, 75, 201, 79, 117, 72, 173, 72, 204, 45, 200, 73, 213, 75, 206, 207, 85, 170, 5, 0, 0, 0, 255, 255},
+		}, { // 3
+			args: []interface{}{
+				`{"name":"John Doe","age":30,"email":"john.doe@example.com","address":{"street":"123 Main St","city":"Anytown","state":"CA","zip":"12345"},"phoneNumbers":[{"type":"home","number":"555-555-1234"},{"type":"work","number":"555-555-5678"}],"isActive":true}`,
+				"gzip",
+			},
+			result: fmt.Errorf("compress type must be consistent, previous zlib, now gzip"),
+		}, { // 4
+			args: []interface{}{
+				`hello world`,
+				"zlib",
+			},
+			result: []byte{0x78, 0x9c, 0xca, 0x48, 0xcd, 0xc9, 0xc9, 0x57, 0x28, 0xcf, 0x2f, 0xca, 0x49, 0x01, 0x00, 0x00, 0x00, 0xff, 0xff},
+		},
+	}
+	for i, tt := range tests {
+		result, _ := f.Exec(tt.args, fctx)
+		if !reflect.DeepEqual(result, tt.result) {
+			t.Errorf("%d result mismatch,\ngot:\t%v \nwant:\t%v", i, result, tt.result)
+		}
+	}
+}

--- a/internal/binder/function/static_executor.go
+++ b/internal/binder/function/static_executor.go
@@ -1,0 +1,74 @@
+// Copyright 2023 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"fmt"
+	"github.com/lf-edge/ekuiper/pkg/api"
+	"github.com/lf-edge/ekuiper/pkg/ast"
+)
+
+type funcExecutor struct{}
+
+func (f *funcExecutor) ValidateWithName(args []ast.Expr, name string) error {
+	fs, ok := builtins[name]
+	if !ok {
+		return fmt.Errorf("validate function %s error: unknown name", name)
+	}
+
+	var eargs []ast.Expr
+	for _, arg := range args {
+		if t, ok := arg.(ast.Expr); ok {
+			eargs = append(eargs, t)
+		} else {
+			// should never happen
+			return fmt.Errorf("receive invalid arg %v", arg)
+		}
+	}
+	// TODO pass in ctx
+	return fs.val(nil, eargs)
+}
+
+func (f *funcExecutor) Validate(_ []interface{}) error {
+	return fmt.Errorf("unknow name")
+}
+
+func (f *funcExecutor) Exec(_ []interface{}, _ api.FunctionContext) (interface{}, bool) {
+	return fmt.Errorf("unknow name"), false
+}
+
+func (f *funcExecutor) ExecWithName(args []interface{}, ctx api.FunctionContext, name string) (interface{}, bool) {
+	fs, ok := builtins[name]
+	if !ok {
+		return fmt.Errorf("unknow name"), false
+	}
+	return fs.exec(ctx, args)
+}
+
+func (f *funcExecutor) IsAggregate() bool {
+	return false
+}
+
+func (f *funcExecutor) GetFuncType(name string) ast.FuncType {
+	fs, ok := builtins[name]
+	if !ok {
+		return ast.FuncTypeUnknown
+	}
+	return fs.fType
+}
+
+var (
+	staticFuncExecutor = &funcExecutor{}
+)

--- a/internal/compressor/compressor.go
+++ b/internal/compressor/compressor.go
@@ -1,0 +1,62 @@
+// Copyright 2023 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package compressor
+
+import (
+	"bytes"
+	"compress/zlib"
+	"fmt"
+	"github.com/lf-edge/ekuiper/pkg/api"
+	"github.com/lf-edge/ekuiper/pkg/message"
+)
+
+func GetCompressor(name string) (message.Compressor, error) {
+	switch name {
+	case "zlib":
+		return &zlibCompressor{}, nil
+	default:
+		return nil, fmt.Errorf("unsupported compressor: %s", name)
+	}
+}
+
+type zlibCompressor struct {
+	writer *zlib.Writer
+}
+
+func (z *zlibCompressor) Close(ctx api.StreamContext) error {
+	if z.writer != nil {
+		ctx.GetLogger().Infof("closing zlib compressor")
+		return z.writer.Close()
+	}
+	return nil
+}
+
+func (z *zlibCompressor) Compress(data []byte) ([]byte, error) {
+	var b bytes.Buffer
+	if z.writer == nil {
+		z.writer = zlib.NewWriter(&b)
+	} else {
+		z.writer.Reset(&b)
+	}
+	_, err := z.writer.Write(data)
+	if err != nil {
+		return nil, err
+	}
+	err = z.writer.Flush()
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}

--- a/internal/xsql/functionRuntime.go
+++ b/internal/xsql/functionRuntime.go
@@ -22,8 +22,8 @@ import (
 	"sync"
 )
 
-//Manage the function plugin instances
-//Each operator has a single instance of this to hold the context
+// Manage the function plugin instances
+// Each operator has a single instance of this to hold the context
 type funcRuntime struct {
 	sync.Mutex
 	regs      []*funcReg
@@ -41,6 +41,8 @@ func NewFuncRuntime(ctx api.StreamContext) *funcRuntime {
 	}
 }
 
+// Get Each funcId returns a single instance of the function
+// The funcId is assigned in operator instance level, thus each operator will have a single instance of the function
 func (fp *funcRuntime) Get(name string, funcId int) (api.Function, api.FunctionContext, error) {
 	fp.Lock()
 	defer fp.Unlock()

--- a/pkg/message/artifacts.go
+++ b/pkg/message/artifacts.go
@@ -14,6 +14,8 @@
 
 package message
 
+import "github.com/lf-edge/ekuiper/pkg/api"
+
 const (
 	FormatBinary    = "binary"
 	FormatJson      = "json"
@@ -46,4 +48,14 @@ type ColumnSetter interface {
 
 type SchemaProvider interface {
 	GetSchemaJson() string
+}
+
+// Compressor compresses and decompresses bytes
+type Compressor interface {
+	Compress([]byte) ([]byte, error)
+	api.Closable
+}
+
+type Decompressor interface {
+	Decompress([]byte) ([]byte, error)
 }


### PR DESCRIPTION
1. Add a new built in function type stateful function, which has state. The function runtime can guarantee each func id in operator level will have only one function instance.
2. Add the compressor package to manage compress methods
3. Refactor function binder, split static executor and support stateful function instantiation