### PR TITLE
fix(schema): allow weak schema type

### DIFF
--- a/internal/schema/inferer.go
+++ b/internal/schema/inferer.go
@@ -28,11 +28,11 @@ type inferer func(schemaFileName string, SchemaMessageName string) (ast.StreamFi
 var inferes = map[string]inferer{}
 
 func InferFromSchemaFile(schemaType string, schemaId string) (ast.StreamFields, error) {
-	r := strings.Split(schemaId, ".")
-	if len(r) != 2 {
-		return nil, fmt.Errorf("invalid schemaId: %s", schemaId)
-	}
 	if c, ok := inferes[schemaType]; ok {
+		r := strings.Split(schemaId, ".")
+		if len(r) != 2 {
+			return nil, fmt.Errorf("invalid schemaId: %s", schemaId)
+		}
 		// mock result for testing
 		if conf.IsTesting {
 			return ast.StreamFields{
@@ -52,6 +52,6 @@ func InferFromSchemaFile(schemaType string, schemaId string) (ast.StreamFields, 
 		}
 		return c(r[0], r[1])
 	} else {
-		return nil, fmt.Errorf("unsupported type: %s", schemaType)
+		return nil, nil
 	}
 }

--- a/internal/schema/inferere_test.go
+++ b/internal/schema/inferere_test.go
@@ -1,0 +1,49 @@
+// Copyright 2023 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInferFromSchemaFileError(t *testing.T) {
+	tests := []struct {
+		name       string
+		schemaType string
+		schemaId   string
+		err        error
+	}{
+		{
+			name:       "test weak schema type",
+			schemaType: "can",
+			schemaId:   "aa",
+			err:        nil,
+		}, {
+			name:       "test wrong schema id",
+			schemaType: "protobuf",
+			schemaId:   "aa",
+			err:        errors.New("invalid schemaId: aa"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := InferFromSchemaFile(tt.schemaType, tt.schemaId)
+			assert.Equal(t, tt.err, err)
+		})
+	}
+}


### PR DESCRIPTION
Should not return error if schema cannot be inferred.