### PR TITLE
feat: let `startRule` rerun the rule

### DIFF
--- a/internal/server/rest_test.go
+++ b/internal/server/rest_test.go
@@ -444,5 +444,5 @@ func (suite *ServerTestSuite) TestStartRuleAfterSchemaChange() {
 	reply = ""
 	err = suite.s.StartRule(ruleId, &reply)
 	assert.Error(suite.T(), err)
-	assert.Equal(suite.T(), err.Error(), "rerun rule topo error: unknown field a")
+	assert.Equal(suite.T(), err.Error(), "unknown field a")
 }

--- a/internal/server/rest_test.go
+++ b/internal/server/rest_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/lf-edge/ekuiper/internal/conf"
+	"github.com/lf-edge/ekuiper/internal/pkg/model"
 	"github.com/lf-edge/ekuiper/internal/processor"
 	"github.com/lf-edge/ekuiper/internal/testx"
 	"github.com/lf-edge/ekuiper/internal/topo/rule"
@@ -392,4 +393,56 @@ func (suite *RestTestSuite) Test_fileUpload() {
 
 func TestRestTestSuite(t *testing.T) {
 	suite.Run(t, new(RestTestSuite))
+}
+
+func (suite *ServerTestSuite) TestStartRuleAfterSchemaChange() {
+	sql := `Create Stream test (a bigint) WITH (DATASOURCE="../internal/server/rpc_test_data/test.json", FORMAT="JSON", type="file");`
+	var reply string
+	err := suite.s.Stream(sql, &reply)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), "Stream test is created.\n", reply)
+
+	reply = ""
+	rule := `{
+			  "sql": "SELECT a from test;",
+			  "actions": [{
+				"file": {
+				  "path": "../internal/server/rpc_test_data/data/result.txt",
+				  "interval": 5000,
+				  "fileType": "lines",
+				  "format": "json"
+				}
+			  }]
+	}`
+	ruleId := "myRule"
+	args := &model.RPCArgDesc{Name: ruleId, Json: rule}
+	err = suite.s.CreateRule(args, &reply)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), "Rule myRule was created successfully, please use 'bin/kuiper getstatus rule myRule' command to get rule status.", reply)
+
+	reply = ""
+	err = suite.s.GetStatusRule(ruleId, &reply)
+	assert.Nil(suite.T(), err)
+
+	reply = ""
+	err = suite.s.StopRule(ruleId, &reply)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), "Rule myRule was stopped.", reply)
+
+	reply = ""
+	sql = `drop stream test`
+	err = suite.s.Stream(sql, &reply)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), "Stream test is dropped.\n", reply)
+
+	reply = ""
+	sql = `Create Stream test (b bigint) WITH (DATASOURCE="../internal/server/rpc_test_data/test.json", FORMAT="JSON", type="file");`
+	err = suite.s.Stream(sql, &reply)
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), "Stream test is created.\n", reply)
+
+	reply = ""
+	err = suite.s.StartRule(ruleId, &reply)
+	assert.Error(suite.T(), err)
+	assert.Equal(suite.T(), err.Error(), "rerun rule topo error: unknown field a")
 }

--- a/internal/server/rule_manager.go
+++ b/internal/server/rule_manager.go
@@ -189,26 +189,7 @@ func reRunRule(name string) error {
 	if !ok {
 		return fmt.Errorf("Rule %s is not found in registry, please check if it is created", name)
 	} else {
-		r := rs.Rule
-		var err error
-		deleteRule(name)
-		// Validate the topo
-		panicOrError := infra.SafeRun(func() error {
-			rs, err = createRuleState(r)
-			return err
-		})
-		if panicOrError != nil {
-			// Do not store to registry so also delete the KV
-			deleteRule(r.Id)
-			_, _ = ruleProcessor.ExecDrop(r.Id)
-			return fmt.Errorf("rerun rule topo error: %v", panicOrError)
-		}
-		err = rs.Start()
-		if err != nil {
-			return err
-		}
-		err = ruleProcessor.ExecReplaceRuleState(rs.RuleId, true)
-		return err
+		return rs.UpdateTopo(rs.Rule)
 	}
 }
 


### PR DESCRIPTION
let startRule rerun the rule in order to re-optimize the rule, then we can generate the plan with the latest schema.