### PR TITLE
fix(planner): analytic in case value expr

### DIFF
--- a/pkg/ast/visitor.go
+++ b/pkg/ast/visitor.go
@@ -152,6 +152,7 @@ func Walk(v Visitor, node Node) {
 
 	case *WhenClause:
 		Walk(v, n.Expr)
+		Walk(v, n.Result)
 	}
 }
 


### PR DESCRIPTION
Analytic functions are not lifted when using in case when value expr. The root cause is that visitor miss to visit value expr.