### PR TITLE
feat: support bump sql source conf

### DIFF
--- a/internal/conf/yaml_config_storage.go
+++ b/internal/conf/yaml_config_storage.go
@@ -228,3 +228,19 @@ func GetCfgFromKVStorage(typ string, plugin string, confKey string) (map[string]
 	}
 	return kvStorage.GetByPrefix(key)
 }
+
+// ClearKVStorage only used in unit test
+func ClearKVStorage() error {
+	kvStorage, err := getKVStorage()
+	if err != nil {
+		return err
+	}
+	km, err := kvStorage.GetByPrefix("")
+	if err != nil {
+		return err
+	}
+	for key := range km {
+		kvStorage.Delete(key)
+	}
+	return nil
+}

--- a/internal/server/bump/bump3.go
+++ b/internal/server/bump/bump3.go
@@ -15,6 +15,7 @@
 package bump
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/lf-edge/ekuiper/v2/internal/conf"
@@ -37,7 +38,8 @@ func rewriteSQLSourceConfiguration() error {
 			continue
 		}
 		data := rewriteCfg(cfg)
-		conf.WriteCfgIntoKVStorage("sources", "sql", key, data)
+		_, _, confKey, _ := extractKey(key)
+		conf.WriteCfgIntoKVStorage("sources", "sql", confKey, data)
 	}
 	return nil
 }
