### PR TITLE
fix(functions): args validation of `date_calc`

### DIFF
--- a/internal/binder/function/funcs_datetime.go
+++ b/internal/binder/function/funcs_datetime.go
@@ -120,7 +120,7 @@ func registerDateTimeFunc() {
 				return ProduceErrInfo(0, "datetime")
 			}
 
-			if ast.IsStringArg(args[1]) {
+			if !ast.IsStringArg(args[1]) {
 				return ProduceErrInfo(1, "string")
 			}
 			return nil

--- a/internal/binder/function/funcs_obj.go
+++ b/internal/binder/function/funcs_obj.go
@@ -217,7 +217,7 @@ func registerObjectFunc() {
 				}
 				return res, true
 			default:
-				return fmt.Errorf("the augument should be slice or string"), false
+				return fmt.Errorf("the argument should be slice or string"), false
 			}
 			for k, v := range argMap {
 				if !sliceStringContains(eraseArray, k) {
@@ -261,7 +261,7 @@ func registerObjectFunc() {
 				}
 				return res, true
 			default:
-				return fmt.Errorf("the augument should be slice or string"), false
+				return fmt.Errorf("the argument should be slice or string"), false
 			}
 			for k, v := range argMap {
 				if sliceStringContains(pickArray, k) {


### PR DESCRIPTION
Fix args validation of `date_calc` and typo error in funcs_obj.go

Close https://github.com/lf-edge/ekuiper/issues/2568