### PR TITLE
fix(service): delete schemaless func

### DIFF
--- a/internal/service/manager.go
+++ b/internal/service/manager.go
@@ -193,6 +193,7 @@ func (m *Manager) initFile(baseName string) error {
 				}
 			}
 		} else {
+			info.Interfaces[name].Functions = []string{name}
 			err := m.functionKV.Set(name, &functionContainer{
 				FuncName:      name,
 				ServiceName:   serviceName,

--- a/internal/service/manager_test.go
+++ b/internal/service/manager_test.go
@@ -127,6 +127,9 @@ func TestInitByFiles(t *testing.T) {
 				Schema: &schemaInfo{
 					Schemaless: true,
 				},
+				Functions: []string{
+					"tsschemaless",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Fix delete schemaless service but the func are still listed problem. The root cause is that the schemaless func are not recorded in the service.