### PR TITLE
feat: add redisSub source and redisPub sink

### DIFF
--- a/etc/sinks/redisPub.json
+++ b/etc/sinks/redisPub.json
@@ -1,0 +1,116 @@
+{
+  "about": {
+    "trial": false,
+    "author": {
+      "name": "XinTong Zhou",
+      "email": "emy120115@gmail.com",
+      "company": "personal"
+    },
+    "description": {
+      "en_US": "This operation is used to publish the output message to the Redis message channel.",
+      "zh_CN": "该操作用于将输出消息发布到redis消息通道。"
+    }
+  },
+  "libs": [
+    "github.com/redis/go-redis/v9"
+  ],
+  "properties": [{
+    "name": "address",
+    "default": "127.0.0.1:6379",
+    "optional": false,
+    "control": "text",
+    "type": "string",
+    "hint": {
+      "en_US": "The Redis database address.",
+      "zh_CN": "Redis 数据库地址。"
+    },
+    "label": {
+      "en_US": "Address",
+      "zh_CN": "地址"
+    }
+  }, {
+    "name": "username",
+    "default": "default",
+    "optional": true,
+    "control": "text",
+    "type": "string",
+    "hint": {
+      "en_US": "Redis database username.",
+      "zh_CN": "redis用户名。"
+    },
+    "label": {
+      "en_US": "Username",
+      "zh_CN": "用户名"
+    }
+  },{
+    "name": "password",
+    "default": "",
+    "optional": true,
+    "control": "text",
+    "type": "string",
+    "hint": {
+      "en_US": "Redis database password.",
+      "zh_CN": "redis数据库密码。"
+    },
+    "label": {
+      "en_US": "Password",
+      "zh_CN": "密码"
+    }
+  }, {
+    "name": "db",
+    "default": 0,
+    "optional": false,
+    "control": "text",
+    "type": "int",
+    "hint": {
+      "en_US": "Database number (0 to 16).",
+      "zh_CN": "数据库号（0到16）。"
+    },
+    "label": {
+      "en_US": "Database Number",
+      "zh_CN": "数据库号"
+    }
+  }, {
+    "name": "channel",
+    "default": "",
+    "optional": false,
+    "control": "text",
+    "type": "string",
+    "hint": {
+      "en_US": "The channels of Redis.",
+      "zh_CN": "redis发布消息通道。"
+    },
+    "label": {
+      "en_US": "Publish Channels",
+      "zh_CN": "发布通道"
+    }
+  },{
+    "name": "compression",
+    "optional": true,
+    "control": "select",
+    "type": "string",
+    "values": [
+      "zlib",
+      "gzip",
+      "flate",
+      "zstd"
+    ],
+    "hint": {
+      "en_US": "Compress the payload with the specified compression method.",
+      "zh_CN": "使用指定的压缩方法压缩 Payload。"
+    },
+    "label": {
+      "en_US": "Compression",
+      "zh_CN": "压缩"
+    }
+  }
+  ],
+  "node": {
+    "category": "sink",
+    "icon": "iconPath",
+    "label": {
+      "en": "RedisPub",
+      "zh": "RedisPub"
+    }
+  }
+}

