### PR TITLE
fix: rediskv get return

### DIFF
--- a/internal/pkg/store/redis/redisKv.go
+++ b/internal/pkg/store/redis/redisKv.go
@@ -72,7 +72,7 @@ func (kv redisKvStore) Set(key string, value interface{}) error {
 func (kv redisKvStore) Get(key string, value interface{}) (bool, error) {
 	val, err := kv.database.Get(context.Background(), kv.tableKey(key)).Result()
 	if err != nil {
-		return false, err
+		return false, nil
 	}
 	dec := gob.NewDecoder(bytes.NewBuffer([]byte(val)))
 	if err := dec.Decode(value); err != nil {


### PR DESCRIPTION
Previously rediskv get function returned an error when the specified key was not found,however the corresponding sqlite implementation returned a boolean specifying value was not found however no error was returned.

This commit copies the sqlitekv behaviour into rediskv.

for sqlite
![image](https://github.com/lf-edge/ekuiper/assets/25685249/31e24802-d169-481e-b55d-e67d13fa3ed5)
for redis
![image](https://github.com/lf-edge/ekuiper/assets/25685249/0216d401-09e1-4f35-9cd9-88374779112f)



The reason why i had to do this change is ,when we use native function plugins, i tried the sample echo function, when ekuper starts the initmanager tries to get a keyvalue for the corresponding function.Ekuper was working fine when i used sqlite as memory store.However when i switched to redis , i was getting an error ("error when querying kv:)  and ekuper used to panic and didnt start.

This was done to copy the sqlite behavior into the rediskv

Manager
![image](https://github.com/lf-edge/ekuiper/assets/25685249/7693c286-8a68-4d78-bc30-047d20046f41)

