### PR TITLE
feat: honor cpu limits in cgroups

### DIFF
--- a/cmd/kuiperd/main.go
+++ b/cmd/kuiperd/main.go
@@ -1,4 +1,4 @@
-// Copyright 2021 EMQ Technologies Co., Ltd.
+// Copyright 2021-2023 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,7 +14,11 @@
 
 package main
 
-import "github.com/lf-edge/ekuiper/internal/server"
+import (
+	_ "go.uber.org/automaxprocs"
+
+	"github.com/lf-edge/ekuiper/internal/server"
+)
 
 var (
 	Version      = "unknown"

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/urfave/cli v1.22.12
 	github.com/valyala/fastjson v1.6.4
 	go.nanomsg.org/mangos/v3 v3.4.2
+	go.uber.org/automaxprocs v1.5.2
 	golang.org/x/text v0.9.0
 	google.golang.org/genproto v0.0.0-20230227214838-9b19f0bdc514
 	google.golang.org/grpc v1.53.0

--- a/go.sum
+++ b/go.sum
@@ -243,6 +243,8 @@ github.com/yuin/gopher-lua v1.1.0 h1:BojcDhfyDWgU2f2TOzYK/g5p2gxMrku8oupLDqlnSqE
 github.com/yuin/gopher-lua v1.1.0/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.nanomsg.org/mangos/v3 v3.4.2 h1:gHlopxjWvJcVCcUilQIsRQk9jdj6/HB7wrTiUN8Ki7Q=
 go.nanomsg.org/mangos/v3 v3.4.2/go.mod h1:8+hjBMQub6HvXmuGvIq6hf19uxGQIjCofmc62lbedLA=
+go.uber.org/automaxprocs v1.5.2 h1:2LxUOGiR3O6tw8ui5sZa2LAaHnsviZdVOUZw4fvbnME=
+go.uber.org/automaxprocs v1.5.2/go.mod h1:eRbA25aqJrxAbsLO0xy5jVwPt7FQnRgjW+efnwa1WM0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=


### PR DESCRIPTION
Go processes usually set the max proc num from the value of `runtime.NumCPU()`, but this function cannot return real/correct cpu limits with certain cgroups settings (e.g. docker, k8s resource limits), which may causes the GMP model running inefficiently and impacts the performance.

This PR uses the uber's [automaxprocs](https://github.com/uber-go/automaxprocs) pkg to automatically and correctly set the max cpu processor numbers that honors cgroups settings.

Ref: https://segmentfault.com/a/1190000043930543