### PR TITLE
fix: scan table join checkpoint

### DIFF
--- a/internal/pkg/store/redis/redisTs.go
+++ b/internal/pkg/store/redis/redisTs.go
@@ -45,10 +45,6 @@ type ts struct {
 	key   string
 }
 
-func init() {
-	gob.Register(make(map[string]interface{}))
-}
-
 func createRedisTs(redis *redis.Client, table string) (*ts, error) {
 	key := fmt.Sprintf("%s:%s", TsPrefix, table)
 	lastTs, err := getLast(redis, key, nil)

--- a/internal/pkg/store/sql/sqlTs.go
+++ b/internal/pkg/store/sql/sqlTs.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2022 EMQ Technologies Co., Ltd.
+// Copyright 2022-2023 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,10 +27,6 @@ type ts struct {
 	database Database
 	table    string
 	last     int64
-}
-
-func init() {
-	gob.Register(make(map[string]interface{}))
 }
 
 func createSqlTs(database Database, table string) (*ts, error) {

--- a/internal/topo/operator/table_processor.go
+++ b/internal/topo/operator/table_processor.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 EMQ Technologies Co., Ltd.
+// Copyright 2021-2023 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ type TableProcessor struct {
 	emitterName  string
 	// States
 	output       *xsql.WindowTuples // current batched message collection
-	batchEmitted bool               // if batch input, this is the signal for whether the last batch has emitted. If true, reinitialize.
+	batchEmitted bool               // If batch input, this is the signal for whether the last batch has emitted. If true, reinitialize.
 }
 
 func NewTableProcessor(isSchemaless bool, name string, fields map[string]*ast.JsonStreamField, options *ast.Options) (*TableProcessor, error) {
@@ -57,7 +57,7 @@ func NewTableProcessor(isSchemaless bool, name string, fields map[string]*ast.Js
 //
 //	input: *xsql.Tuple or BatchCount
 //	output: WindowTuples
-func (p *TableProcessor) Apply(ctx api.StreamContext, data interface{}, fv *xsql.FunctionValuer, _ *xsql.AggregateFunctionValuer) interface{} {
+func (p *TableProcessor) Apply(ctx api.StreamContext, data interface{}, _ *xsql.FunctionValuer, _ *xsql.AggregateFunctionValuer) interface{} {
 	logger := ctx.GetLogger()
 	tuple, ok := data.(*xsql.Tuple)
 	if !ok {

--- a/internal/topo/topotest/checkpoint_test.go
+++ b/internal/topo/topotest/checkpoint_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 EMQ Technologies Co., Ltd.
+// Copyright 2021-2023 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -115,6 +115,101 @@ func TestCheckpoint(t *testing.T) {
 		}, {
 			BufferLength:       100,
 			Qos:                api.ExactlyOnce,
+			CheckpointInterval: 600,
+			SendError:          true,
+		},
+	}
+	for j, opt := range options {
+		DoCheckpointRuleTest(t, tests, j, opt)
+	}
+}
+
+func TestTableJoinCheckpoint(t *testing.T) {
+	conf.IsTesting = true
+	streamList := []string{"demo", "table1"}
+	HandleStream(false, streamList, t)
+	tests := []RuleCheckpointTest{
+		{
+			RuleTest: RuleTest{
+				Name: `TestCheckpointRule2`,
+				Sql:  `SELECT * FROM demo INNER JOIN table1 on demo.ts = table1.id`,
+				R: [][]map[string]interface{}{
+					{{
+						"id":    float64(1541152486013),
+						"name":  "name1",
+						"color": "red",
+						"size":  float64(3),
+						"ts":    float64(1541152486013),
+					}},
+					{{
+						"id":    float64(1541152487632),
+						"name":  "name2",
+						"color": "blue",
+						"size":  float64(2),
+						"ts":    float64(1541152487632),
+					}},
+					{{
+						"id":    float64(1541152487632),
+						"name":  "name2",
+						"color": "blue",
+						"size":  float64(2),
+						"ts":    float64(1541152487632),
+					}},
+					{{
+						"id":    float64(1541152489252),
+						"name":  "name3",
+						"color": "red",
+						"size":  float64(1),
+						"ts":    float64(1541152489252),
+					}},
+				},
+				M: map[string]interface{}{
+					"op_3_join_aligner_0_records_in_total":  int64(4),
+					"op_3_join_aligner_0_records_out_total": int64(3),
+
+					"op_4_join_0_exceptions_total":  int64(0),
+					"op_4_join_0_records_in_total":  int64(3),
+					"op_4_join_0_records_out_total": int64(2),
+
+					"op_5_project_0_exceptions_total":  int64(0),
+					"op_5_project_0_records_in_total":  int64(2),
+					"op_5_project_0_records_out_total": int64(2),
+
+					"sink_mockSink_0_exceptions_total":  int64(0),
+					"sink_mockSink_0_records_in_total":  int64(2),
+					"sink_mockSink_0_records_out_total": int64(2),
+
+					"source_demo_0_exceptions_total":  int64(0),
+					"source_demo_0_records_in_total":  int64(3),
+					"source_demo_0_records_out_total": int64(3),
+
+					"source_table1_0_exceptions_total":  int64(0),
+					"source_table1_0_records_in_total":  int64(4),
+					"source_table1_0_records_out_total": int64(1),
+				},
+			},
+			PauseSize: 3,
+			Cc:        2,
+			PauseMetric: map[string]interface{}{
+				"sink_mockSink_0_exceptions_total":  int64(0),
+				"sink_mockSink_0_records_in_total":  int64(2),
+				"sink_mockSink_0_records_out_total": int64(2),
+
+				"source_demo_0_exceptions_total":  int64(0),
+				"source_demo_0_records_in_total":  int64(3),
+				"source_demo_0_records_out_total": int64(3),
+
+				"source_table1_0_exceptions_total":  int64(0),
+				"source_table1_0_records_in_total":  int64(4),
+				"source_table1_0_records_out_total": int64(1),
+			},
+		},
+	}
+	HandleStream(true, streamList, t)
+	options := []*api.RuleOption{
+		{
+			BufferLength:       100,
+			Qos:                api.AtLeastOnce,
 			CheckpointInterval: 600,
 			SendError:          true,
 		},

--- a/internal/xsql/gob_register.go
+++ b/internal/xsql/gob_register.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 EMQ Technologies Co., Ltd.
+// Copyright 2023 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,18 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package encoding
+package xsql
 
 import (
-	"bytes"
 	"encoding/gob"
+	"time"
 )
 
-func Encode(value interface{}) ([]byte, error) {
-	var buff bytes.Buffer
-	enc := gob.NewEncoder(&buff)
-	if err := enc.Encode(value); err != nil {
-		return nil, err
-	}
-	return buff.Bytes(), nil
+func init() {
+	gob.Register(time.Time{})
+	gob.Register(make(map[string]interface{}))
+	gob.Register(make(map[string][]*Tuple))
+	gob.Register(Tuple{})
 }

--- a/internal/xsql/row.go
+++ b/internal/xsql/row.go
@@ -26,7 +26,7 @@ import (
 // The tuple clone should be cheap.
 
 /*
- *  Interfaces definition
+ * Interfaces definition
  */
 
 type Wildcarder interface {

--- a/sdk/go/context/default.go
+++ b/sdk/go/context/default.go
@@ -1,4 +1,4 @@
-// Copyright 2021 EMQ Technologies Co., Ltd.
+// Copyright 2021-2023 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ func WithValue(parent *DefaultContext, key, val interface{}) *DefaultContext {
 	return parent
 }
 
-// Implement context interface
+// Deadline Implement context interface
 func (c *DefaultContext) Deadline() (deadline time.Time, ok bool) {
 	return c.ctx.Deadline()
 }


### PR DESCRIPTION
Scan table saves state data with an interface type which cannot encode/decode by gob

Closes #2111 