### PR TITLE
ci(codecov): avoid needless ci failure

### DIFF
--- a/.github/workflows/run_test_case.yaml
+++ b/.github/workflows/run_test_case.yaml
@@ -74,7 +74,7 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         files: coverage.out,topotest-plugin.out
-        fail_ci_if_error: true
+        fail_ci_if_error: false
         verbose: true
     - name: Run plugins test case
       run: |


### PR DESCRIPTION
Setting the `fail_ci_if_error` option to true will mark the whole test CI as failed if uploading process is temporarily unavailable.

Turning this option off is recommended (as `false` is the default value by codecov).