### PR TITLE
fix(topo): avoid wrong topo open state

### DIFF
--- a/internal/topo/topo.go
+++ b/internal/topo/topo.go
@@ -82,6 +82,7 @@ func (s *Topo) GetName() string {
 
 // Cancel may be called multiple times so must be idempotent
 func (s *Topo) Cancel() {
+	s.hasOpened.Store(false)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	// completion signal


### PR DESCRIPTION
Update open state when cancel
This leads to a problem in trial run because it