### PR TITLE
fix(func): array_shuffle should clone

### DIFF
--- a/internal/binder/function/funcs_array.go
+++ b/internal/binder/function/funcs_array.go
@@ -607,11 +607,12 @@ func registerArrayFunc() {
 	builtins["array_shuffle"] = builtinFunc{
 		fType: ast.FuncTypeScalar,
 		exec: func(ctx api.FunctionContext, args []interface{}) (interface{}, bool) {
-			array, ok := args[0].([]interface{})
+			arr, ok := args[0].([]interface{})
 			if !ok {
 				return errorArrayFirstArgumentNotArrayError, false
 			}
-
+			array := make([]interface{}, len(arr))
+			copy(array, arr)
 			rand.Shuffle(len(array), func(i, j int) {
 				array[i], array[j] = array[j], array[i]
 			})


### PR DESCRIPTION
Fix the problem that array_shuffle would change the original array data.