### PR TITLE
feat: support trace strategy

### DIFF
--- a/docs/en_US/api/restapi/trace.md
+++ b/docs/en_US/api/restapi/trace.md
@@ -4,8 +4,14 @@ eKuiper supports viewing recent tracing data of rules through API.
 
 ## Start trace the data of specific rule
 
+Turn on the data tracing of the rules. The strategy supports `always` and `head`. `always` means that each message is always traced, and `head` means that only upstream messages containing trace context will be traced.
+
 ```shell
 POST http://localhost:9081/rule/{ruleID}/trace/start
+
+{
+    "strategy": "head"
+}
 ```
 
 ## Stop trace the data of specific rule

--- a/docs/zh_CN/api/restapi/trace.md
+++ b/docs/zh_CN/api/restapi/trace.md
@@ -4,8 +4,14 @@ eKuiper 支持通过 API 查看规则最近的追踪数据。
 
 ## 开启特定规则的数据追踪
 
+开启规则的数据追踪，strategy 支持 `always` 与 `head`. `always` 代表总是对每条消息进行追踪，`head` 代表只有上游消息含有 trace context 才会进行追踪。
+
 ```shell
 POST http://localhost:9081/rule/{ruleID}/trace/start
+
+{
+    "strategy": "head"
+}
 ```
 
 ## 关闭特定规则的数据追踪

--- a/internal/io/mqtt/source.go
+++ b/internal/io/mqtt/source.go
@@ -121,7 +121,7 @@ func (ms *SourceConnector) onMessage(ctx api.StreamContext, msg pahoMqtt.Message
 		ms.eof(ctx)
 		return
 	}
