### PR TITLE
fix: exit process after an error occurs

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -156,7 +156,7 @@ func StartUp(Version string) {
 			err = srvRest.ListenAndServeTLS(conf.Config.Basic.RestTls.Certfile, conf.Config.Basic.RestTls.Keyfile)
 		}
 		if err != nil && err != http.ErrServerClosed {
-			logger.Errorf("Error serving rest service: %s", err)
+			logger.Fatal("Error serving rest service: ", err)
 		}
 	}()
 


### PR DESCRIPTION
exit process after an error occurs like bind failed "bind: address already in use"

Signed-off-by: ke4nec <ke4nec@qq.com>