### PR TITLE
ci(tests): fix a potential apt hanging

### DIFF
--- a/.github/workflows/run_fvt_tests.yaml
+++ b/.github/workflows/run_fvt_tests.yaml
@@ -13,6 +13,9 @@ on:
     types:
       - published
 
+env:
+  DEBIAN_FRONTEND: noninteractive
+
 jobs:
   fvt_tests_with_edgex:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_test_case.yaml
+++ b/.github/workflows/run_test_case.yaml
@@ -35,6 +35,8 @@ jobs:
           exit 1
         fi
     - name: install lib
+      env:
+        DEBIAN_FRONTEND: noninteractive
       run: sudo apt-get update && sudo apt-get install libzmq3-dev -y
     - name: run test case
       run: |


### PR DESCRIPTION
When writing unattended scripts (including Dockerfiles), when `using apt install -y` but without `DEBIAN_FRONTEND=noninteractive`, sometimes installation will get stuck at an interactive prompt.