### PR TITLE
build: Dockerfile-alpine-python and Makefile build

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -113,6 +113,7 @@ jobs:
             suffix:
             - ""
             - "-alpine"
+            - "-alpine-python"
             - "-dev"
             - "-slim"
             - "-slim-python"

--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,7 @@ docker:
 	docker buildx build --no-cache --platform=linux/amd64 -t $(TARGET):$(VERSION)-slim -f deploy/docker/Dockerfile-slim . --load
 	docker buildx build --no-cache --platform=linux/amd64 -t $(TARGET):$(VERSION)-full -f deploy/docker/Dockerfile-full . --load
 	docker buildx build --no-cache --platform=linux/amd64 -t $(TARGET):$(VERSION)-dev -f deploy/docker/Dockerfile-dev . --load
+	docker buildx build --no-cache --platform=linux/amd64 -t $(TARGET):$(VERSION)-alpine-python -f deploy/docker/Dockerfile-alpine-python . --load
 
 PLUGINS := sinks/influx \
 	sinks/influx2 \

--- a/deploy/docker/Dockerfile-alpine-python
+++ b/deploy/docker/Dockerfile-alpine-python
@@ -21,7 +21,7 @@ WORKDIR /go/kuiper
 
 RUN make build_with_edgex
 
-FROM python:3.12.7-alpine3.20
+FROM python:3.12-alpine
 
 # Set environment vars
 ENV MAINTAINER="emqx.io" \

--- a/deploy/docker/Dockerfile-alpine-python
+++ b/deploy/docker/Dockerfile-alpine-python
@@ -1,0 +1,54 @@
+# Copyright 2021-2023 EMQ Technologies Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG GO_VERSION=1.23.1
+FROM ghcr.io/lf-edge/ekuiper/base:$GO_VERSION-alpine AS builder
+
+COPY . /go/kuiper
+
+WORKDIR /go/kuiper
+
+RUN make build_with_edgex
+
+FROM python:3.12.7-alpine3.20
+
+# Set environment vars
+ENV MAINTAINER="emqx.io" \
+    KUIPER_HOME="/kuiper" \
+    KUIPER__BASIC__CONSOLELOG=true
+
+# These vars are not persisted in the final image layer
+ARG KUIPER_USER="kuiper"
+ARG KUIPER_USER_ID="1001"
+
+WORKDIR ${KUIPER_HOME}
+
+# Set appropriate ownership to allow binary full access to KUIPER_HOME dir
+RUN adduser -DH -s /sbin/nologin -u ${KUIPER_USER_ID} ${KUIPER_USER} && \
+    chown -Rh ${KUIPER_USER}:${KUIPER_USER} ${KUIPER_HOME} && \
+    mkdir -p /usr/local/taos && \
+    chown -Rh ${KUIPER_USER}:${KUIPER_USER} /usr/local/taos
+
+# Run the kuiper process under the kuiper user
+USER ${KUIPER_USER}
+
+COPY --chown=${KUIPER_USER}:${KUIPER_USER} ./deploy/docker/docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
+COPY --chown=${KUIPER_USER}:${KUIPER_USER} --from=builder /go/kuiper/_build/kuiper-* /kuiper/
+
+VOLUME ["${KUIPER_HOME}/etc", "${KUIPER_HOME}/data", "${KUIPER_HOME}/plugins", "${KUIPER_HOME}/log"]
+EXPOSE 9081 20498
+
+ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
+
+CMD ["./bin/kuiperd"]


### PR DESCRIPTION
**Motivation:**
When running Edgex in secure mode it uses securitty-bootstrapper which has been compiled in Alpine Linux. 
Thus, using any other docker image than ekuiper-alpine fails because it cannot run the aforementioned binary.

**Suggested solution:**
Make a eKuiper python Alpine based docker image to be able to use python based plugins

**Tests:**
Tested and running successfully using ekuiper v1.14.4