### PR TITLE
refactor: replace strings.Title with cases.Title

### DIFF
--- a/internal/processor/stream.go
+++ b/internal/processor/stream.go
@@ -18,6 +18,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+
 	"github.com/lf-edge/ekuiper/internal/conf"
 	"github.com/lf-edge/ekuiper/internal/pkg/store"
 	"github.com/lf-edge/ekuiper/internal/schema"
@@ -26,7 +31,6 @@ import (
 	"github.com/lf-edge/ekuiper/pkg/ast"
 	"github.com/lf-edge/ekuiper/pkg/errorx"
 	"github.com/lf-edge/ekuiper/pkg/kv"
-	"strings"
 )
 
 var (
@@ -74,7 +78,7 @@ func (p *StreamProcessor) ExecStmt(statement string) (result []string, err error
 		if err != nil {
 			err = fmt.Errorf("Create %s fails: %v.", stt, err)
 		} else {
-			r = fmt.Sprintf("%s %s is created.", strings.Title(stt), s.Name)
+			r = fmt.Sprintf("%s %s is created.", cases.Title(language.Und).String(stt), s.Name)
 			log.Printf("%s", r)
 		}
 		result = append(result, r)
@@ -191,7 +195,7 @@ func (p *StreamProcessor) ExecReplaceStream(name string, statement string, st as
 		if err != nil {
 			return "", fmt.Errorf("Replace %s fails: %v.", stt, err)
 		} else {
-			info := fmt.Sprintf("%s %s is replaced.", strings.Title(stt), s.Name)
+			info := fmt.Sprintf("%s %s is replaced.", cases.Title(language.Und).String(stt), s.Name)
 			log.Printf("%s", info)
 			return info, nil
 		}
@@ -425,7 +429,7 @@ func (p *StreamProcessor) DropStream(name string, st ast.StreamType) (string, er
 	if err != nil {
 		return "", err
 	} else {
-		return fmt.Sprintf("%s %s is dropped.", strings.Title(ast.StreamTypeMap[st]), name), nil
+		return fmt.Sprintf("%s %s is dropped.", cases.Title(language.Und).String(ast.StreamTypeMap[st]), name), nil
 	}
 }
 

--- a/internal/server/rest.go
+++ b/internal/server/rest.go
@@ -19,10 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/lf-edge/ekuiper/internal/conf"
-	"github.com/lf-edge/ekuiper/internal/meta"
-	"github.com/lf-edge/ekuiper/internal/pkg/httpx"
-	"github.com/lf-edge/ekuiper/internal/processor"
 	"io"
 	"net/http"
 	"os"
@@ -30,11 +26,17 @@ import (
 	"reflect"
 	"runtime"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+
+	"github.com/lf-edge/ekuiper/internal/conf"
+	"github.com/lf-edge/ekuiper/internal/meta"
+	"github.com/lf-edge/ekuiper/internal/pkg/httpx"
+	"github.com/lf-edge/ekuiper/internal/processor"
 	"github.com/lf-edge/ekuiper/internal/server/middleware"
 	"github.com/lf-edge/ekuiper/pkg/api"
 	"github.com/lf-edge/ekuiper/pkg/ast"
@@ -318,7 +320,7 @@ func sourcesManageHandler(w http.ResponseWriter, r *http.Request, st ast.StreamT
 			content, err = streamProcessor.ShowStream(st)
 		}
 		if err != nil {
-			handleError(w, err, fmt.Sprintf("%s command error", strings.Title(ast.StreamTypeMap[st])), logger)
+			handleError(w, err, fmt.Sprintf("%s command error", cases.Title(language.Und).String(ast.StreamTypeMap[st])), logger)
 			return
 		}
 		jsonResponse(content, w, logger)
@@ -330,7 +332,7 @@ func sourcesManageHandler(w http.ResponseWriter, r *http.Request, st ast.StreamT
 		}
 		content, err := streamProcessor.ExecStreamSql(v.Sql)
 		if err != nil {
-			handleError(w, err, fmt.Sprintf("%s command error", strings.Title(ast.StreamTypeMap[st])), logger)
+			handleError(w, err, fmt.Sprintf("%s command error", cases.Title(language.Und).String(ast.StreamTypeMap[st])), logger)
 			return
 		}
 		w.WriteHeader(http.StatusCreated)
@@ -367,7 +369,7 @@ func sourceManageHandler(w http.ResponseWriter, r *http.Request, st ast.StreamTy
 		}
 		content, err := streamProcessor.ExecReplaceStream(name, v.Sql, st)
 		if err != nil {
-			handleError(w, err, fmt.Sprintf("%s command error", strings.Title(ast.StreamTypeMap[st])), logger)
+			handleError(w, err, fmt.Sprintf("%s command error", cases.Title(language.Und).String(ast.StreamTypeMap[st])), logger)
 			return
 		}
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
`strings.Title` has been deprecated since Go 1.18. Use golang.org/x/text/cases instead.