### PR TITLE
ci(lint): bump `golangci-lint-action` to v6

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version-file: 'go.mod'
 
       - name: Check licenses
         run: |
@@ -36,12 +36,12 @@ jobs:
       - check_licenses
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version-file: 'go.mod'
 
       - name: Install dependencies
         env:
@@ -50,27 +50,27 @@ jobs:
           sudo apt-get update && sudo apt-get install -y --no-install-recommends pkg-config libzmq3-dev
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           args: "--out-${NO_FUTURE}format line-number"
 
       - name: golangci-lint (extensions)
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           working-directory: extensions
           args: "--out-${NO_FUTURE}format line-number"
 
       - name: golangci-lint (tools/kubernetes)
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           working-directory: tools/kubernetes
           args: "--out-${NO_FUTURE}format line-number"
 
       - name: golangci-lint (sdk/go)
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           working-directory: sdk/go


### PR DESCRIPTION
This PR mainly updates `golangci-lint-action` to v6, and also automatically specifies the go version from `go.mod` for further convenience.