### PR TITLE
fix: use print-style functions

### DIFF
--- a/internal/io/http/rest_sink_test.go
+++ b/internal/io/http/rest_sink_test.go
@@ -167,7 +167,7 @@ func TestRestSink_Apply(t *testing.T) {
 			}},
 		},
 	}
-	fmt.Printf("The test bucket size is %d.\n\n", len(tests))
+	t.Logf("The test bucket size is %d.", len(tests))
 	contextLogger := conf.Log.WithField("rule", "TestRestSink_Apply")
 	ctx := context.WithValue(context.Background(), context.LoggerKey, contextLogger)
 
@@ -186,7 +186,7 @@ func TestRestSink_Apply(t *testing.T) {
 			ContentType: r.Header.Get("Content-Type"),
 		})
 		contextLogger.Debugf(string(body))
-		fmt.Fprintf(w, string(body))
+		fmt.Fprint(w, string(body))
 	}))
 	tf, _ := transform.GenTransform("", "json", "", "")
 	defer ts.Close()
@@ -346,7 +346,7 @@ func TestRestSinkTemplate_Apply(t *testing.T) {
 			ContentType: r.Header.Get("Content-Type"),
 		})
 		contextLogger.Debugf(string(body))
-		fmt.Fprintf(w, string(body))
+		fmt.Fprint(w, string(body))
 	}))
 	defer ts.Close()
 	for i, tt := range tests {

--- a/internal/server/rpc.go
+++ b/internal/server/rpc.go
@@ -96,7 +96,7 @@ func (t *Server) CreateQuery(sql string, reply *string) error {
 		registry.Store(QueryRuleId, rs)
 		msg := fmt.Sprintf("Query was submit successfully.")
 		logger.Println(msg)
-		*reply = fmt.Sprintf(msg)
+		*reply = fmt.Sprint(msg)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR fixes a potential printing issue in printf-style functions with dynamic format strings.

e.g., when dynamic format string contains strings like `%s` will cause unexpected problems.