### PR TITLE
fix(docs): correct typo

### DIFF
--- a/docs/zh_CN/guide/sources/builtin/neuron.md
+++ b/docs/zh_CN/guide/sources/builtin/neuron.md
@@ -17,7 +17,7 @@ eKuiper 的 Neuron 连接器可订阅本地 Neuron 实例的消息。需要注�
 
 eKuiper 连接器可以通过[环境变量](../../../configuration/configuration.md#environment-variable-syntax)、[REST API](../../../api/restapi/configKey.md) 或配置文件进行配置，本节将介绍配置文件的使用方法。
 
-Neuron 源连接器的配置文件位于：`$ekuiper/etc/mqtt_source.yaml`。
+Neuron 源连接器的配置文件位于：`$ekuiper/etc/sources/neuron.yaml`。
 
 ```yaml
 default:


### PR DESCRIPTION
Correct an error in the Chinese documentation describing the Neuron connector configuration.

Closes #2611 