### PR TITLE
ci(docker/debian): upgrade debian to bullseye

### DIFF
--- a/.github/dockerfile/Dockerfile.debian
+++ b/.github/dockerfile/Dockerfile.debian
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:stretch
+FROM debian:bullseye
 
 ARG GO_VERSION
 

--- a/.github/workflows/build_base_image.yaml
+++ b/.github/workflows/build_base_image.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           image: tonistiigi/binfmt:latest
           platforms: all
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: /tmp/.docker-buildx-cache
           key: docker-buildx-${{ matrix.golang }}-${{ matrix.os }}

--- a/.github/workflows/build_base_image.yaml
+++ b/.github/workflows/build_base_image.yaml
@@ -41,7 +41,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
-      - uses: docker/build-push-action@v3
+      - uses: docker/build-push-action@v4
         if: matrix.os == 'centos'
         with:
           push: true
@@ -52,7 +52,7 @@ jobs:
           build-args: GO_VERSION=${{ matrix.golang }}
           tags: ghcr.io/${{ github.repository }}/base:${{ matrix.golang }}-${{ matrix.os }}
           file: .github/dockerfile/Dockerfile.${{ matrix.os }}
-      - uses: docker/build-push-action@v3
+      - uses: docker/build-push-action@v4
         if: matrix.os == 'debian'
         with:
           push: true
@@ -63,7 +63,7 @@ jobs:
           build-args: GO_VERSION=${{ matrix.golang }}
           tags: ghcr.io/${{ github.repository }}/base:${{ matrix.golang }}-${{ matrix.os }}
           file: .github/dockerfile/Dockerfile.${{ matrix.os }}
-      - uses: docker/build-push-action@v3
+      - uses: docker/build-push-action@v4
         if: matrix.os == 'alpine'
         with:
           push: true

--- a/deploy/docker/Dockerfile-slim
+++ b/deploy/docker/Dockerfile-slim
@@ -21,7 +21,7 @@ WORKDIR /go/kuiper
 
 RUN make build_with_edgex_and_script
 
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 COPY ./deploy/docker/docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
 COPY --from=builder /go/kuiper/_build/kuiper-* /kuiper/


### PR DESCRIPTION
This PR upgrades all debian-based images to `bullseye` release. The [stretch](https://hub.docker.com/layers/library/debian/stretch/images/sha256-16ee3e11da473f6565ef94a715f1a38b3079e0664913be78869c336a71cb6085?context=explore) release is no longer maintained and supported by debian official docker image.