### PR TITLE
fix: fix memory leak when stop rule

### DIFF
--- a/internal/io/memory/pubsub/manager.go
+++ b/internal/io/memory/pubsub/manager.go
@@ -105,6 +105,9 @@ func RemovePub(topic string) {
 	if sinkConsumerChannels, exists := pubTopics[topic]; exists {
 		sinkConsumerChannels.count -= 1
 		if len(sinkConsumerChannels.consumers) == 0 && sinkConsumerChannels.count == 0 {
+			for _, ch := range sinkConsumerChannels.consumers {
+				close(ch)
+			}
 			delete(pubTopics, topic)
 		}
 	}

--- a/internal/io/memory/pubsub/manager.go
+++ b/internal/io/memory/pubsub/manager.go
@@ -105,9 +105,6 @@ func RemovePub(topic string) {
 	if sinkConsumerChannels, exists := pubTopics[topic]; exists {
 		sinkConsumerChannels.count -= 1
 		if len(sinkConsumerChannels.consumers) == 0 && sinkConsumerChannels.count == 0 {
-			for _, ch := range sinkConsumerChannels.consumers {
-				close(ch)
-			}
 			delete(pubTopics, topic)
 		}
 	}

--- a/internal/topo/rule/ruleState.go
+++ b/internal/topo/rule/ruleState.go
@@ -433,6 +433,8 @@ func (rs *RuleState) stop() error {
 	rs.triggered = 0
 	if rs.Topology != nil {
 		rs.Topology.Cancel()
+		// de-reference old Topology in order to release data memory
+		rs.Topology = rs.Topology.NewTopoWithSucceededCtx()
 	}
 	rs.lastStopTimestamp = time.Now().UnixMilli()
 	rs.ActionCh <- ActionSignalStop
@@ -459,6 +461,8 @@ func (rs *RuleState) internalStop() error {
 	rs.triggered = 2
 	if rs.Topology != nil {
 		rs.Topology.Cancel()
+		// de-reference old Topology in order to release data memory
+		rs.Topology = rs.Topology.NewTopoWithSucceededCtx()
 	}
 	rs.ActionCh <- ActionSignalStop
 	return nil

--- a/internal/topo/topo.go
+++ b/internal/topo/topo.go
@@ -68,6 +68,13 @@ func (s *Topo) GetContext() api.StreamContext {
 	return s.ctx
 }
 
+func (s *Topo) NewTopoWithSucceededCtx() *Topo {
+	n := &Topo{}
+	n.ctx = s.ctx
+	n.cancel = s.cancel
+	return n
+}
+
 // Cancel may be called multiple times so must be idempotent
 func (s *Topo) Cancel() {
 	s.mu.Lock()

--- a/pkg/infra/saferun.go
+++ b/pkg/infra/saferun.go
@@ -57,9 +57,9 @@ func DrainError(ctx api.StreamContext, err error, errCh chan<- error) {
 		} else {
 			conf.Log.Errorf("runtime error: %v", err)
 		}
-		select {
-		case errCh <- err:
-		default:
-		}
+	}
+	select {
+	case errCh <- err:
+	default:
 	}
 }


### PR DESCRIPTION
1. fix goroutine leak when stop rule in `runTopo`
2. de-reference old Topo in order to release memory after stop/close rule
3. close channel to release memory after `removePub`