### PR TITLE
ci(codecov): fix upload issue with explicit token

### DIFF
--- a/.github/workflows/run_test_case.yaml
+++ b/.github/workflows/run_test_case.yaml
@@ -65,15 +65,16 @@ jobs:
         cp -r sdk/python/ekuiper plugins/portable/pysam/
     - name: Run topotest case
       run: |
-        go test --tags="edgex msgpack script test" --cover -covermode=atomic -coverpkg=github.com/lf-edge/ekuiper/internal/topo -coverprofile=topotest-plugin.out github.com/lf-edge/ekuiper/internal/topo/topotest/plugin
+        go test --tags="edgex msgpack script test" --cover -covermode=atomic -coverpkg=github.com/lf-edge/ekuiper/internal/topo -coverprofile=topotest-plugin.xml github.com/lf-edge/ekuiper/internal/topo/topotest/plugin
     - name: Run test case
       run: |
         source $HOME/.wasmedge/env
-        go test --tags="edgex msgpack script test" --cover -covermode=atomic -coverpkg=./... -coverprofile=coverage.out $(go list ./... | grep -v "github.com/lf-edge/ekuiper/internal/topo/topotest/plugin")
+        go test --tags="edgex msgpack script test" --cover -covermode=atomic -coverpkg=./... -coverprofile=coverage.xml $(go list ./... | grep -v "github.com/lf-edge/ekuiper/internal/topo/topotest/plugin")
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
       with:
-        files: coverage.out,topotest-plugin.out
+        files: coverage.xml,topotest-plugin.xml
+        token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false
         verbose: true
     - name: Run plugins test case


### PR DESCRIPTION
This PR aims for fixing the unstable uploading issue with Codecov.

The reason for the failed uploads is due to Codecov’s inability to check the validity of a coverage upload when using tokenless uploads. The underlying issue is rate-limiting from GitHub.

Adding the [Codecov upload token](https://docs.codecov.com/docs/codecov-uploader#upload-token) into GitHub Secrets will solve this issue in most cases even if the project is public.

> The issue is still ongoing, and we are taking steps to decrease our GitHub API use. At this point, we **strongly recommend** using the Codecov upload token to upload to Codecov.

Ref: https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954