### PR TITLE
fix(import): print static error message

### DIFF
--- a/fvt/import_test.go
+++ b/fvt/import_test.go
@@ -52,4 +52,16 @@ func (s *ImportTestSuite) TestImportError() {
 
 		s.Require().Equal(exp, result)
 	})
+
+	s.Run("full import wrong json", func() {
+		wrongContent := `{"content":"{\"streams\": {\"demo\": \"CREATE STwREAM demo () WITH (DATASOURCE=\\\"users\\\", CONF_KEY=\\\"td\\\",TYPE=\\\"none\\\", FORMAT=\\\"JSO"}`
+		resp, err := client.Post("data/import", wrongContent)
+		s.Require().NoError(err)
+		s.Require().Equal(400, resp.StatusCode)
+		result, err := GetResponseText(resp)
+		s.Require().NoError(err)
+		exp := "{\"error\":1000,\"message\":\"configuration unmarshal with error unexpected end of JSON input\"}\n"
+
+		s.Require().Equal(exp, result)
+	})
 }

--- a/internal/server/import_export.go
+++ b/internal/server/import_export.go
@@ -54,6 +54,8 @@ func InitConfManagers() {
 	}
 }
 
+const ProcessErr = "process error"
+
 type Configuration struct {
 	Streams          map[string]string `json:"streams"`
 	Tables           map[string]string `json:"tables"`
@@ -271,7 +273,7 @@ func configurationImport(ctx context.Context, data []byte, reboot bool) ImportCo
 	if reflect.DeepEqual(ResponseNil, configResponse) {
 		importStatus.ConfigResponse = ResponseNil
 	} else {
-		importStatus.ErrorMsg = "process error"
+		importStatus.ErrorMsg = ProcessErr
 		importStatus.ConfigResponse = configResponse
 	}
 
@@ -375,7 +377,8 @@ func configurationPartialImport(ctx context.Context, data []byte) ImportConfigur
 	if reflect.DeepEqual(ResponseNil, configResponse) {
 		importStatus.ConfigResponse = ResponseNil
 	} else {
-		importStatus.ErrorMsg = "process error"
+
+		importStatus.ErrorMsg = ProcessErr
 		importStatus.ConfigResponse = configResponse
 	}
 
@@ -400,7 +403,7 @@ func configurationImportHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	result, err := handleConfigurationImport(context.Background(), rsi, partial, stop)
 	if err != nil {
-		if result != nil {
+		if result != nil && err.Error() == ProcessErr {
 			errStr, _ := json.Marshal(result.ConfigResponse)
 			err = errors.New(string(errStr))
 		}


### PR DESCRIPTION
Currently, only return import runtime error message