### PR TITLE
feat(sql): add `to_seconds` function

### DIFF
--- a/docs/en_US/sqls/functions/transform_functions.md
+++ b/docs/en_US/sqls/functions/transform_functions.md
@@ -32,6 +32,14 @@ Convert a time value to a time in the corresponding time zone. The time zone par
 
 > Note: To use this function in an alpine-based environment, you need to ensure that the time zone data has been properly installed (e.g. `apk add tzdata`).
 
+## TO_SECONDS
+
+```text
+to_seconds(col)
+```
+
+`to_seconds` converts col to a datetime first and returns it as a Unix time, the number of seconds elapsed since January 1, 1970 UTC.
+
 ## ENCODE
 
 ```text

--- a/docs/zh_CN/sqls/functions/transform_functions.md
+++ b/docs/zh_CN/sqls/functions/transform_functions.md
@@ -30,6 +30,14 @@ convert_tz(col, "Asia/Shanghai")
 
 > 注意：在基于 alpine 的环境里使用该函数，需要确保已经正确安装（`apk add tzdata`）了时区数据。
 
+## TO_SECONDS
+
+```text
+to_seconds(col)
+```
+
+`to_seconds` 首先将 col 转换为日期时间并将其作为 Unix 时间返回，即自 1970 年 1 月 1 日 UTC 以来经过的秒数。
+
 ## CHR
 
 ```text

--- a/internal/binder/function/funcs_misc.go
+++ b/internal/binder/function/funcs_misc.go
@@ -91,6 +91,18 @@ func registerMiscFunc() {
 		},
 		check: returnNilIfHasAnyNil,
 	}
+	builtins["to_seconds"] = builtinFunc{
+		fType: ast.FuncTypeScalar,
+		exec: func(ctx api.FunctionContext, args []interface{}) (interface{}, bool) {
+			t, err := cast.InterfaceToTime(args[0], "")
+			if err != nil {
+				return err, false
+			}
+			return t.Unix(), true
+		},
+		val:   ValidateOneArg,
+		check: returnNilIfHasAnyNil,
+	}
 	builtins["to_json"] = builtinFunc{
 		fType: ast.FuncTypeScalar,
 		exec: func(ctx api.FunctionContext, args []interface{}) (interface{}, bool) {

--- a/internal/binder/function/funcs_misc_test.go
+++ b/internal/binder/function/funcs_misc_test.go
@@ -147,6 +147,37 @@ func TestCoalesceExec(t *testing.T) {
 	}
 }
 
+func TestToSeconds(t *testing.T) {
+	f, ok := builtins["to_seconds"]
+	if !ok {
+		t.Fatal("builtin not found")
+	}
+	contextLogger := conf.Log.WithField("rule", "testExec")
+	ctx := kctx.WithValue(kctx.Background(), kctx.LoggerKey, contextLogger)
+	tempStore, _ := state.CreateStore("mockRule0", api.AtMostOnce)
+	fctx := kctx.NewDefaultFuncContext(ctx.WithMeta("mockRule0", "test", tempStore), 2)
+	tests := []struct {
+		args   []interface{}
+		result interface{}
+	}{
+		{ // 0
+			args: []interface{}{
+				time.Unix(1e9, 0),
+			},
+			result: int64(1e9),
+		}, { // 1
+			args: []interface{}{
+				nil,
+			},
+			result: errors.New("unsupported type to convert to timestamp <nil>"),
+		},
+	}
+	for _, tt := range tests {
+		result, _ := f.exec(fctx, tt.args)
+		assert.Equal(t, tt.result, result)
+	}
+}
+
 func TestToJson(t *testing.T) {
 	f, ok := builtins["to_json"]
 	if !ok {


### PR DESCRIPTION
This PR adds a MySQL-style [`to_seconds`](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_to-seconds) function that converts a datetime to its unix seconds form.