@@ -45,7 +47,7 @@ func rewriteSQLSourceConfiguration() error {
 func rewriteCfg(cfg *OriginSqlSourceCfg) map[string]interface{} {
 	m := make(map[string]interface{})
 	m["dburl"] = cfg.Url
-	m["interval"] = time.Duration(cfg.Internal).String()
+	m["interval"] = time.Duration(cfg.Interval).String()
 	if cfg.InternalSqlQueryCfg != nil {
 		icfg := cfg.InternalSqlQueryCfg
 		im := make(map[string]interface{})
@@ -73,7 +75,10 @@ func rewriteCfg(cfg *OriginSqlSourceCfg) map[string]interface{} {
 		}
 		m["templateSqlQueryCfg"] = tm
 	}
-	return m
+	bs, _ := json.Marshal(m)
+	newm := make(map[string]interface{})
+	json.Unmarshal(bs, &newm)
+	return newm
 }
 
 func extractIndexField(icfg *OriginInternalSqlQueryCfg) *store.IndexField {
@@ -116,9 +121,9 @@ func extractIndexField2(icfg *OriginTemplateSqlQueryCfg) *store.IndexField {
 
 type OriginSqlSourceCfg struct {
 	Url                 string                     `json:"url"`
-	Internal            cast.DurationConf          `json:"internal"`
-	InternalSqlQueryCfg *OriginInternalSqlQueryCfg `json:"internalSqlQueryCfg"`
-	TemplateSqlQueryCfg *OriginTemplateSqlQueryCfg `json:"templateSqlQueryCfg"`
+	Interval            cast.DurationConf          `json:"interval"`
+	InternalSqlQueryCfg *OriginInternalSqlQueryCfg `json:"internalSqlQueryCfg,omitempty"`
+	TemplateSqlQueryCfg *OriginTemplateSqlQueryCfg `json:"templateSqlQueryCfg,omitempty"`
 }
 
 type OriginInternalSqlQueryCfg struct {

--- a/internal/server/bump/bump3_test.go
+++ b/internal/server/bump/bump3_test.go
@@ -1,0 +1,202 @@
+// Copyright 2024 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bump
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/lf-edge/ekuiper/v2/internal/conf"
+	"github.com/lf-edge/ekuiper/v2/pkg/cast"
+	"github.com/lf-edge/ekuiper/v2/pkg/store"
+)
+
+func TestRewriteSQLConf(t *testing.T) {
+	testcases := []struct {
+		oldCfg   *OriginSqlSourceCfg
+		expected *TargetSqlSourceCfg
+	}{
+		{
+			oldCfg: &OriginSqlSourceCfg{
+				Url:      "123",
+				Interval: cast.DurationConf(10 * time.Second),
+			},
+			expected: &TargetSqlSourceCfg{
+				DbUrl:    "123",
+				Interval: cast.DurationConf(10 * time.Second),
+			},
+		},
+		{
+			oldCfg: &OriginSqlSourceCfg{
+				Url:      "123",
+				Interval: cast.DurationConf(10 * time.Second),
+				InternalSqlQueryCfg: &OriginInternalSqlQueryCfg{
+					Table:              "t",
+					Limit:              10,
+					IndexFieldName:     "a",
+					IndexFieldValue:    1,
+					IndexFieldDataType: "bigint",
+				},
+			},
+			expected: &TargetSqlSourceCfg{
+				DbUrl:    "123",
+				Interval: cast.DurationConf(10 * time.Second),
+				InternalSqlQueryCfg: &TargetInternalSqlQueryCfg{
+					Table: "t",
+					Limit: 10,
+					IndexFields: []*store.IndexField{
+						{
+							IndexFieldName:     "a",
+							IndexFieldValue:    float64(1),
+							IndexFieldDataType: "bigint",
+						},
+					},
+				},
+			},
+		},
+		{
+			oldCfg: &OriginSqlSourceCfg{
+				Url:      "123",
+				Interval: cast.DurationConf(10 * time.Second),
+				TemplateSqlQueryCfg: &OriginTemplateSqlQueryCfg{
+					TemplateSQL:        "select * from t",
+					IndexFieldName:     "a",
+					IndexFieldValue:    1,
+					IndexFieldDataType: "bigint",
+				},
+			},
+			expected: &TargetSqlSourceCfg{
+				DbUrl:    "123",
+				Interval: cast.DurationConf(10 * time.Second),
+				TemplateSqlQueryCfg: &TargetTemplateSqlQueryCfg{
+					TemplateSQL: "select * from t",
+					IndexFields: []*store.IndexField{
+						{
+							IndexFieldName:     "a",
+							IndexFieldValue:    float64(1),
+							IndexFieldDataType: "bigint",
+						},
+					},
+				},
+			},
+		},
+		{
+			oldCfg: &OriginSqlSourceCfg{
+				Url:      "123",
+				Interval: cast.DurationConf(10 * time.Second),
+				InternalSqlQueryCfg: &OriginInternalSqlQueryCfg{
+					Table:              "t",
+					Limit:              10,
+					IndexFieldName:     "a",
+					IndexFieldValue:    1,
+					IndexFieldDataType: "bigint",
+					IndexFields: []*store.IndexField{
+						{
+							IndexFieldName:     "b",
+							IndexFieldValue:    1,
+							IndexFieldDataType: "bigint",
+						},
+					},
+				},
+				TemplateSqlQueryCfg: &OriginTemplateSqlQueryCfg{
+					TemplateSQL:        "select * from t",
+					IndexFieldName:     "a",
+					IndexFieldValue:    1,
+					IndexFieldDataType: "bigint",
+					IndexFields: []*store.IndexField{
+						{
+							IndexFieldName:     "b",
+							IndexFieldValue:    1,
+							IndexFieldDataType: "bigint",
+						},
+					},
+				},
+			},
+			expected: &TargetSqlSourceCfg{
+				DbUrl:    "123",
+				Interval: cast.DurationConf(10 * time.Second),
+				InternalSqlQueryCfg: &TargetInternalSqlQueryCfg{
+					Table: "t",
+					Limit: 10,
+					IndexFields: []*store.IndexField{
+						{
+							IndexFieldName:     "b",
+							IndexFieldValue:    float64(1),
+							IndexFieldDataType: "bigint",
+						},
+						{
+							IndexFieldName:     "a",
+							IndexFieldValue:    float64(1),
+							IndexFieldDataType: "bigint",
+						},
+					},
+				},
+				TemplateSqlQueryCfg: &TargetTemplateSqlQueryCfg{
+					TemplateSQL: "select * from t",
+					IndexFields: []*store.IndexField{
+						{
+							IndexFieldName:     "b",
+							IndexFieldValue:    float64(1),
+							IndexFieldDataType: "bigint",
+						},
+						{
+							IndexFieldName:     "a",
+							IndexFieldValue:    float64(1),
+							IndexFieldDataType: "bigint",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for index, tc := range testcases {
+		require.NoError(t, conf.ClearKVStorage())
+		originData, err := json.Marshal(tc.oldCfg)
+		require.NoError(t, err)
+		m := make(map[string]interface{})
+		require.NoError(t, json.Unmarshal(originData, &m))
+		cfgKey := fmt.Sprintf("%v", index)
+		require.NoError(t, conf.WriteCfgIntoKVStorage("sources", "sql", cfgKey, m))
+		require.NoError(t, rewriteSQLSourceConfiguration())
+		gotm, err := conf.GetCfgFromKVStorage("sources", "sql", cfgKey)
+		require.NoError(t, err)
+		tcfg := &TargetSqlSourceCfg{}
+		cast.MapToStruct(gotm[fmt.Sprintf("sources.sql.%s", cfgKey)], tcfg)
+		require.Equal(t, tc.expected, tcfg)
+	}
+}
+
+type TargetSqlSourceCfg struct {
+	DbUrl               string                     `json:"dburl"`
+	Interval            cast.DurationConf          `json:"interval"`
+	InternalSqlQueryCfg *TargetInternalSqlQueryCfg `json:"internalSqlQueryCfg,omitempty"`
+	TemplateSqlQueryCfg *TargetTemplateSqlQueryCfg `json:"templateSqlQueryCfg,omitempty"`
+}
+
+type TargetInternalSqlQueryCfg struct {
+	Table       string              `json:"table"`
+	Limit       int                 `json:"limit"`
+	IndexFields []*store.IndexField `json:"indexFields"`
+}
+
+type TargetTemplateSqlQueryCfg struct {
+	TemplateSQL string              `json:"templateSql"`
+	IndexFields []*store.IndexField `json:"indexFields"`
+}

--- a/internal/server/bump/bump_manager.go
+++ b/internal/server/bump/bump_manager.go
@@ -30,7 +30,7 @@ import (
 	"github.com/lf-edge/ekuiper/v2/pkg/kv"
 )
 
-const currentVersion = 2
+const currentVersion = 3
 
 var GlobalBumpManager *BumpManager
 
@@ -79,6 +79,10 @@ func BumpToCurrentVersion(dataDir string) error {
 			}
 		case 2:
 			if err := bumpFrom1TO2(); err != nil {
+				return err
+			}
+		case 3:
+			if err := bumpFrom2TO3(); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
bump sql source configuration from :

```yaml
default:
  interval: 10000
  url: mysql://user:test@140.210.204.147/user?parseTime=true
  internalSqlQueryCfg:
    table: test
    limit: 1
    indexField: registerTime
    indexValue: "2022-04-21 10:23:55"
    indexFieldType: "DATETIME"
    dateTimeFormat: "YYYY-MM-dd HH:mm:ss"
  templateSqlQueryCfg:
    TemplateSql: "select * from table where entry_data > {{.entry_data}}"
    indexField: entry_data
    indexValue: "2022-04-13 06:22:32.233"
    indexFieldType: "DATETIME"
    dateTimeFormat: "YYYY-MM-dd HH:mm:ssSSS"
```

into

```yaml
default:
  interval: "10s"
  dburl: mysql://user:test@140.210.204.147/user?parseTime=true
  internalSqlQueryCfg:
    table: test
    limit: 1
    indexFields:
    - indexField: registerTime
      indexValue: "2022-04-21 10:23:55"
      indexFieldType: "DATETIME"
      dateTimeFormat: "YYYY-MM-dd HH:mm:ss"
  templateSqlQueryCfg:
    templateSql: "select * from table where entry_data > {{.entry_data}}"
    indexFields:
    - indexField: entry_data
      indexValue: "2022-04-13 06:22:32.233"
      indexFieldType: "DATETIME"
      dateTimeFormat: "YYYY-MM-dd HH:mm:ssSSS"
```