### PR TITLE
fix(valuer): nil handling

### DIFF
--- a/internal/topo/operator/filter_test.go
+++ b/internal/topo/operator/filter_test.go
@@ -54,12 +54,7 @@ func TestFilterPlan_Apply(t *testing.T) {
 					"a": int64(6),
 				},
 			},
-			result: &xsql.Tuple{
-				Emitter: "tbl",
-				Message: xsql.Message{
-					"a": int64(6),
-				},
-			},
+			result: nil,
 		},
 		{
 			sql: "SELECT * FROM tbl WHERE abc > def and abc <= ghi",

--- a/internal/topo/operator/join_test.go
+++ b/internal/topo/operator/join_test.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/lf-edge/ekuiper/internal/conf"
 	"github.com/lf-edge/ekuiper/internal/topo/context"
 	"github.com/lf-edge/ekuiper/internal/xsql"
@@ -433,13 +435,6 @@ func TestLeftJoinPlan_Apply(t *testing.T) {
 					{
 						Tuples: []xsql.Row{
 							&xsql.Tuple{Emitter: "src1", Message: xsql.Message{"id1": 1, "f2": "w1"}},
-							&xsql.Tuple{Emitter: "src2", Message: xsql.Message{"id2": 2, "f2": "w1"}},
-						},
-					},
-					{
-						Tuples: []xsql.Row{
-							&xsql.Tuple{Emitter: "src1", Message: xsql.Message{"id1": 1, "f2": "w1"}},
-							&xsql.Tuple{Emitter: "src2", Message: xsql.Message{"id2": 2, "f2": "w2"}},
 						},
 					},
 				},
@@ -762,7 +757,7 @@ func TestLeftJoinPlan_Apply(t *testing.T) {
 	fmt.Printf("The test bucket size is %d.\n\n", len(tests))
 	contextLogger := conf.Log.WithField("rule", "TestLeftJoinPlan_Apply")
 	ctx := context.WithValue(context.Background(), context.LoggerKey, contextLogger)
-	for i, tt := range tests {
+	for _, tt := range tests {
 		stmt, err := xsql.NewParser(strings.NewReader(tt.sql)).Parse()
 		if err != nil {
 			t.Errorf("statement parse error %s", err)
@@ -775,9 +770,7 @@ func TestLeftJoinPlan_Apply(t *testing.T) {
 			fv, afv := xsql.NewFunctionValuersForOp(nil)
 			pp := &JoinOp{Joins: stmt.Joins, From: table}
 			result := pp.Apply(ctx, tt.data, fv, afv)
-			if !reflect.DeepEqual(tt.result, result) {
-				t.Errorf("%d. %q\n\nresult mismatch:\n\nexp=%#v\n\ngot=%#v\n\n", i, tt.sql, tt.result, result)
-			}
+			assert.Equal(t, tt.result, result)
 		}
 	}
 }

--- a/internal/xsql/valuer_test.go
+++ b/internal/xsql/valuer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 EMQ Technologies Co., Ltd.
+// Copyright 2021-2024 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -128,7 +128,7 @@ func TestComparison(t *testing.T) {
 			},
 			r: []interface{}{
 				false, false, false,
-				true, false, true, false, false, true,
+				false, false, false, false, false, false,
 			},
 		}, { // 11
 			m: map[string]interface{}{
@@ -137,7 +137,7 @@ func TestComparison(t *testing.T) {
 			},
 			r: []interface{}{
 				false, true, errors.New("invalid operation int64(12) = string(string literal)"),
-				false, false, false, true, false, true,
+				false, false, false, false, false, false,
 			},
 		}, { // 12
 			m: map[string]interface{}{

--- a/pkg/ast/token.go
+++ b/pkg/ast/token.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 EMQ Technologies Co., Ltd.
+// Copyright 2021-2024 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ const (
 	BADSTRING   // "abc
 
 	operatorBeg
-	// ADD and the following are InfluxQL Operators
+	// ADD and the following
 	ADD         // +
 	SUB         // -
 	MUL         // *


### PR DESCRIPTION
- For binary comparison, null value always return false
- In/NotIn should always return bool (or error)