-	traced, spanCtx, span := tracenode.StartTrace(ctx, ctx.GetOpId())
+	traced, spanCtx, span := tracenode.StartTraceBackground(ctx, ctx.GetOpId())
 	meta := map[string]interface{}{
 		"topic":     msg.Topic(),
 		"qos":       msg.Qos(),

--- a/internal/io/neuron/sink.go
+++ b/internal/io/neuron/sink.go
@@ -23,12 +23,11 @@ import (
 
 	"github.com/lf-edge/ekuiper/v2/internal/conf"
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/util"
-	"github.com/lf-edge/ekuiper/v2/internal/xsql"
+	"github.com/lf-edge/ekuiper/v2/internal/topo/node/tracenode"
 	"github.com/lf-edge/ekuiper/v2/pkg/cast"
 	"github.com/lf-edge/ekuiper/v2/pkg/connection"
 	"github.com/lf-edge/ekuiper/v2/pkg/errorx"
 	"github.com/lf-edge/ekuiper/v2/pkg/nng"
-	"github.com/lf-edge/ekuiper/v2/pkg/tracer"
 )
 
 type c struct {
@@ -216,8 +215,9 @@ func doPublish(ctx api.StreamContext, cli *nng.Sock, tuple api.MessageTuple, t *
 }
 
 func extractSpanContextIntoData(ctx api.StreamContext, data interface{}, sendBytes []byte) []byte {
-	if tracerCtx, ok := data.(xsql.HasTracerCtx); ok && ctx.IsTraceEnabled() {
-		_, span := tracer.GetTracer().Start(tracerCtx.GetTracerCtx(), ctx.GetOpId())
+	traced, _, span := tracenode.TraceInput(ctx, data, ctx.GetOpId())
+	if traced {
+		defer span.End()
 		traceID := span.SpanContext().TraceID()
 		spanID := span.SpanContext().SpanID()
 		defer span.End()

--- a/internal/io/neuron/sink.go
+++ b/internal/io/neuron/sink.go
@@ -220,7 +220,6 @@ func extractSpanContextIntoData(ctx api.StreamContext, data interface{}, sendByt
 		defer span.End()
 		traceID := span.SpanContext().TraceID()
 		spanID := span.SpanContext().SpanID()
-		defer span.End()
 		r := NeuronTraceHeader
 		r = append(r, traceID[:]...)
 		r = append(r, spanID[:]...)

--- a/internal/io/neuron/source.go
+++ b/internal/io/neuron/source.go
@@ -145,7 +145,7 @@ func extractTraceMeta(ctx api.StreamContext, data []byte) ([]byte, map[string]in
 		spanID := data[NeuronTraceSpanIDStartIndex:NeuronTraceSpanIDEndIndex]
 		traced, tracerCtx, span = tracenode.StartTraceByID(ctx, [16]byte(traceID), [8]byte(spanID))
 	} else {
-		traced, tracerCtx, span = tracenode.StartTrace(ctx, ctx.GetOpId())
+		traced, tracerCtx, span = tracenode.StartTraceBackground(ctx, ctx.GetOpId())
 	}
 	if traced {
 		meta["traceId"] = span.SpanContext().TraceID().String()

--- a/internal/server/rest.go
+++ b/internal/server/rest.go
@@ -41,6 +41,7 @@ import (
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/store"
 	"github.com/lf-edge/ekuiper/v2/internal/processor"
 	"github.com/lf-edge/ekuiper/v2/internal/server/middleware"
+	kctx "github.com/lf-edge/ekuiper/v2/internal/topo/context"
 	"github.com/lf-edge/ekuiper/v2/internal/topo/planner"
 	"github.com/lf-edge/ekuiper/v2/internal/trial"
 	"github.com/lf-edge/ekuiper/v2/pkg/ast"
@@ -822,12 +823,21 @@ func restartRuleHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Rule %s was restarted", name)
 }
 
+type EnableRuleTraceRequest struct {
+	Strategy string `json:"strategy"`
+}
+
 func enableRuleTraceHandler(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 	vars := mux.Vars(r)
 	name := vars["name"]
-
-	err := setIsRuleTraceEnabledHandler(name, true)
+	req := &EnableRuleTraceRequest{}
+	err := json.NewDecoder(r.Body).Decode(req)
+	if err != nil {
+		handleError(w, err, "Invalid body: Error decoding json", logger)
+		return
+	}
+	err = setIsRuleTraceEnabledHandler(name, true, kctx.StringToStrategy(req.Strategy))
 	if err != nil {
 		handleError(w, err, "", logger)
 		return
@@ -840,7 +850,7 @@ func disableRuleTraceHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name := vars["name"]
 
-	err := setIsRuleTraceEnabledHandler(name, false)
+	err := setIsRuleTraceEnabledHandler(name, false, kctx.AlwaysTraceStrategy)
 	if err != nil {
 		handleError(w, err, "", logger)
 		return
@@ -848,12 +858,12 @@ func disableRuleTraceHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func setIsRuleTraceEnabledHandler(name string, isEnabled bool) error {
+func setIsRuleTraceEnabledHandler(name string, isEnabled bool, stra kctx.TraceStrategy) error {
 	rs, ok := registry.load(name)
 	if !ok {
 		return fmt.Errorf("rule %s isn't existed", name)
 	}
-	return rs.SetIsTraceEnabled(isEnabled)
+	return rs.SetIsTraceEnabled(isEnabled, stra)
 }
 
 // get topo of a rule

--- a/internal/server/rule_init.go
+++ b/internal/server/rule_init.go
@@ -262,16 +262,18 @@ func StartCPUProfiling(ctx context.Context, cpuProfile Profiler) error {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				data := cpuProfile.GetWindowData()
-				if data == nil {
-					continue
-				}
-				ruleUsage, ok := data["rule"]
-				if !ok {
-					continue
-				}
-				for labelValue, t := range ruleUsage.Stats {
-					promMetrics.SetRuleCPUUsageGauge(labelValue, t)
+				if conf.Config.Basic.Prometheus {
+					data := cpuProfile.GetWindowData()
+					if data == nil {
+						continue
+					}
+					ruleUsage, ok := data["rule"]
+					if !ok {
+						continue
+					}
+					for labelValue, t := range ruleUsage.Stats {
+						promMetrics.SetRuleCPUUsageGauge(labelValue, t)
+					}
 				}
 			}
 		}

--- a/internal/server/tracer_test.go
+++ b/internal/server/tracer_test.go
@@ -38,7 +38,11 @@ func (suite *RestTestSuite) TestTraceRule() {
 	suite.r.ServeHTTP(w2, req2)
 	require.Equal(suite.T(), http.StatusCreated, w2.Code)
 
-	req2, _ = http.NewRequest(http.MethodPost, "http://localhost:8080/rules/test54321/trace/start", bytes.NewBufferString("any"))
+	r := &EnableRuleTraceRequest{
+		Strategy: "always",
+	}
+	c, _ := json.Marshal(r)
+	req2, _ = http.NewRequest(http.MethodPost, "http://localhost:8080/rules/test54321/trace/start", bytes.NewBufferString(string(c)))
 	w2 = httptest.NewRecorder()
 	suite.r.ServeHTTP(w2, req2)
 	require.Equal(suite.T(), http.StatusOK, w2.Code)

--- a/internal/topo/node/tracenode/trace_node.go
+++ b/internal/topo/node/tracenode/trace_node.go
@@ -25,6 +25,9 @@ func TraceRowTuple(ctx api.StreamContext, input *xsql.RawTuple, opName string) (
 	if !ctx.IsTraceEnabled() {
 		return false, nil, nil
 	}
+	if !checkCtxByStrategy(ctx, input.GetTracerCtx()) {
+		return false, nil, nil
+	}
 	spanCtx, span := tracer.GetTracer().Start(input.GetTracerCtx(), opName)
 	x := topoContext.WithContext(spanCtx)
 	return true, x, span
@@ -58,7 +61,11 @@ func TraceInput(ctx api.StreamContext, d interface{}, opName string, opts ...tra
 	if !ok {
 		return false, nil, nil
 	}
+	if !checkCtxByStrategy(ctx, input.GetTracerCtx()) {
+		return false, nil, nil
+	}
 	spanCtx, span := tracer.GetTracer().Start(input.GetTracerCtx(), opName, opts...)
+	span.SetAttributes(attribute.String(RuleKey, ctx.GetRuleId()))
 	x := topoContext.WithContext(spanCtx)
 	input.SetTracerCtx(x)
 	return true, x, span
@@ -68,18 +75,39 @@ func TraceRow(ctx api.StreamContext, input xsql.Row, opName string, opts ...trac
 	if !ctx.IsTraceEnabled() {
 		return false, nil, nil
 	}
+	if !checkCtxByStrategy(ctx, input.GetTracerCtx()) {
+		return false, nil, nil
+	}
 	spanCtx, span := tracer.GetTracer().Start(input.GetTracerCtx(), opName, opts...)
+	span.SetAttributes(attribute.String(RuleKey, ctx.GetRuleId()))
 	x := topoContext.WithContext(spanCtx)
 	input.SetTracerCtx(x)
 	return true, x, span
 }
 
-func StartTrace(ctx api.StreamContext, opName string) (bool, api.StreamContext, trace.Span) {
+func StartTraceBySpanCtx(ctx, sctx api.StreamContext, opName string) (bool, api.StreamContext, trace.Span) {
 	if !ctx.IsTraceEnabled() {
 		return false, nil, nil
 	}
-	spanCtx, span := tracer.GetTracer().Start(context.Background(), opName)
+	if !checkCtxByStrategy(ctx, sctx) {
+		return false, nil, nil
+	}
+	spanCtx, span := tracer.GetTracer().Start(sctx, opName)
 	span.SetAttributes(attribute.String(RuleKey, ctx.GetRuleId()))
+	ingestCtx := topoContext.WithContext(spanCtx)
+	return true, ingestCtx, span
+}
+
+func StartTraceBackground(ctx api.StreamContext, opName string) (bool, api.StreamContext, trace.Span) {
+	if !ctx.IsTraceEnabled() {
+		return false, nil, nil
+	}
+	if !checkCtxByStrategy(ctx, ctx) {
+		return false, nil, nil
+	}
+	spanCtx, span := tracer.GetTracer().Start(context.Background(), opName)
+	ruleID := ctx.GetRuleId()
+	span.SetAttributes(attribute.String(RuleKey, ruleID))
 	ingestCtx := topoContext.WithContext(spanCtx)
 	return true, ingestCtx, span
 }
@@ -113,4 +141,28 @@ func ToStringCollection(r xsql.Collection) string {
 
 func buildTraceParent(traceID [16]byte, spanID [8]byte) string {
 	return fmt.Sprintf("00-%s-%s-01", hex.EncodeToString(traceID[:]), hex.EncodeToString(spanID[:]))
+}
+
+func checkCtxByStrategy(ctx, tracerCtx api.StreamContext) bool {
+	strategy := extractStrategy(ctx)
+	switch strategy {
+	case topoContext.AlwaysTraceStrategy:
+		return true
+	case topoContext.HeadTraceStrategy:
+		return hasTraceContext(tracerCtx)
+	}
+	return false
+}
+
+func extractStrategy(ctx api.StreamContext) topoContext.TraceStrategy {
+	dctx, ok := ctx.(*topoContext.DefaultContext)
+	if !ok {
+		return topoContext.AlwaysTraceStrategy
+	}
+	return dctx.GetStrategy()
+}
+
+func hasTraceContext(ctx context.Context) bool {
+	spanContext := trace.SpanContextFromContext(ctx)
+	return spanContext.IsValid()
 }

--- a/internal/topo/node/transform_op.go
+++ b/internal/topo/node/transform_op.go
@@ -23,13 +23,11 @@ import (
 	"github.com/lf-edge/ekuiper/contract/v2/api"
 
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
-	topoContext "github.com/lf-edge/ekuiper/v2/internal/topo/context"
 	"github.com/lf-edge/ekuiper/v2/internal/topo/node/tracenode"
 	"github.com/lf-edge/ekuiper/v2/internal/topo/transform"
 	"github.com/lf-edge/ekuiper/v2/internal/xsql"
 	"github.com/lf-edge/ekuiper/v2/pkg/infra"
 	"github.com/lf-edge/ekuiper/v2/pkg/timex"
-	"github.com/lf-edge/ekuiper/v2/pkg/tracer"
 )
 
 // TransformOp transforms the row/collection to sink tuples
@@ -152,10 +150,8 @@ func toSinkTuple(ctx, spanCtx api.StreamContext, bs any, props map[string]string
 	if bs == nil {
 		return bs
 	}
-	var tupleCtx api.StreamContext
-	if ctx.IsTraceEnabled() {
-		sctx, span := tracer.GetTracer().Start(spanCtx, "transform_op_split")
-		tupleCtx = topoContext.WithContext(sctx)
+	traced, tupleCtx, span := tracenode.StartTraceBySpanCtx(ctx, spanCtx, "transform_op_split")
+	if traced {
 		defer span.End()
 	}
 	switch bt := bs.(type) {

--- a/internal/topo/node/window_op.go
+++ b/internal/topo/node/window_op.go
@@ -741,7 +741,7 @@ func (o *WindowOperator) handleTraceEmitTuple(ctx api.StreamContext, wt *xsql.Wi
 }
 
 func (o *WindowOperator) handleNextWindowTupleSpan(ctx api.StreamContext) {
-	traced, spanCtx, span := tracenode.StartTrace(ctx, "window_op")
+	traced, spanCtx, span := tracenode.StartTraceBackground(ctx, "window_op")
 	if traced {
 		o.nextSpanCtx = spanCtx
 		o.nextSpan = span

--- a/internal/topo/rule/state.go
+++ b/internal/topo/rule/state.go
@@ -33,6 +33,7 @@ import (
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/schedule"
 	"github.com/lf-edge/ekuiper/v2/internal/topo"
+	kctx "github.com/lf-edge/ekuiper/v2/internal/topo/context"
 	"github.com/lf-edge/ekuiper/v2/internal/topo/planner"
 	"github.com/lf-edge/ekuiper/v2/pkg/cast"
 	"github.com/lf-edge/ekuiper/v2/pkg/errorx"
@@ -562,11 +563,11 @@ func (s *State) GetTopoGraph() *def.PrintableTopo {
 	}
 }
 
-func (s *State) SetIsTraceEnabled(isEnabled bool) error {
+func (s *State) SetIsTraceEnabled(isEnabled bool, stra kctx.TraceStrategy) error {
 	s.Lock()
 	defer s.Unlock()
 	if s.topology != nil {
-		s.topology.EnableTracer(isEnabled)
+		s.topology.EnableTracer(isEnabled, stra)
 		return nil
 	}
 	return fmt.Errorf("rule %s set trace failed due to rule didn't started", s.Rule.Name)

--- a/internal/topo/topo.go
+++ b/internal/topo/topo.go
@@ -231,8 +231,12 @@ func (s *Topo) prepareContext() {
 	}
 }
 
-func (s *Topo) EnableTracer(isEnabled bool) {
+func (s *Topo) EnableTracer(isEnabled bool, strategy kctx.TraceStrategy) {
 	s.ctx.EnableTracer(isEnabled)
+	dctx, ok := s.ctx.(*kctx.DefaultContext)
+	if ok {
+		dctx.SetStrategy(strategy)
+	}
 }
 
 func (s *Topo) IsTraceEnabled() bool {


### PR DESCRIPTION
support trace strategy `head`/`always`

1. `head` will check whether the source request has trace parent if enabled
2. `always`will always trace if enabled