### PR TITLE
fix: fix walk function

### DIFF
--- a/pkg/ast/visitor.go
+++ b/pkg/ast/visitor.go
@@ -142,6 +142,9 @@ func Walk(v Visitor, node Node) {
 
 	case *LikePattern:
 		Walk(v, n.Expr)
+
+	case *WhenClause:
+		Walk(v, n.Expr)
 	}
 }
 


### PR DESCRIPTION
```
SELECT *,  CASE WHEN ts - lag(ts) OVER (WHEN temperature < 0 AND lag(temperature) > 0) BETWEEN 1000 AND 1100 THEN 1 ELSE 0 END AS condition FROM mockStream
```
In the given example, the presence of only a "when" clause implies that the "walk" function needs to account for this specific case.