### PR TITLE
chore: use `t.Logf` in unit tests

### DIFF
--- a/pkg/ast/sourceStmt_test.go
+++ b/pkg/ast/sourceStmt_test.go
@@ -15,7 +15,6 @@
 package ast
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 )
@@ -55,9 +54,9 @@ func TestPrintFieldType(t *testing.T) {
 		},
 		printed: `string`,
 	}}
-	fmt.Printf("The test bucket size is %d.\n\n", len(tests))
+	t.Logf("The test bucket size is %d.", len(tests))
 	for i, tt := range tests {
-		//fmt.Printf("Parsing SQL %q.\n",tt.s)
+		// t.Logf("Parsing SQL %q.",tt.s)
 		result, _ := doPrintFieldTypeForJson(tt.ft)
 		if !reflect.DeepEqual(tt.printed, result) {
 			t.Errorf("%d. \nstmt mismatch:\n\nexp=%#v\n\ngot=%#v\n\n", i, tt.printed, result)
@@ -128,7 +127,7 @@ func TestToJsonFields(t *testing.T) {
 			},
 		},
 	}
-	fmt.Printf("The test bucket size is %d.\n\n", len(tests))
+	t.Logf("The test bucket size is %d.", len(tests))
 	for i, tt := range tests {
 		result := tt.input.ToJsonSchema()
 		if !reflect.DeepEqual(tt.output, result) {

--- a/pkg/cast/cast_test.go
+++ b/pkg/cast/cast_test.go
@@ -67,7 +67,7 @@ func TestToTypedSlice(t *testing.T) {
 			e: "cannot convert []interface {}([<nil> bbb ddd]) to string slice for the 0 element: <nil>",
 		},
 	}
-	fmt.Printf("The test bucket size is %d.\n\n", len(tests))
+	t.Logf("The test bucket size is %d.", len(tests))
 	for i, tt := range tests {
 		result, err := ToTypedSlice(tt.s, func(input interface{}, ssn Strictness) (interface{}, error) {
 			if input == nil {

--- a/sdk/go/example/mirror/random_source_test.go
+++ b/sdk/go/example/mirror/random_source_test.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"github.com/lf-edge/ekuiper/sdk/go/api"
 	"github.com/lf-edge/ekuiper/sdk/go/mock"
 	"reflect"
@@ -60,7 +59,7 @@ func TestConfigure(t *testing.T) {
 			err: "source `random` property `pattern` is required",
 		},
 	}
-	fmt.Printf("The test bucket size is %d.\n\n", len(tests))
+	t.Logf("The test bucket size is %d.", len(tests))
 	for i, tt := range tests {
 		r := &randomSource{}
 		err := r.Configure("new", tt.p)


### PR DESCRIPTION
Logf formats its arguments according to the format, analogous to Printf, and records the text in the error log. A final newline is added if not provided.