### PR TITLE
test: fix loop spin

### DIFF
--- a/internal/io/memory/memory_test.go
+++ b/internal/io/memory/memory_test.go
@@ -16,16 +16,18 @@ package memory
 
 import (
 	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
 	"github.com/benbjohnson/clock"
 	"github.com/gdexlab/go-render/render"
+
 	"github.com/lf-edge/ekuiper/internal/conf"
 	"github.com/lf-edge/ekuiper/internal/io/memory/pubsub"
 	"github.com/lf-edge/ekuiper/internal/topo/context"
 	"github.com/lf-edge/ekuiper/internal/topo/state"
 	"github.com/lf-edge/ekuiper/pkg/api"
-	"reflect"
-	"testing"
-	"time"
 )
 
 func TestSharedInmemoryNode(t *testing.T) {
@@ -83,7 +85,6 @@ func TestSharedInmemoryNode(t *testing.T) {
 				t.Errorf("result %s should be equal to %s", res, expected)
 			}
 			return
-		default:
 		}
 	}
 }


### PR DESCRIPTION
`default` was wrongly used in a for-loop.