### PR TITLE
feat: add -json flag to describe

### DIFF
--- a/internal/processor/stream.go
+++ b/internal/processor/stream.go
@@ -483,3 +483,35 @@ func (p *StreamProcessor) GetAll() (result map[string]map[string]string, e error
 	}
 	return
 }
+
+// DescribeToJson takes the human redable text from execDescribe and converts it to json
+// Intended use is for CLI when passing -json flag
+func DescribeToJson(s string) string {
+	q := strings.Replace(s, "Fields\n--------------------------------------------------------------------------------\n", "", 1)
+	sections := strings.Split(q, "\n\n")
+	fields, options := sections[0], sections[1]
+	type field struct {
+		Name, Type string
+	}
+	type output struct {
+		Fields  []field
+		Options map[string]string
+	}
+	o := output{Options: make(map[string]string)}
+	for _, f := range strings.Split(fields, "\n") {
+		split := strings.Split(f, "\t")
+		n, t := split[0], split[1]
+		o.Fields = append(o.Fields, field{Name: n, Type: t})
+	}
+	for _, f := range strings.Split(strings.Trim(options, "\n"), "\n") {
+		split := strings.Split(f, " ")
+		n, v := split[0], split[1:]
+		o.Options[n] = strings.Join(v, "")
+	}
+	b, err := json.MarshalIndent(o, "", "\t")
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+	return string(b)
+}

--- a/internal/processor/stream_test.go
+++ b/internal/processor/stream_test.go
@@ -380,3 +380,55 @@ func TestInferredStream(t *testing.T) {
 		}
 	}
 }
+
+func TestDescribeToJson(t *testing.T) {
+	tests := []struct {
+		s string
+		r string
+	}{
+		{
+			s: "Fields\n--------------------------------------------------------------------------------\n" +
+				"USERID\tbigint\nFIRST_NAME\tstring\nLAST_NAME\tstring\nNICKNAMES\tarray(string)\nGender\tboolean\nADDRESS\t" +
+				"struct(STREET_NAME string, NUMBER bigint)\n\nDATASOURCE: users\nFORMAT: JSON\nKEY: USERID\n",
+			r: `{
+	"Fields": [
+		{
+			"Name": "USERID",
+			"Type": "bigint"
+		},
+		{
+			"Name": "FIRST_NAME",
+			"Type": "string"
+		},
+		{
+			"Name": "LAST_NAME",
+			"Type": "string"
+		},
+		{
+			"Name": "NICKNAMES",
+			"Type": "array(string)"
+		},
+		{
+			"Name": "Gender",
+			"Type": "boolean"
+		},
+		{
+			"Name": "ADDRESS",
+			"Type": "struct(STREET_NAME string, NUMBER bigint)"
+		}
+	],
+	"Options": {
+		"DATASOURCE:": "users",
+		"FORMAT:": "JSON",
+		"KEY:": "USERID"
+	}
+}`,
+		},
+	}
+	for _, tt := range tests {
+		s := DescribeToJson(tt.s)
+		if !reflect.DeepEqual(tt.r, s) {
+			t.Errorf("DescribeToJson mismatch:\nexp=%v\ngot=%v", tt.r, s)
+		}
+	}
+}


### PR DESCRIPTION
Add ability to get output from describe as json format.

Closes: [#186](https://github.com/lf-edge/ekuiper/issues/186)

I added a converter to parse the regular describe return val. I did this so as not to pass a flag all the way down, also not to potentially impact anything else in other places uses the `execDescribe` - since that method outputs a predictable format I just added a parses to convert it to json.

examples:

* No Flag
`go run main.go describe stream topic`
Fields
--------------------------------------------------------------------------------
USERID  bigint
FIRST_NAME      string
LAST_NAME       string
NICKNAMES       array(string)
Gender  boolean
ADDRESS struct(STREET_NAME string, NUMBER bigint)

DATASOURCE: users
FORMAT: JSON
KEY: USERID

* With flag
`go run main.go describe stream topic -json`
{
        "Fields": [
                {
                        "Name": "USERID",
                        "Type": "bigint"
                },
                {
                        "Name": "FIRST_NAME",
                        "Type": "string"
                },
                {
                        "Name": "LAST_NAME",
                        "Type": "string"
                },
                {
                        "Name": "NICKNAMES",
                        "Type": "array(string)"
                },
                {
                        "Name": "Gender",
                        "Type": "boolean"
                },
                {
                        "Name": "ADDRESS",
                        "Type": "struct(STREET_NAME string, NUMBER bigint)"
                }
        ],
        "Options": {
                "DATASOURCE:": "users",
                "FORMAT:": "JSON",
                "KEY:": "USERID"
        }
}
