### PR TITLE
fix(mqtt): sync mqtt connection state

### DIFF
--- a/internal/topo/connection/clients/mqtt/mqtt_wrapper.go
+++ b/internal/topo/connection/clients/mqtt/mqtt_wrapper.go
@@ -1,4 +1,4 @@
-// Copyright 2022 EMQ Technologies Co., Ltd.
+// Copyright 2022-2023 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -67,13 +67,14 @@ func NewMqttClientWrapper(props map[string]interface{}) (clients.ClientWrapper, 
 		topicSubscriptions: make(map[string]*mqttSubscriptionInfo),
 		subscribers:        make(map[string]clients.SubscribedTopics),
 		refCnt:             1,
+		// set default connected to true, because we only return the client when it is create
+		connected: true,
 	}
-
 	err = client.Connect(cliWpr.onConnectHandler, cliWpr.onConnectLost)
 	if err != nil {
 		return nil, err
 	}
-
+	conf.Log.Infof("new mqtt client created")
 	return cliWpr, nil
 }
 


### PR DESCRIPTION
The default connection state is set to false and suppose to be sync by connect callback. It seems it is possible that the connect callback runs after publish so the first publish check conn return error.

Closes #1716 