### PR TITLE
Fix code scanning alert no. 107: Database query built from user-controlled sources

### DIFF
--- a/internal/pkg/store/sql/sqlTs.go
+++ b/internal/pkg/store/sql/sqlTs.go
@@ -30,18 +30,21 @@ type ts struct {
 }
 
 func createSqlTs(database Database, table string) (*ts, error) {
+	if !isValidTableName(table) {
+		return nil, fmt.Errorf("invalid table name: %s", table)
+	}
 	store := &ts{
 		database: database,
 		table:    table,
 		last:     getLast(database, table),
 	}
 	err := store.database.Apply(func(db *sql.DB) error {
-		query := fmt.Sprintf("CREATE TABLE IF NOT EXISTS '%s'('key' INTEGER PRIMARY KEY, 'val' BLOB);", table)
+		query := "CREATE TABLE IF NOT EXISTS ? ('key' INTEGER PRIMARY KEY, 'val' BLOB);"
 		stmt, err := db.Prepare(query)
 		if err != nil {
 			return err
 		}
-		_, err = stmt.Exec(query)
+		_, err = stmt.Exec(table)
 		return err
 	})
 	if err != nil {
@@ -131,12 +134,12 @@ func (t ts) Delete(key int64) error {
 
 func (t ts) DeleteBefore(key int64) error {
 	return t.database.Apply(func(db *sql.DB) error {
-		query := fmt.Sprintf("DELETE FROM %s WHERE key<?;", t.table)
+		query := "DELETE FROM ? WHERE key<?;"
 		stmt, err := db.Prepare(query)
 		if err != nil {
 			return err
 		}
-		_, err = stmt.Exec(key)
+		_, err = stmt.Exec(t.table, key)
 		return err
 	})
 }
@@ -147,8 +150,8 @@ func (t ts) Close() error {
 
 func (t ts) Drop() error {
 	return t.database.Apply(func(db *sql.DB) error {
-		query := fmt.Sprintf("Drop table %s;", t.table)
-		_, err := db.Exec(query)
+		query := "Drop table ?;"
+		_, err := db.Exec(query, t.table)
 		return err
 	})
 }
@@ -156,12 +159,12 @@ func (t ts) Drop() error {
 func getLast(d Database, table string) int64 {
 	var last int64 = 0
 	_ = d.Apply(func(db *sql.DB) error {
-		query := fmt.Sprintf("SELECT key FROM %s Order by key DESC Limit 1;", table)
+		query := "SELECT key FROM ? Order by key DESC Limit 1;"
 		stmt, err := db.Prepare(query)
 		if err != nil {
 			return err
 		}
-		row := stmt.QueryRow(query)
+		row := stmt.QueryRow(table)
 		return row.Scan(&last)
 	})
 	return last


### PR DESCRIPTION
Fixes [https://github.com/lf-edge/ekuiper/security/code-scanning/107](https://github.com/lf-edge/ekuiper/security/code-scanning/107)

To fix the problem, we should use parameterized queries or prepared statements instead of constructing SQL queries using `fmt.Sprintf`. This approach ensures that user input is properly escaped and prevents SQL injection attacks.

1. Replace the `fmt.Sprintf` calls with parameterized queries.
2. Use the `?` placeholder for the table name and pass the table name as a parameter to the query execution function.
3. Ensure that the table name is validated to contain only safe characters (e.g., alphanumeric and underscores) before using it in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
