### PR TITLE
fix(source): race-condition at httpserver

### DIFF
--- a/internal/io/http/httpserver/data_server.go
+++ b/internal/io/http/httpserver/data_server.go
@@ -126,7 +126,7 @@ func createDataServer() (*http.Server, *mux.Router, error) {
 		Handler:      handlers.CORS(handlers.AllowedHeaders([]string{"Accept", "Accept-Language", "Content-Type", "Content-Language", "Origin", "Authorization"}), handlers.AllowedMethods([]string{"POST", "GET", "PUT", "DELETE", "HEAD"}))(r),
 	}
 	done = make(chan struct{})
-	go func() {
+	go func(done chan struct{}) {
 		var err error
 		if conf.Config.Source.HttpServerTls == nil {
 			err = s.ListenAndServe()
@@ -137,7 +137,7 @@ func createDataServer() (*http.Server, *mux.Router, error) {
 			sctx.GetLogger().Errorf("http data server error: %v", err)
 			close(done)
 		}
-	}()
+	}(done)
 	sctx.GetLogger().Infof("Serving http data server on port http://%s", cast.JoinHostPortInt(conf.Config.Source.HttpServerIp, conf.Config.Source.HttpServerPort))
 	return s, r, nil
 }


### PR DESCRIPTION
Fixes #2027 

The done channel is a global variable. createDataServer function is covered by a mutex, but the part that closes the channel is in a different goroutine - which isn't tracked.

This can lead to the following race condition:
1. createDataServer called.
2. UnregisterEndpoint called. The goroutine from createDataServer wasn't called yet.
3. createDataServer called. The goroutine from the first createDataServer is called now, and it just closed the new done channel.
4. UnregisterEndpoint called. The goroutine from the second createDataServer is called now, and it closes a closed channel - panic.

The solution is to pass the done channel to the goroutine scope.