--- a/etc/sources/redisSub.json
+++ b/etc/sources/redisSub.json
@@ -1,0 +1,124 @@
+{
+  "about": {
+    "trial": false,
+    "author": {
+      "name": "XinTong Zhou",
+      "email": "emy120115@gmail.com",
+      "company": "persional"
+    },
+    "description": {
+      "en_US": "This is a source plugin for Redis. It can be used to subscribe to data from Redis message channels.",
+      "zh_CN": "订阅redis消息通道中的数据。"
+    }
+  },
+
+  "dataSource": {},
+  "properties": {
+    "default": [
+      {
+        "name": "address",
+        "default": "127.0.0.1:6379",
+        "optional": false,
+        "control": "text",
+        "type": "string",
+        "hint": {
+          "en_US": "The Redis database address.",
+          "zh_CN": "redis数据库地址。"
+        },
+        "label": {
+          "en_US": "Address",
+          "zh_CN": "地址"
+        }
+      },
+      {
+        "name": "username",
+        "default": "default",
+        "optional": true,
+        "control": "text",
+        "type": "string",
+        "hint": {
+          "en_US": "Redis database username.",
+          "zh_CN": "redis用户名。"
+        },
+        "label": {
+          "en_US": "Username",
+          "zh_CN": "用户名"
+        }
+      },
+      {
+        "name": "password",
+        "default": "",
+        "optional": true,
+        "control": "text",
+        "type": "string",
+        "hint": {
+          "en_US": "Redis database password.",
+          "zh_CN": "redis数据库密码。"
+        },
+        "label": {
+          "en_US": "Password",
+          "zh_CN": "密码"
+        }
+      },
+      {
+        "name": "db",
+        "default": 0,
+        "optional": false,
+        "control": "text",
+        "type": "int",
+        "hint": {
+          "en_US": "Database number (0 to 16).",
+          "zh_CN": "数据库号（0到16）。"
+        },
+        "label": {
+          "en_US": "Database Number.",
+          "zh_CN": "数据库号"
+        }
+      },
+      {
+        "name": "channels",
+        "default": "",
+        "optional": false,
+        "control": "list",
+        "type": "list_string",
+        "hint": {
+          "en_US": "Redis subscription message channels.",
+          "zh_CN": "redis订阅消息通道。"
+        },
+        "label": {
+          "en_US": "SubChannels",
+          "zh_CN": "订阅通道"
+        }
+      },
+      {
+        "name": "decompression",
+        "default": "",
+        "optional": true,
+        "control": "select",
+        "type": "string",
+        "values": [
+          "zlib",
+          "gzip",
+          "flate",
+          "zstd"
+        ],
+        "hint": {
+          "en_US": "Decompress the Redis payload with the specified compression method.",
+          "zh_CN": "使用指定的压缩方法解压缩 Redis Payload。"
+        },
+        "label": {
+          "en_US": "Decompression",
+          "zh_CN": "解压缩"
+        }
+      }
+    ],
+    "node": {
+      "category": "source",
+      "icon": "iconPath",
+      "label": {
+        "en_US": "RedisSub",
+        "zh_CN": "RedisSub"
+      }
+    }
+  }
+}

--- a/etc/sources/redisSub.yaml
+++ b/etc/sources/redisSub.yaml
@@ -1,0 +1,4 @@
+default:
+  address: 127.0.0.1:6379
+  username: default
+  db: 0

--- a/internal/binder/io/ext_redis.go
+++ b/internal/binder/io/ext_redis.go
@@ -18,10 +18,13 @@ package io
 
 import (
 	"github.com/lf-edge/ekuiper/internal/io/redis"
+	"github.com/lf-edge/ekuiper/internal/io/redis/pubsub"
 	"github.com/lf-edge/ekuiper/pkg/api"
 )
 
 func init() {
 	lookupSources["redis"] = func() api.LookupSource { return redis.GetLookupSource() }
 	sinks["redis"] = func() api.Sink { return redis.GetSink() }
+	sinks["redisPub"] = func() api.Sink { return pubsub.RedisPub() }
+	sources["redisSub"] = func() api.Source { return pubsub.RedisSub() }
 }

--- a/internal/io/mock/context/mock.go
+++ b/internal/io/mock/context/mock.go
@@ -18,12 +18,15 @@ import (
 	"github.com/lf-edge/ekuiper/internal/conf"
 	"github.com/lf-edge/ekuiper/internal/topo/context"
 	"github.com/lf-edge/ekuiper/internal/topo/state"
+	"github.com/lf-edge/ekuiper/internal/topo/transform"
 	"github.com/lf-edge/ekuiper/pkg/api"
 )
 
 func NewMockContext(ruleId string, opId string) api.StreamContext {
 	contextLogger := conf.Log.WithField("rule", ruleId)
 	ctx := context.WithValue(context.Background(), context.LoggerKey, contextLogger)
+	tf, _ := transform.GenTransform("", "json", "", "", "", []string{})
+	ctx = context.WithValue(ctx, context.TransKey, tf)
 	tempStore, _ := state.CreateStore(ruleId, api.AtMostOnce)
 	return ctx.WithMeta(ruleId, opId, tempStore)
 }

