### PR TITLE
fix(sql): update sql should use single quote literal

### DIFF
--- a/extensions/sinks/sql/sql.go
+++ b/extensions/sinks/sql/sql.go
@@ -15,13 +15,13 @@
 package main
 
 import (
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"github.com/lf-edge/ekuiper/internal/topo/transform"
 	"reflect"
 	"strings"
 
+	"github.com/lf-edge/ekuiper/extensions/sqldatabase"
 	"github.com/lf-edge/ekuiper/extensions/sqldatabase/driver"
 	"github.com/lf-edge/ekuiper/extensions/util"
 	"github.com/lf-edge/ekuiper/pkg/api"
@@ -92,7 +92,7 @@ func (t *sqlConfig) getKeyValues(ctx api.StreamContext, mapData map[string]inter
 type sqlSink struct {
 	conf *sqlConfig
 	// The db connection instance
-	db *sql.DB
+	db sqldatabase.DB
 }
 
 func (m *sqlSink) Configure(props map[string]interface{}) error {
@@ -322,7 +322,7 @@ func (m *sqlSink) save(ctx api.StreamContext, table string, data map[string]inte
 			sqlStr += fmt.Sprintf("%s=%s", key, vals[i])
 		}
 		if _, ok := keyval.(string); ok {
-			sqlStr += fmt.Sprintf(" WHERE %s = \"%s\";", m.conf.KeyField, keyval)
+			sqlStr += fmt.Sprintf(" WHERE %s = '%s';", m.conf.KeyField, keyval)
 		} else {
 			sqlStr += fmt.Sprintf(" WHERE %s = %v;", m.conf.KeyField, keyval)
 		}
@@ -332,7 +332,7 @@ func (m *sqlSink) save(ctx api.StreamContext, table string, data map[string]inte
 			return fmt.Errorf("field %s does not exist in data %v", m.conf.KeyField, data)
 		}
 		if _, ok := keyval.(string); ok {
-			sqlStr = fmt.Sprintf("DELETE FROM %s WHERE %s = \"%s\";", table, m.conf.KeyField, keyval)
+			sqlStr = fmt.Sprintf("DELETE FROM %s WHERE %s = '%s';", table, m.conf.KeyField, keyval)
 		} else {
 			sqlStr = fmt.Sprintf("DELETE FROM %s WHERE %s = %v;", table, m.conf.KeyField, keyval)
 		}

--- a/extensions/sqldatabase/db.go
+++ b/extensions/sqldatabase/db.go
@@ -1,0 +1,21 @@
+// Copyright 2023 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqldatabase
+
+import "database/sql"
+
+type DB interface {
+	Exec(query string, args ...interface{}) (sql.Result, error)
+}

--- a/extensions/sqldatabase/mock.go
+++ b/extensions/sqldatabase/mock.go
@@ -1,0 +1,46 @@
+// Copyright 2023 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqldatabase
+
+import "database/sql"
+
+type MockDB struct {
+	sqls []string
+}
+
+func (m *MockDB) Exec(query string, _ ...interface{}) (sql.Result, error) {
+	m.sqls = append(m.sqls, query)
+	return &MockResult{rowsAffected: 1}, nil
+}
+
+func (m *MockDB) LastSql() string {
+	if len(m.sqls) == 0 {
+		return ""
+	} else {
+		return m.sqls[len(m.sqls)-1]
+	}
+}
+
+type MockResult struct {
+	rowsAffected int64
+}
+
+func (m *MockResult) LastInsertId() (int64, error) {
+	return 1, nil
+}
+
+func (m *MockResult) RowsAffected() (int64, error) {
+	return m.rowsAffected, nil
+}


### PR DESCRIPTION
Because double quote is recognized as column by pgsql