### PR TITLE
fix(operator): script Type->IOINPUT_TYPE_ANY

### DIFF
--- a/internal/topo/graph/io.go
+++ b/internal/topo/graph/io.go
@@ -160,7 +160,7 @@ var OpIO = map[string][]*IOType{
 		{Type: IOINPUT_TYPE_SAME},
 	},
 	"script": {
-		{Type: IOINPUT_TYPE_ROW, RowType: IOROW_TYPE_ANY, CollectionType: IOCOLLECTION_TYPE_ANY},
+		{Type: IOINPUT_TYPE_ANY, RowType: IOROW_TYPE_ANY, CollectionType: IOCOLLECTION_TYPE_ANY},
 		{Type: IOINPUT_TYPE_SAME},
 	},
 }


### PR DESCRIPTION
问题：
使用graph rule时，同时包含join和script节点会报类型错误

解决办法：
将script io input改为any

Signed-off-by: Pengfei Liu <261223363@qq.com>