### PR TITLE
ci(fvt-tests): replace apt with apt-get

### DIFF
--- a/.github/workflows/run_fvt_tests.yaml
+++ b/.github/workflows/run_fvt_tests.yaml
@@ -86,7 +86,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: build kuiper
       run: |
-        sudo apt update && sudo apt install pkg-config libczmq-dev -y
+        sudo apt-get update && sudo apt-get install pkg-config libczmq-dev -y
         make build_with_edgex
         go build -trimpath --buildmode=plugin -o plugins/sources/Zmq.so extensions/sources/zmq/zmq.go
         go build -trimpath --buildmode=plugin -o plugins/functions/Image.so extensions/functions/image/*.go
@@ -110,7 +110,7 @@ jobs:
         path: ./jmeter_logs
     - name: check logs
       run: |
-        sudo apt update && sudo apt install -y libxml2-utils
+        sudo apt-get update && sudo apt-get install -y libxml2-utils
         cd jmeter_logs
         for file in `ls *.jtl`
         do
@@ -200,7 +200,7 @@ jobs:
           path: ./jmeter_logs
       - name: check logs
         run: |
-          sudo apt update && sudo apt install -y libxml2-utils
+          sudo apt-get update && sudo apt-get install -y libxml2-utils
           cd jmeter_logs
           for file in `ls *.jtl`
           do
@@ -247,11 +247,11 @@ jobs:
       run: |
         sudo apt-get remove docker docker-engine docker.io containerd runc
         sudo apt-get update
-        sudo apt-get install apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+        sudo apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
         curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
         sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
         sudo apt-get update
-        sudo apt-get install docker-ce docker-ce-cli containerd.io
+        sudo apt-get install -y docker-ce docker-ce-cli containerd.io
     - name: install k3s
       env:
         KUBECONFIG: "/etc/rancher/k3s/k3s.yaml"


### PR DESCRIPTION
apt does not have a stable CLI interface.