### PR TITLE
ci(release): fail release with update errors

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -383,7 +383,7 @@ jobs:
       if: github.event_name == 'release'
       run: |
         set -e -x -u
-        curl -w %{http_code} \
+        curl -fvs -w %{http_code} \
              --insecure \
              -H "Content-Type: application/json" \
              -H "token: ${{ secrets.EMQX_IO_TOKEN }}" \


### PR DESCRIPTION
options description:

- `-f`: non-zero exit code if http failed
- `-v`: enable verbose mode
- `-s`: silent mode to suppress curl's progress bar