### PR TITLE
fix(planner): avoid create subtopo in error

### DIFF
--- a/internal/topo/node/conf/source.go
+++ b/internal/topo/node/conf/source.go
@@ -39,18 +39,20 @@ func GetSourceConf(sourceType string, options *ast.Options) map[string]interface
 		} else {
 			props = def
 		}
-		// config keys in etc folder will transform to lowercase
-		// while those in data will not
-		if c, ok := cfg[strings.ToLower(confkey)]; ok {
-			for k, v := range c {
-				props[k] = v
+		if confkey != "" {
+			// config keys in etc folder will transform to lowercase
+			// while those in data will not
+			if c, ok := cfg[strings.ToLower(confkey)]; ok {
+				for k, v := range c {
+					props[k] = v
+				}
+			} else if c, ok := cfg[confkey]; ok {
+				for k, v := range c {
+					props[k] = v
+				}
+			} else {
+				conf.Log.Warnf("fail to find config key %s for source %s", confkey, sourceType)
 			}
-		} else if c, ok := cfg[confkey]; ok {
-			for k, v := range c {
-				props[k] = v
-			}
-		} else {
-			conf.Log.Warnf("fail to find config key %s for source %s", confkey, sourceType)
 		}
 	}
 	f := options.FORMAT


### PR DESCRIPTION
If other source node has error, subtopo should not be created. For example, if decode validation fails with error, subtopo should not be created.