### PR TITLE
feat(planner): set default payload format

### DIFF
--- a/internal/topo/planner/planner_source.go
+++ b/internal/topo/planner/planner_source.go
@@ -225,8 +225,13 @@ func checkFeatures(ss api.Source, sp *SourcePropsForSplit, props map[string]any)
 	if sp.Merger != "" && sp.MergeField != "" {
 		return traits{}, fmt.Errorf("mergeField and merger cannot set together")
 	}
-	if sp.Merger != "" && (sp.Format == "" || sp.PayloadFormat == "") {
-		return traits{}, fmt.Errorf("merger must work with both format and payloadFormat")
+	// Let merger payload format defaults to format
+	if sp.Merger != "" && sp.PayloadFormat == "" {
+		sp.PayloadFormat = sp.Format
+		if sp.PayloadFormat == "" {
+			sp.PayloadFormat = "json"
+		}
+		props["payloadFormat"] = sp.PayloadFormat
 	}
 
 	info := checkByteSource(ss)
@@ -271,6 +276,10 @@ func checkFeatures(ss api.Source, sp *SourcePropsForSplit, props map[string]any)
 		r.needDecode = false
 		props["payloadBatchField"] = "frames"
 		props["payloadField"] = "data"
+		if _, ok := props["payloadSchemaId"]; !ok {
+			props["payloadSchemaId"] = props["schemaId"]
+			props["payloadDelimiter"] = props["delimiter"]
+		}
 	}
 	return r, nil
 }

--- a/internal/topo/planner/planner_source_test.go
+++ b/internal/topo/planner/planner_source_test.go
@@ -94,7 +94,6 @@ func TestPlanTopo(t *testing.T) {
 				"connectionSelector": "mqtt.localConnection",
 				"interval":           "1s",
 				"merger":             "mock",
-				"payloadFormat":      "json",
 			},
 			p: "mqtt",
 			k: "testSelMerger",
@@ -490,11 +489,6 @@ func TestPlanError(t *testing.T) {
 			name: "mergeField and merger mutual exclusive",
 			sql:  `SELECT * FROM src1`,
 			e:    "mergeField and merger cannot set together",
-		},
-		{
-			name: "merger need decoder",
-			sql:  `SELECT * FROM src2`,
-			e:    "merger must work with both format and payloadFormat",
 		},
 		{
 			name: "merger need rate limit",


### PR DESCRIPTION
- If merger does not set payload format, use the message format and schema