### PR TITLE
chore: enable x509negativeserial

### DIFF
--- a/cmd/kuiperd/main.go
+++ b/cmd/kuiperd/main.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:debug x509negativeserial=1
 package main
 
 import "github.com/lf-edge/ekuiper/v2/cmd"


### PR DESCRIPTION
Because MSSQL driver is not compatible with go 1.23, need to enable this param