### PR TITLE
fix(trial): do not close control ws

### DIFF
--- a/internal/io/simulator/simulator.go
+++ b/internal/io/simulator/simulator.go
@@ -43,6 +43,8 @@ func (s *SimulatorSource) Provision(ctx api.StreamContext, configs map[string]an
 }
 
 func (s *SimulatorSource) Close(ctx api.StreamContext) error {
+	// Allow to reset in close rule trial run
+	s.index = 0
 	return nil
 }
 

--- a/internal/trial/manager.go
+++ b/internal/trial/manager.go
@@ -1,10 +1,10 @@
-// Copyright 2023 EMQ Technologies Co., Ltd.
+// Copyright 2023-2024 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,8 +20,9 @@ import (
 	"sync"
 
 	"github.com/lf-edge/ekuiper/v2/internal/conf"
-	"github.com/lf-edge/ekuiper/v2/internal/io/http/httpserver"
 	"github.com/lf-edge/ekuiper/v2/internal/topo"
+	"github.com/lf-edge/ekuiper/v2/internal/topo/context"
+	"github.com/lf-edge/ekuiper/v2/pkg/connection"
 )
 
 // TrialManager Manager Initialized in the binder
@@ -71,7 +72,7 @@ func (m *Manager) StopRule(ruleId string) {
 	if r, ok := m.runs[ruleId]; ok {
 		r.topo.Cancel()
 		delete(m.runs, ruleId)
-		httpserver.UnRegisterWebSocketEndpoint(r.def.endpoint)
+		_ = connection.DetachConnection(context.Background(), r.def.endpoint)
 	} else {
 		conf.Log.Warnf("try to stop test rule %s but it is not found", ruleId)
 	}
@@ -81,7 +82,7 @@ func (m *Manager) StartRule(ruleId string) error {
 	m.RLock()
 	defer m.RUnlock()
 	if r, ok := m.runs[ruleId]; ok {
-		trialRun(r.topo)
+		trialRun(r.topo, r.def.endpoint)
 	} else {
 		return fmt.Errorf("try to start test rule %s but it is not found", ruleId)
 	}

--- a/internal/trial/manager_test.go
+++ b/internal/trial/manager_test.go
@@ -45,7 +45,7 @@ func TestTrialRule(t *testing.T) {
 	p := processor.NewStreamProcessor()
 	p.ExecStmt("DROP STREAM demo876")
 	// Test 1 wrong rule
-	mockDef1 := `{"id":"rule876","sql":"select * from demo876","mockSource":{"demo876":{"data":[{"name":"demo876","value":1}],"interval":100,"loop":true}},"sinkProps":{"sendSingle":true}}`
+	mockDef1 := `{"id":"rule876","sql":"select * from demo876","mockSource":{"demo876":{"data":[{"name":"demo876","value":1}],"interval":100,"loop":false}},"sinkProps":{"sendSingle":true}}`
 	_, err = TrialManager.CreateRule(mockDef1)
 	require.Error(t, err)
 	require.Equal(t, "fail to run rule rule876: fail to get stream demo876, please check if stream is created", err.Error())


### PR DESCRIPTION
The control websocket is closed immediately once rule ends. This has problem if simulator has EOF

1. The mirror websocket is not created by pool. The rule stop can close the mirror control ws.
2. EOF will stop the rule immediately before user click stop. In trial run, EOF will not close mirror ws immediately to wait for user click.