### PR TITLE
feat(sink): support databend as sink

### DIFF
--- a/extensions/go.mod
+++ b/extensions/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/segmentio/kafka-go v0.4.39
 	github.com/sijms/go-ora/v2 v2.5.33
 	github.com/snowflakedb/gosnowflake v1.6.19
+	github.com/databendcloud/databend-go v0.4.2
 	github.com/stretchr/testify v1.8.2
 	github.com/taosdata/driver-go/v2 v2.0.4
 	github.com/thda/tds v0.1.7

--- a/extensions/sqldatabase/driver/apply.go
+++ b/extensions/sqldatabase/driver/apply.go
@@ -22,7 +22,7 @@ func KnownBuildTags() map[string]string {
 		"clickhouse":    "clickhouse",    // github.com/ClickHouse/clickhouse-go
 		"cosmos":        "cosmos",        // github.com/btnguyen2k/gocosmos
 		"couchbase":     "n1ql",          // github.com/couchbase/go_n1ql
-		"databend":      "databend",      //github.com/databendcloud/databend-go
+		"databend":      "databend",      // github.com/databendcloud/databend-go
 		"firebird":      "firebird",      // github.com/nakagami/firebirdsql
 		"godror":        "godror",        // github.com/godror/godror
 		"h2":            "h2",            // github.com/jmrobles/h2go

--- a/extensions/sqldatabase/driver/apply.go
+++ b/extensions/sqldatabase/driver/apply.go
@@ -22,6 +22,7 @@ func KnownBuildTags() map[string]string {
 		"clickhouse":    "clickhouse",    // github.com/ClickHouse/clickhouse-go
 		"cosmos":        "cosmos",        // github.com/btnguyen2k/gocosmos
 		"couchbase":     "n1ql",          // github.com/couchbase/go_n1ql
+		"databend":      "databend",      //github.com/databendcloud/databend-go
 		"firebird":      "firebird",      // github.com/nakagami/firebirdsql
 		"godror":        "godror",        // github.com/godror/godror
 		"h2":            "h2",            // github.com/jmrobles/h2go

--- a/extensions/sqldatabase/driver/databend.go
+++ b/extensions/sqldatabase/driver/databend.go
@@ -1,0 +1,21 @@
+// Copyright 2023 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build (all || databend) && !no_databend
+
+package driver
+
+import (
+	_ "github.com/databendcloud/databend-go" // Databend driver
+)

--- a/go.work.sum
+++ b/go.work.sum
@@ -273,6 +273,7 @@ github.com/coreos/go-systemd/v22 v22.3.2 h1:D9/bQk5vlXQFZ6Kwuu6zaiXJ9oTPe68++AzA
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X51MTk3ycuNI=
+github.com/databendcloud/databend-go v0.4.2/go.mod h1:gc59O5283qi8NyzAJ1le0SEZb5p/SL7nwvrB9p6lxDw=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1m5sE92cU+pd5Mcc=
 github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=
 github.com/dop251/goja_nodejs v0.0.0-20211022123610-8dd9abb0616d h1:W1n4DvpzZGOISgp7wWNtraLcHtnmnTwBlJidqtMIuwQ=


### PR DESCRIPTION
- fix https://github.com/lf-edge/ekuiper/issues/2178

I found that databend has already been added into [dburl](https://github.com/xo/dburl), so it is very convenient to support it as a sink. BTW, how can I add some integration tests for databend sink?
