### PR TITLE
feat: prometheus view rule cpu usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/PaesslerAG/gval v1.2.2
 	github.com/PaesslerAG/jsonpath v0.1.1
-	github.com/Rookiecom/cpuprofile v1.0.2
+	github.com/Rookiecom/cpuprofile v1.0.4
 	github.com/alicebob/miniredis/v2 v2.30.0
 	github.com/apple/foundationdb/bindings/go v0.0.0-20240315202255-8943393e84fc
 	github.com/benbjohnson/clock v1.3.5

--- a/go.sum
+++ b/go.sum
@@ -281,8 +281,8 @@ github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV
 github.com/PaesslerAG/jsonpath v0.1.1 h1:c1/AToHQMVsduPAa4Vh6xp2U0evy4t8SWp8imEsylIk=
 github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
-github.com/Rookiecom/cpuprofile v1.0.2 h1:wXGOmpSyCfoi7D0OB79srblNSw5Ccn0fTy4c537yWy4=
-github.com/Rookiecom/cpuprofile v1.0.2/go.mod h1:JEBcjNHceN6/g4ppueDEqWlbtbMGMyLy0YlT8QnKFbE=
+github.com/Rookiecom/cpuprofile v1.0.4 h1:F2eQVuVlHE5XnpNbAk9oBD9vdHbBusaAaAsbu23OGco=
+github.com/Rookiecom/cpuprofile v1.0.4/go.mod h1:JEBcjNHceN6/g4ppueDEqWlbtbMGMyLy0YlT8QnKFbE=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=

--- a/internal/server/promMetrics/core_metrics.go
+++ b/internal/server/promMetrics/core_metrics.go
@@ -23,3 +23,5 @@ func SetRuleStatusCountGauge(isRunning bool, count int) {}
 func SetRuleStatus(ruleID string, value int) {}
 
 func RemoveRuleStatus(ruleID string) {}
+
+func SetRuleCPUUsageGauge(ruleID string, value int) {}

--- a/internal/server/promMetrics/prom_metrcis.go
+++ b/internal/server/promMetrics/prom_metrcis.go
@@ -29,6 +29,7 @@ const (
 var (
 	RuleStatusCountGauge *prometheus.GaugeVec
 	RuleStatusGauge      *prometheus.GaugeVec
+	RuleCPUUsageGauge    *prometheus.GaugeVec
 )
 
 func InitServerMetrics() {
@@ -45,12 +46,20 @@ func InitServerMetrics() {
 		Name:      "status",
 		Help:      "gauge of rule status",
 	}, []string{LblRuleIDType})
+
+	RuleCPUUsageGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "kuiper",
+		Subsystem: "rule",
+		Name:      "cpuUsage",
+		Help:      "gauge of rule CPU usage",
+	}, []string{LblRuleIDType})
 }
 
 func RegisterMetrics() {
 	InitServerMetrics()
 	prometheus.MustRegister(RuleStatusCountGauge)
 	prometheus.MustRegister(RuleStatusGauge)
+	prometheus.MustRegister(RuleCPUUsageGauge)
 }
 
 func SetRuleStatusCountGauge(isRunning bool, count int) {
@@ -68,4 +77,8 @@ func SetRuleStatus(ruleID string, value int) {
 
 func RemoveRuleStatus(ruleID string) {
 	RuleStatusGauge.DeleteLabelValues(ruleID)
+}
+
+func SetRuleCPUUsageGauge(ruleID string, value int) {
+	RuleCPUUsageGauge.WithLabelValues(ruleID).Set(float64(value))
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -140,7 +140,8 @@ func StartUp(Version string) {
 
 	serverCtx, serverCancel := context.WithCancel(context.Background())
 	if conf.Config.Basic.EnableResourceProfiling {
-		startCPUProfiling(serverCtx)
+		err := StartCPUProfiling(serverCtx, &ekuiperProfile{})
+		conf.Log.Warn(err)
 	}
 
 	undo, _ := maxprocs.Set(maxprocs.Logger(conf.Log.Infof))


### PR DESCRIPTION
By introducing the feature of observing cpu usage in a specified time window provided by the cpuprofile library, we can now observe the cpu usage of each rule of ekuiper through prometheus.

To use this feature, you need to set prometheus and enableResourceProfiling in the configuration file to true.

Then, run ekuiper and use [test tool](https://github.com/Yisaer/kuiper-nexmark-test) as shown below:

![image](https://github.com/user-attachments/assets/4ddaebb0-75d6-471f-97f0-5d0e973ea56e)

You can observe rule cpu usge in prometheus as shown below:

<img width="2552" alt="image" src="https://github.com/user-attachments/assets/5c7c2691-69ac-4567-98c7-1ab0d45fe488">

