### PR TITLE
fix: avoid log override when update

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -179,7 +179,7 @@ func SetDebugLevel(v bool) {
 	Log.SetLevel(lvl)
 }
 
-func SetConsoleAndFileLog(fileLog, consoleLog bool) error {
+func SetConsoleAndFileLog(consoleLog, fileLog bool) error {
 	if !fileLog {
 		if consoleLog {
 			Log.SetOutput(os.Stdout)
@@ -252,7 +252,7 @@ func InitConf() {
 		SetDebugLevel(true)
 	}
 
-	if err := SetConsoleAndFileLog(Config.Basic.FileLog, Config.Basic.ConsoleLog); err != nil {
+	if err := SetConsoleAndFileLog(Config.Basic.ConsoleLog, Config.Basic.FileLog); err != nil {
 		log.Fatal(err)
 	}
 

--- a/internal/server/rest.go
+++ b/internal/server/rest.go
@@ -1118,22 +1118,22 @@ func configurationUpdateHandler(w http.ResponseWriter, r *http.Request) {
 		conf.Config.Basic.TimeZone = *basic.TimeZone
 	}
 
-	if basic.FileLog != nil || basic.ConsoleLog != nil {
-		fileLog := conf.Config.Basic.FileLog
-		if basic.FileLog != nil {
-			fileLog = *basic.FileLog
-		}
+	if basic.ConsoleLog != nil || basic.FileLog != nil {
 		consoleLog := conf.Config.Basic.ConsoleLog
 		if basic.ConsoleLog != nil {
 			consoleLog = *basic.ConsoleLog
 		}
-		if err := conf.SetConsoleAndFileLog(fileLog, consoleLog); err != nil {
+		fileLog := conf.Config.Basic.FileLog
+		if basic.FileLog != nil {
+			fileLog = *basic.FileLog
+		}
+		if err := conf.SetConsoleAndFileLog(consoleLog, fileLog); err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			handleError(w, err, "", logger)
 			return
 		}
-		conf.Config.Basic.FileLog = fileLog
 		conf.Config.Basic.ConsoleLog = consoleLog
+		conf.Config.Basic.FileLog = fileLog
 	}
 
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/server/rest.go
+++ b/internal/server/rest.go
@@ -1118,16 +1118,22 @@ func configurationUpdateHandler(w http.ResponseWriter, r *http.Request) {
 		conf.Config.Basic.TimeZone = *basic.TimeZone
 	}
 
-	if basic.FileLog != nil {
-		if err := conf.SetFileLog(*basic.FileLog); err != nil {
+	if basic.FileLog != nil || basic.ConsoleLog != nil {
+		fileLog := conf.Config.Basic.FileLog
+		if basic.FileLog != nil {
+			fileLog = *basic.FileLog
+		}
+		consoleLog := conf.Config.Basic.ConsoleLog
+		if basic.ConsoleLog != nil {
+			consoleLog = *basic.ConsoleLog
+		}
+		if err := conf.SetConsoleAndFileLog(fileLog, consoleLog); err != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			handleError(w, err, "", logger)
 			return
 		}
-		conf.Config.Basic.FileLog = *basic.FileLog
-	} else if basic.ConsoleLog != nil {
-		conf.SetConsoleLog(*basic.ConsoleLog)
-		conf.Config.Basic.ConsoleLog = *basic.ConsoleLog
+		conf.Config.Basic.FileLog = fileLog
+		conf.Config.Basic.ConsoleLog = consoleLog
 	}
 
 	w.WriteHeader(http.StatusNoContent)


### PR DESCRIPTION
This PR will fix an issue when updating from:

- consoleLog: true
- fileLog: false

to:

- consoleLog: false
- fileLog: true

that console log cannot be disabled due to a logic flaw in the previous code.