### PR TITLE
fix(ci): remove lint check in push

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,12 +1,5 @@
 name: Lint
 on:
-  push:
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - 'tools/check/revive.toml'
-      - '.github/workflows/lint.yaml'
   pull_request:
     types: [opened, edited, synchronize, reopened]
     paths:


### PR DESCRIPTION
This check while pushing to fork branch always return an error and an error email. We only allow pr to merge code, it is not mandatory to check in push, so remove it