### PR TITLE
fix(func): array distinct ignore un-hashable

### DIFF
--- a/internal/binder/function/funcs_array.go
+++ b/internal/binder/function/funcs_array.go
@@ -494,9 +494,18 @@ func registerArrayFunc() {
 			set := make(map[interface{}]bool)
 
 			for _, val := range array {
-				if !set[val] {
+				switch val.(type) {
+				case int, int8, int16, int32, int64,
+					uint, uint8, uint16, uint32, uint64,
+					float32, float64,
+					string,
+					bool:
+					if !set[val] {
+						output = append(output, val)
+						set[val] = true
+					}
+				default: // all un-hashable types are not deduplicated, including array, map, etc.
 					output = append(output, val)
-					set[val] = true
 				}
 			}
 

--- a/internal/binder/function/funcs_array_test.go
+++ b/internal/binder/function/funcs_array_test.go
@@ -532,6 +532,13 @@ func TestArrayCommonFunctions(t *testing.T) {
 			result: []interface{}{1, 2},
 		},
 		{
+			name: "array_distinct",
+			args: []interface{}{
+				[]interface{}{map[string]any{"a": 1}, map[string]any{"a": 1}, map[string]any{"a": 2}},
+			},
+			result: []interface{}{map[string]any{"a": 1}, map[string]any{"a": 1}, map[string]any{"a": 2}},
+		},
+		{
 			name: "array_map",
 			args: []interface{}{
 				"round", []interface{}{0, 0.4, 1.2},


### PR DESCRIPTION
Fix the problem of panic when running against an embedded array