### PR TITLE
fix(file): scanner dynamic buffer

### DIFF
--- a/internal/io/file/reader/csv.go
+++ b/internal/io/file/reader/csv.go
@@ -60,7 +60,7 @@ func (r *CsvReader) Provision(ctx api.StreamContext, props map[string]any) error
 	return nil
 }
 
-func (r *CsvReader) Bind(ctx api.StreamContext, fileStream io.Reader) error {
+func (r *CsvReader) Bind(ctx api.StreamContext, fileStream io.Reader, _ int) error {
 	cr := csv.NewReader(fileStream)
 	cr.Comma = rune(r.config.Delimiter[0])
 	cr.TrimLeadingSpace = true

--- a/internal/io/file/source_test.go
+++ b/internal/io/file/source_test.go
@@ -184,7 +184,7 @@ func TestSourceProvision(t *testing.T) {
 			},
 		},
 		{
-			name: "no decompression for stream typs",
+			name: "no decompression for stream types",
 			props: map[string]any{
 				"datasource":    name,
 				"path":          path,

--- a/pkg/modules/file.go
+++ b/pkg/modules/file.go
@@ -47,7 +47,7 @@ type FileStreamReader interface {
 	// Provision Set up the static properties
 	Provision(ctx api.StreamContext, props map[string]any) error
 	// Bind set the file stream. Make sure the previous read has done
-	Bind(ctx api.StreamContext, fileStream io.Reader) error
+	Bind(ctx api.StreamContext, fileStream io.Reader, maxSize int) error
 	// Read the next record. Returns EOF when the input has reached its end.
 	Read(ctx api.StreamContext) (any, error)
 	// IsBytesReader If is bytes reader, Read must return []byte, otherwise return map or []map


### PR DESCRIPTION
Currently, if line is big, the lines scanner exit silently