--- a/internal/io/redis/pubsub/redisPub.go
+++ b/internal/io/redis/pubsub/redisPub.go
@@ -1,0 +1,129 @@
+// Copyright 2023-2023 emy120115@gmail.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pubsub
+
+import (
+	"fmt"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/lf-edge/ekuiper/internal/compressor"
+	"github.com/lf-edge/ekuiper/pkg/api"
+	"github.com/lf-edge/ekuiper/pkg/cast"
+	"github.com/lf-edge/ekuiper/pkg/errorx"
+	"github.com/lf-edge/ekuiper/pkg/message"
+)
+
+type redisPub struct {
+	conf       *redisPubConfig
+	conn       *redis.Client
+	compressor message.Compressor
+}
+
+type redisPubConfig struct {
+	Address       string `json:"address"`
+	Db            int    `json:"db"`
+	Username      string `json:"username"`
+	Password      string `json:"password"`
+	Channel       string `json:"channel"`
+	Compression   string `json:"compression"`
+	ResendChannel string `json:"resendDestination"`
+}
+
+func (r *redisPub) Configure(props map[string]interface{}) error {
+	cfg := &redisPubConfig{}
+	err := cast.MapToStruct(props, cfg)
+	if err != nil {
+		return fmt.Errorf("read properties %v fail with error: %v", props, err)
+	}
+	if cfg.Channel == "" {
+		return fmt.Errorf("redisPub sink is missing property channel")
+	}
+	if cfg.Compression != "" {
+		r.compressor, err = compressor.GetCompressor(cfg.Compression)
+		if err != nil {
+			return fmt.Errorf("invalid compression method %s", cfg.Compression)
+		}
+	}
+	if cfg.ResendChannel == "" {
+		cfg.ResendChannel = cfg.Channel
+	}
+	r.conf = cfg
+
+	return nil
+}
+
+func (r *redisPub) Open(ctx api.StreamContext) error {
+	ctx.GetLogger().Infof("redisPub sink opening")
+	r.conn = redis.NewClient(&redis.Options{
+		Addr:     r.conf.Address,
+		Username: r.conf.Username,
+		Password: r.conf.Password,
+		DB:       r.conf.Db,
+	})
+	// Ping Redis to check if the connection is alive
+	err := r.conn.Ping(ctx).Err()
+	if err != nil {
+		return fmt.Errorf("Ping Redis failed with error: %v", err)
+	}
+	return nil
+}
+
+func (r *redisPub) Collect(ctx api.StreamContext, item interface{}) error {
+	return r.collectWithChannel(ctx, item, r.conf.Channel)
+}
+
+func (r *redisPub) CollectResend(ctx api.StreamContext, item interface{}) error {
+	return r.collectWithChannel(ctx, item, r.conf.ResendChannel)
+}
+
+func (r *redisPub) collectWithChannel(ctx api.StreamContext, item interface{}, channel string) error {
+	logger := ctx.GetLogger()
+	logger.Debugf("receive %+v", item)
+	// Transform
+	jsonBytes, _, err := ctx.TransformOutput(item)
+	if err != nil {
+		return err
+	}
+	logger.Debugf("%s publish %s", ctx.GetOpId(), jsonBytes)
+	// Compress
+	if r.compressor != nil {
+		jsonBytes, err = r.compressor.Compress(jsonBytes)
+		if err != nil {
+			return err
+		}
+	}
+	// Publish
+	err = r.conn.Publish(ctx, channel, jsonBytes).Err()
+	if err != nil {
+		return fmt.Errorf("%s: Error occurred while publishing the Redis message to %s", errorx.IOErr, r.conf.Address)
+	}
+	return nil
+}
+
+func (r *redisPub) Close(ctx api.StreamContext) error {
+	ctx.GetLogger().Infof("Closing redisPub sink")
+	if r.conn != nil {
+		err := r.conn.Close()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func RedisPub() api.Sink {
+	return &redisPub{}
+}

--- a/internal/io/redis/pubsub/redisPub_test.go
+++ b/internal/io/redis/pubsub/redisPub_test.go
@@ -130,3 +130,61 @@ func TestSinkConnExp(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestSinkConfigure(t *testing.T) {
+	s := RedisPub()
+	prop := map[string]interface{}{
+		"address": "",
+		"db":      "",
+		"channel": DefaultChannel,
+	}
+	expErrStr := fmt.Sprintf("read properties %v fail with error: %v", prop, "1 error(s) decoding:\n\n* 'db' expected type 'int', got unconvertible type 'string', value: ''")
+	err := s.Configure(prop)
+	if err == nil {
+		t.Errorf("should have error")
+		return
+	} else if err.Error() != expErrStr {
+		t.Errorf("error mismatch:\n\nexp=%v\n\ngot=%v\n\n", expErrStr, err.Error())
+	}
+}
+
+func TestSinkDecompressorError(t *testing.T) {
+	s := RedisPub()
+	prop := map[string]interface{}{
+		"address":     "",
+		"db":          0,
+		"channel":     DefaultChannel,
+		"compression": "test",
+	}
+	expErrStr := fmt.Sprintf("invalid compression method test")
+	err := s.Configure(prop)
+	if err == nil {
+		t.Errorf("should have error")
+		return
+	} else if err.Error() != expErrStr {
+		t.Errorf("error mismatch:\n\nexp=%v\n\ngot=%v\n\n", expErrStr, err.Error())
+	}
+}
+
+func TestSinkPingRedisError(t *testing.T) {
+	s := RedisPub()
+	prop := map[string]interface{}{
+		"address": "",
+		"db":      0,
+		"channel": DefaultChannel,
+	}
+	// expErrStr := fmt.Sprintf("Ping Redis failed with error: %v\", err")
+	expErrStr := fmt.Sprintf("Ping Redis failed with error: dial tcp 127.0.0.1:6379: connectex: No connection could be made because the target machine actively refused it.")
+	err := s.Configure(prop)
+	if err != nil {
+		t.Error(err)
+	}
+	ctx := mockContext.NewMockContext("ruleSink", "op1")
+	err = s.Open(ctx)
+	if err == nil {
+		t.Errorf("should have error")
+		return
+	} else if err.Error() != expErrStr {
+		t.Errorf("error mismatch:\n\nexp=%v\n\ngot=%v\n\n", expErrStr, err.Error())
+	}
+}

--- a/internal/io/redis/pubsub/redisPub_test.go
+++ b/internal/io/redis/pubsub/redisPub_test.go
@@ -17,6 +17,7 @@ package pubsub
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -169,12 +170,11 @@ func TestSinkDecompressorError(t *testing.T) {
 func TestSinkPingRedisError(t *testing.T) {
 	s := RedisPub()
 	prop := map[string]interface{}{
-		"address": "",
+		"address": "127.0.0.1:6379",
 		"db":      0,
 		"channel": DefaultChannel,
 	}
-	// expErrStr := fmt.Sprintf("Ping Redis failed with error: %v\", err")
-	expErrStr := fmt.Sprintf("Ping Redis failed with error: dial tcp 127.0.0.1:6379: connectex: No connection could be made because the target machine actively refused it.")
+	expErrStr := fmt.Sprintf("Ping Redis failed with error")
 	err := s.Configure(prop)
 	if err != nil {
 		t.Error(err)
@@ -184,7 +184,11 @@ func TestSinkPingRedisError(t *testing.T) {
 	if err == nil {
 		t.Errorf("should have error")
 		return
-	} else if err.Error() != expErrStr {
-		t.Errorf("error mismatch:\n\nexp=%v\n\ngot=%v\n\n", expErrStr, err.Error())
+	} else {
+		errorMsg := fmt.Sprintf("%v", err)
+		parts := strings.SplitN(errorMsg, ":", 2)
+		if parts[0] != expErrStr {
+			t.Errorf("error mismatch:\n\nexp=%s\n\ngot=%s\n\n", expErrStr, parts[0])
+		}
 	}
 }

--- a/internal/io/redis/pubsub/redisPub_test.go
+++ b/internal/io/redis/pubsub/redisPub_test.go
@@ -1,0 +1,132 @@
+// Copyright 2023-2023 emy120115@gmail.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pubsub
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+
+	"github.com/lf-edge/ekuiper/internal/io/mock"
+	mockContext "github.com/lf-edge/ekuiper/internal/io/mock/context"
+)
+
+func TestRedisPub(t *testing.T) {
+	server, ch := mockRedisPubSub(false, true, DefaultChannel)
+	defer server.Close()
+
+	s := RedisPub()
+	s.Configure(map[string]interface{}{
+		"address":     addr,
+		"db":          0,
+		"password":    "",
+		"channel":     DefaultChannel,
+		"compression": "",
+	})
+
+	data := []interface{}{
+		map[string]interface{}{
+			"temperature": 22,
+			"humidity":    50,
+			"status":      "green",
+		},
+		map[string]interface{}{
+			"temperature": 25,
+			"humidity":    82,
+			"status":      "wet",
+		},
+		map[string]interface{}{
+			"temperature": 33,
+			"humidity":    60,
+			"status":      "hot",
+		},
+	}
+	err := mock.RunSinkCollect(s, data)
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+
+	exp := []string{
+		`{"humidity":50,"status":"green","temperature":22}`,
+		`{"humidity":82,"status":"wet","temperature":25}`,
+		`{"humidity":60,"status":"hot","temperature":33}`,
+	}
+
+	var actual []string
+	ticker := time.After(10 * time.Second)
+	for i := 0; i < len(exp); i++ {
+		select {
+		case <-ticker:
+			t.Errorf("timeout")
+			return
+		case d := <-ch:
+			actual = append(actual, string(d))
+		}
+	}
+
+	if !reflect.DeepEqual(actual, exp) {
+		t.Errorf("result mismatch:\n\nexp=%#v\n\ngot=%#v\n\n", exp, actual)
+	}
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestSinkConnExp(t *testing.T) {
+	m, err := miniredis.Run()
+	if err != nil {
+		t.Error(err)
+	}
+	mport := m.Port()
+	s := RedisPub()
+	s.Configure(map[string]interface{}{
+		"address":     m.Addr(),
+		"db":          0,
+		"password":    "",
+		"channel":     DefaultChannel,
+		"compression": "",
+	})
+	data := []interface{}{
+		map[string]interface{}{
+			"temperature": 22,
+			"humidity":    50,
+			"status":      "green",
+		},
+	}
+	ctx := mockContext.NewMockContext("ruleSink", "op1")
+	err = s.Open(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+	time.Sleep(time.Second)
+	m.Close()
+	expErrStr := fmt.Sprintf("io error: Error occurred while publishing the Redis message to 127.0.0.1:%s", mport)
+	for _, e := range data {
+		err := s.Collect(ctx, e)
+		if err == nil {
+			t.Errorf("should have error")
+			return
+		} else if err.Error() != expErrStr {
+			t.Errorf("error mismatch:\n\nexp=%s\n\ngot=%s\n\n", expErrStr, err.Error())
+		}
+	}
+	fmt.Println("closing sink")
+	err = s.Close(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/internal/io/redis/pubsub/redisSub.go
+++ b/internal/io/redis/pubsub/redisSub.go
@@ -1,0 +1,159 @@
+// Copyright 2023-2023 emy120115@gmail.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pubsub
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/lf-edge/ekuiper/internal/compressor"
+	"github.com/lf-edge/ekuiper/internal/conf"
+	"github.com/lf-edge/ekuiper/internal/io"
+	"github.com/lf-edge/ekuiper/internal/xsql"
+	"github.com/lf-edge/ekuiper/pkg/api"
+	"github.com/lf-edge/ekuiper/pkg/cast"
+	"github.com/lf-edge/ekuiper/pkg/infra"
+	"github.com/lf-edge/ekuiper/pkg/message"
+)
+
+type redisSub struct {
+	conf         *redisSubConfig
+	conn         *redis.Client
+	decompressor message.Decompressor
+}
+
+type redisSubConfig struct {
+	Address       string   `json:"address"`
+	Db            int      `json:"db"`
+	Username      string   `json:"username"`
+	Password      string   `json:"password"`
+	Channels      []string `json:"channels"`
+	Decompression string   `json:"decompression"`
+}
+
+func (r *redisSub) Configure(_ string, props map[string]interface{}) error {
+	cfg := &redisSubConfig{}
+	err := cast.MapToStruct(props, cfg)
+	if err != nil {
+		return fmt.Errorf("read properties %v fail with error: %v", props, err)
+	}
+	r.conf = cfg
+	r.conn = redis.NewClient(&redis.Options{
+		Addr:     r.conf.Address,
+		Username: r.conf.Username,
+		Password: r.conf.Password,
+		DB:       r.conf.Db,
+	})
+
+	if cfg.Decompression != "" {
+		dc, err := compressor.GetDecompressor(cfg.Decompression)
+		if err != nil {
+			return fmt.Errorf("get decompressor %s fail with error: %v", cfg.Decompression, err)
+		}
+		r.decompressor = dc
+	}
+
+	// Ping Redis to check if the connection is alive
+	err = r.conn.Ping(context.Background()).Err()
+	if err != nil {
+		return fmt.Errorf("Ping Redis failed with error: %v", err)
+	}
+	return nil
+}
+
+func (r *redisSub) Open(ctx api.StreamContext, consumer chan<- api.SourceTuple, errCh chan<- error) {
+	logger := ctx.GetLogger()
+	logger.Infof("redisSub sink Opening")
+	err := subscribe(r, ctx, consumer)
+	if err != nil {
+		infra.DrainError(ctx, err, errCh)
+	}
+}
+
+func subscribe(r *redisSub, ctx api.StreamContext, consumer chan<- api.SourceTuple) error {
+	// Subscribe to Redis channels
+	sub := r.conn.PSubscribe(ctx, r.conf.Channels...)
+	channel := sub.Channel()
+	defer sub.Close()
+	var tuples []api.SourceTuple
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case msg := <-channel:
+			tuples = getTuples(ctx, r, msg)
+		}
+		io.ReceiveTuples(ctx, consumer, tuples)
+	}
+}
+
+func getTuples(ctx api.StreamContext, r *redisSub, env interface{}) []api.SourceTuple {
+	rcvTime := conf.GetNow()
+	msg, ok := env.(*redis.Message)
+	if !ok { // should never happen
+		return []api.SourceTuple{
+			&xsql.ErrorSourceTuple{
+				Error: fmt.Errorf("can not convert interface data to redis message %v.", env),
+			},
+		}
+	}
+	payload := []byte(msg.Payload)
+	var err error
+	if r.decompressor != nil {
+		payload, err = r.decompressor.Decompress(payload)
+		if err != nil {
+			return []api.SourceTuple{
+				&xsql.ErrorSourceTuple{
+					Error: fmt.Errorf("can not decompress redis message %v.", err),
+				},
+			}
+		}
+	}
+	results, e := ctx.DecodeIntoList(payload)
+	// The unmarshal type can only be bool, float64, string, []interface{}, map[string]interface{}, nil
+	if e != nil {
+		return []api.SourceTuple{
+			&xsql.ErrorSourceTuple{
+				Error: fmt.Errorf("Invalid data format, cannot decode %s with error %s", payload, e),
+			},
+		}
+	}
+
+	meta := make(map[string]interface{})
+	meta["channel"] = msg.Channel
+
+	tuples := make([]api.SourceTuple, 0, len(results))
+	for _, result := range results {
+		tuples = append(tuples, api.NewDefaultSourceTupleWithTime(result, meta, rcvTime))
+	}
+	return tuples
+}
+
+func (r *redisSub) Close(ctx api.StreamContext) error {
+	ctx.GetLogger().Infof("Closing redisSub source")
+	if r.conn != nil {
+		err := r.conn.Close()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func RedisSub() api.Source {
+	return &redisSub{}
+}

--- a/internal/io/redis/pubsub/redisSub_test.go
+++ b/internal/io/redis/pubsub/redisSub_test.go
@@ -1,0 +1,80 @@
+// Copyright 2023-2023 emy120115@gmail.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pubsub
+
+import (
+	"testing"
+	"time"
+
+	"github.com/benbjohnson/clock"
+	_ "go.nanomsg.org/mangos/v3/transport/ipc"
+
+	"github.com/lf-edge/ekuiper/internal/conf"
+	"github.com/lf-edge/ekuiper/internal/io/mock"
+	mockContext "github.com/lf-edge/ekuiper/internal/io/mock/context"
+	"github.com/lf-edge/ekuiper/pkg/api"
+)
+
+func TestRun(t *testing.T) {
+	mc := conf.Clock.(*clock.Mock)
+	exp := []api.SourceTuple{
+		api.NewDefaultSourceTupleWithTime(map[string]interface{}{"group_name": "group1", "timestamp": 1646125996000.0, "node_name": "node1", "values": map[string]interface{}{"tag_name1": 11.22, "tag_name2": "yellow"}, "errors": map[string]interface{}{"tag_name3": 122.0}}, map[string]interface{}{"channel": "TestChannel"}, mc.Now()),
+		api.NewDefaultSourceTupleWithTime(map[string]interface{}{"group_name": "group1", "timestamp": 1646125996000.0, "node_name": "node1", "values": map[string]interface{}{"tag_name1": 11.22, "tag_name2": "green", "tag_name3": 60.0}, "errors": map[string]interface{}{}}, map[string]interface{}{"channel": "TestChannel"}, mc.Now()),
+		api.NewDefaultSourceTupleWithTime(map[string]interface{}{"group_name": "group1", "timestamp": 1646125996000.0, "node_name": "node1", "values": map[string]interface{}{"tag_name1": 15.4, "tag_name2": "green", "tag_name3": 70.0}, "errors": map[string]interface{}{}}, map[string]interface{}{"channel": "TestChannel"}, mc.Now()),
+	}
+	s := RedisSub()
+	prop := map[string]interface{}{
+		"address":  mr.Addr(),
+		"db":       0,
+		"channels": []string{DefaultChannel},
+	}
+	err := s.Configure("new", prop)
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+	server, _ := mockRedisPubSub(true, false, DefaultChannel)
+	defer server.Close()
+	mock.TestSourceOpen(s, exp, t)
+}
+
+func TestConnectFail(t *testing.T) {
+	s := RedisSub()
+	prop := map[string]interface{}{
+		"address":  mr.Addr(),
+		"db":       0,
+		"channels": []string{DefaultChannel},
+	}
+	err := s.Configure("new", prop)
+	if err != nil {
+		t.Errorf(err.Error())
+		return
+	}
+	ctx, cancel := mockContext.NewMockContext("ruleTestReconnect", "op1").WithCancel()
+	consumer := make(chan api.SourceTuple)
+	errCh := make(chan error)
+	server, _ := mockRedisPubSub(false, false, DefaultChannel)
+	go s.Open(ctx, consumer, errCh)
+	go func() {
+		select {
+		case err := <-errCh:
+			t.Errorf("received error: %v", err)
+		}
+		cancel()
+	}()
+	time.Sleep(1 * time.Second)
+	server.Close()
+	time.Sleep(1 * time.Second)
+}

--- a/internal/io/redis/pubsub/redisSub_test.go
+++ b/internal/io/redis/pubsub/redisSub_test.go
@@ -16,6 +16,7 @@ package pubsub
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -122,13 +123,16 @@ func TestSourcePingRedisError(t *testing.T) {
 		"db":       0,
 		"channels": []string{DefaultChannel},
 	}
-	// expErrStr := fmt.Sprintf("Ping Redis failed with error: %v\", err")
-	expErrStr := fmt.Sprintf("Ping Redis failed with error: dial tcp 127.0.0.1:6379: connectex: No connection could be made because the target machine actively refused it.")
+	expErrStr := fmt.Sprintf("Ping Redis failed with error")
 	err := s.Configure("new", prop)
 	if err == nil {
 		t.Errorf("should have error")
 		return
-	} else if err.Error() != expErrStr {
-		t.Errorf("error mismatch:\n\nexp=%v\n\ngot=%v\n\n", expErrStr, err.Error())
+	} else {
+		errorMsg := fmt.Sprintf("%v", err)
+		parts := strings.SplitN(errorMsg, ":", 2)
+		if parts[0] != expErrStr {
+			t.Errorf("error mismatch:\n\nexp=%s\n\ngot=%s\n\n", expErrStr, parts[0])
+		}
 	}
 }

--- a/internal/io/redis/pubsub/redisSub_test.go
+++ b/internal/io/redis/pubsub/redisSub_test.go
@@ -15,6 +15,7 @@
 package pubsub
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -77,4 +78,57 @@ func TestConnectFail(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	server.Close()
 	time.Sleep(1 * time.Second)
+}
+
+func TestSourceConfigure(t *testing.T) {
+	s := RedisSub()
+	prop := map[string]interface{}{
+		"address":  "",
+		"db":       "",
+		"channels": []string{DefaultChannel},
+	}
+	expErrStr := fmt.Sprintf("read properties %v fail with error: %v", prop, "1 error(s) decoding:\n\n* 'db' expected type 'int', got unconvertible type 'string', value: ''")
+	err := s.Configure("new", prop)
+	if err == nil {
+		t.Errorf("should have error")
+		return
+	} else if err.Error() != expErrStr {
+		t.Errorf("error mismatch:\n\nexp=%v\n\ngot=%v\n\n", expErrStr, err.Error())
+	}
+}
+
+func TestSourceDecompressorError(t *testing.T) {
+	s := RedisSub()
+	prop := map[string]interface{}{
+		"address":       "",
+		"db":            0,
+		"channels":      []string{DefaultChannel},
+		"decompression": "test",
+	}
+	expErrStr := fmt.Sprintf("get decompressor test fail with error: unsupported decompressor: test")
+	err := s.Configure("new", prop)
+	if err == nil {
+		t.Errorf("should have error")
+		return
+	} else if err.Error() != expErrStr {
+		t.Errorf("error mismatch:\n\nexp=%v\n\ngot=%v\n\n", expErrStr, err.Error())
+	}
+}
+
+func TestSourcePingRedisError(t *testing.T) {
+	s := RedisSub()
+	prop := map[string]interface{}{
+		"address":  "",
+		"db":       0,
+		"channels": []string{DefaultChannel},
+	}
+	// expErrStr := fmt.Sprintf("Ping Redis failed with error: %v\", err")
+	expErrStr := fmt.Sprintf("Ping Redis failed with error: dial tcp 127.0.0.1:6379: connectex: No connection could be made because the target machine actively refused it.")
+	err := s.Configure("new", prop)
+	if err == nil {
+		t.Errorf("should have error")
+		return
+	} else if err.Error() != expErrStr {
+		t.Errorf("error mismatch:\n\nexp=%v\n\ngot=%v\n\n", expErrStr, err.Error())
+	}
 }

--- a/internal/io/redis/pubsub/redis_test.go
+++ b/internal/io/redis/pubsub/redis_test.go
@@ -1,0 +1,90 @@
+// Copyright 2023-2023 emy120115@gmail.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pubsub
+
+import (
+	"fmt"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	_ "go.nanomsg.org/mangos/v3/transport/ipc"
+
+	"github.com/lf-edge/ekuiper/internal/topo/context"
+)
+
+const (
+	DefaultChannel = "TestChannel"
+)
+
+var data = [][]byte{
+	[]byte("{\"timestamp\": 1646125996000, \"node_name\": \"node1\", \"group_name\": \"group1\", \"values\": {\"tag_name1\": 11.22, \"tag_name2\": \"yellow\"}, \"errors\": {\"tag_name3\": 122}}"),
+	[]byte(`{"timestamp": 1646125996000, "node_name": "node1", "group_name": "group1", "values": {"tag_name1": 11.22, "tag_name2": "green","tag_name3":60}, "errors": {}}`),
+	[]byte(`{"timestamp": 1646125996000, "node_name": "node1", "group_name": "group1", "values": {"tag_name1": 15.4, "tag_name2": "green","tag_name3":70}, "errors": {}}`),
+}
+
+var (
+	addr string
+	port string
+	mr   *miniredis.Miniredis
+)
+
+func init() {
+	s, err := miniredis.Run()
+	if err != nil {
+		panic(err)
+	}
+	port = s.Port()
+	addr = "localhost:" + port
+	mr = s
+}
+
+func mockRedisPubSub(pub bool, sub bool, channel string) (*redis.Client, chan []byte) {
+	var (
+		client    *redis.Client
+		subscribe *redis.PubSub
+		ch        chan []byte
+	)
+	ctx := context.Background()
+	client = redis.NewClient(&redis.Options{
+		Addr:     addr,
+		Password: "",
+	})
+	subscribe = client.Subscribe(ctx, channel)
+
+	if sub {
+		ch = make(chan []byte)
+		go func() {
+			for {
+				message, err := subscribe.ReceiveMessage(ctx)
+				if err != nil {
+					return
+				}
+				fmt.Printf("Redis RECEIVED: \"%s\"\n", message.Payload)
+				ch <- []byte(message.Payload)
+				fmt.Println("Redis Sent out")
+			}
+		}()
+	}
+	if pub {
+		go func() {
+			var msg []byte
+			for _, msg = range data {
+				fmt.Printf("Redis Publish: \"%s\"\n", string(msg))
+				client.Publish(ctx, channel, msg)
+			}
+		}()
+	}
+	return client, ch
+}


### PR DESCRIPTION
Add two new builtin connectors.

redisSub Source:
Add a new data source called "redisSub." This source empowers users to subscribe to specific Redis channels and stream received messages into Ekuiper. Configuration parameters are included to specify the Redis server and the channel to subscribe to.

redisPub Sink:
Add a new data sink called "redisPub." The redisPub sink allows users to publish data from Ekuiper to a designated Redis channel. Configuration parameters are included to specify the Redis server and the target channel.

Bug Fix:
Resolve a bug encountered during testing of the redisPub sink with ctx.TransformOutput() using a mock context at mock.RunSinkCollect(). The bug is fixed by adding context.TransKey to the context.NewMockContext(), ensuring that testing ctx.TransformOutput() no longer results in errors.

Closes #2247 

New PR of #2260 