### PR TITLE
fix: arbitrary file access

### DIFF
--- a/internal/pkg/filex/zip.go
+++ b/internal/pkg/filex/zip.go
@@ -21,11 +21,15 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pingcap/failpoint"
 )
 
 func UnzipTo(f *zip.File, fpath string) (err error) {
+	if strings.Contains(fpath, "..") {
+		return fmt.Errorf("invalid file path: %s", fpath)
+	}
 	defer func() {
 		failpoint.Inject("UnzipToErr", func() {
 			err = errors.New("UnzipToErr")

--- a/internal/plugin/native/manager.go
+++ b/internal/plugin/native/manager.go
@@ -510,6 +510,9 @@ func (rr *Manager) install(t plugin2.PluginType, name, src string, shellParas []
 	for _, file := range r.File {
 		zipFiles = append(zipFiles, file.Name)
 		fileName := file.Name
+		if strings.Contains(fileName, "..") {
+			return version, fmt.Errorf("invalid file path: %s", fileName)
+		}
 		switch {
 		case yamlFile == fileName:
 			yamlFileChecked = true

--- a/internal/plugin/portable/manager.go
+++ b/internal/plugin/portable/manager.go
@@ -346,6 +346,9 @@ func (m *Manager) install(name, src string, shellParas []string) (resultErr erro
 	target := ""
 	for _, file := range r.File {
 		fileName := file.Name
+		if strings.Contains(fileName, "..") {
+			return fmt.Errorf("invalid file path: %s", fileName)
+		}
 		if strings.HasPrefix(fileName, "sources/") || strings.HasPrefix(fileName, "sinks/") || strings.HasPrefix(fileName, "functions/") {
 			target = path.Join(m.pluginConfDir, fileName)
 		} else {

--- a/internal/service/manager.go
+++ b/internal/service/manager.go
@@ -452,7 +452,12 @@ func (m *Manager) unzip(name, src string) error {
 	}
 	// unzip
 	for _, file := range r.File {
-		err := filex.UnzipTo(file, path.Join(m.etcDir, file.Name))
+		// Validate the file path to prevent directory traversal
+		fpath := path.Join(m.etcDir, file.Name)
+		if !strings.HasPrefix(filepath.Clean(fpath), filepath.Clean(m.etcDir)) {
+			return fmt.Errorf("invalid file path: %s", fpath)
+		}
+		err := filex.UnzipTo(file, fpath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes [https://github.com/lf-edge/ekuiper/security/code-scanning/59](https://github.com/lf-edge/ekuiper/security/code-scanning/59)

To fix the problem, we need to ensure that the file paths extracted from the zip archive do not contain any directory traversal sequences like `..`. This can be achieved by validating the file paths before using them. Specifically, we should check that the file paths are within the intended directory and do not contain any `..` sequences.

1. Modify the `unzip` method in `internal/service/manager.go` to validate the file paths.
2. Ensure that the `filex.UnzipTo` function in `internal/pkg/filex/zip.go` is only called with validated paths.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
