### PR TITLE
refactor(trace): move trace into common func

### DIFF
--- a/internal/topo/node/batch_op.go
+++ b/internal/topo/node/batch_op.go
@@ -109,12 +109,7 @@ func (b *BatchOp) ingest(ctx api.StreamContext, item any, checkSize bool) {
 	if processed {
 		return
 	}
-	b.onProcessStart(ctx)
-	traced, _, span := tracenode.TraceInput(ctx, data, "batch_op_ingest")
-	if traced {
-		tracenode.RecordRowOrCollection(data, span)
-		span.End()
-	}
+	b.onProcessStart(ctx, data)
 	switch input := data.(type) {
 	case xsql.Row:
 		b.handleTraceIngest(ctx, input, input)
@@ -217,7 +212,7 @@ func (b *BatchOp) handleTraceIngest(ctx api.StreamContext, d any, row xsql.Row) 
 		b.rowHandle[row] = struct{}{}
 		row.SetTracerCtx(topoContext.WithContext(spanCtx))
 		tracenode.RecordRowOrCollection(row, span)
-		defer span.End()
+		span.End()
 	}
 }
 

--- a/internal/topo/node/cache_op.go
+++ b/internal/topo/node/cache_op.go
@@ -81,15 +81,14 @@ func (s *CacheOp) Exec(ctx api.StreamContext, errCh chan<- error) {
 					if processed {
 						break
 					}
-					s.onProcessStart(ctx)
+					s.onProcessStart(ctx, data)
 					// If already have the cache, append this to cache and send the currItem
 					// Otherwise, send out the new data. If blocked, make it currItem
 					if s.hasCache { // already have cache, add current data to cache and send out the cache
 						err := s.cache.AddCache(ctx, data)
 						ctx.GetLogger().Debugf("add data %v to cache", data)
 						if err != nil {
-							s.statManager.IncTotalExceptions(err.Error())
-							s.Broadcast(err)
+							s.onError(ctx, err)
 							break
 						}
 					} else {

--- a/internal/topo/node/concurrent.go
+++ b/internal/topo/node/concurrent.go
@@ -114,7 +114,7 @@ func worker(ctx api.StreamContext, node *defaultSinkNode, i int, wf workerFunc, 
 			case error, *xsql.WatermarkTuple, xsql.EOFTuple:
 				result = []any{item}
 			default:
-				node.onProcessStart(ctx)
+				node.onProcessStart(ctx, item)
 				result = wf(ctx, item)
 				node.onProcessEnd(ctx)
 			}

--- a/internal/topo/node/decode_op.go
+++ b/internal/topo/node/decode_op.go
@@ -20,12 +20,10 @@ import (
 	"time"
 
 	"github.com/lf-edge/ekuiper/contract/v2/api"
-	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/lf-edge/ekuiper/v2/internal/converter"
 	schemaLayer "github.com/lf-edge/ekuiper/v2/internal/converter/schema"
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
-	"github.com/lf-edge/ekuiper/v2/internal/topo/node/tracenode"
 	"github.com/lf-edge/ekuiper/v2/internal/xsql"
 	"github.com/lf-edge/ekuiper/v2/pkg/ast"
 	"github.com/lf-edge/ekuiper/v2/pkg/cast"
@@ -381,18 +379,12 @@ func mergeTuple(ctx api.StreamContext, d *xsql.Tuple, result any) {
 }
 
 func toTupleFromRawTuple(ctx api.StreamContext, v map[string]any, d *xsql.RawTuple) *xsql.Tuple {
-	traced, spanCtx, span := tracenode.TraceInput(ctx, d, ctx.GetOpId())
 	t := &xsql.Tuple{
 		Ctx:       d.Ctx,
 		Message:   v,
 		Metadata:  d.Metadata,
 		Timestamp: d.Timestamp,
 		Emitter:   d.Emitter,
-	}
-	if traced {
-		t.Ctx = spanCtx
-		span.SetAttributes(attribute.String(tracenode.DataKey, tracenode.ToStringRow(t)))
-		defer span.End()
 	}
 	return t
 }

--- a/internal/topo/node/event_window_trigger.go
+++ b/internal/topo/node/event_window_trigger.go
@@ -175,7 +175,7 @@ func (o *WindowOperator) execEventWindow(ctx api.StreamContext, inputs []*xsql.T
 				nextWindowEndTs = windowEndTs
 				log.Debugf("next window end %d", nextWindowEndTs.UnixMilli())
 			case *xsql.Tuple:
-				o.onProcessStart(ctx)
+				o.onProcessStart(ctx, d)
 				ctx.GetLogger().Debug("Tuple", d.GetTimestamp())
 				log.Debugf("event window receive tuple %s", d.Message)
 				// first tuple, set the window start time, which will set to triggerTime
@@ -189,10 +189,8 @@ func (o *WindowOperator) execEventWindow(ctx api.StreamContext, inputs []*xsql.T
 				o.onProcessEnd(ctx)
 				_ = ctx.PutState(WindowInputsKey, inputs)
 			default:
-				o.onProcessStart(ctx)
-				e := fmt.Errorf("run Window error: expect xsql.Event type but got %[1]T(%[1]v)", d)
-				o.Broadcast(e)
-				o.statManager.IncTotalExceptions(e.Error())
+				o.onProcessStart(ctx, d)
+				o.onError(ctx, fmt.Errorf("run Window error: expect xsql.Event type but got %[1]T(%[1]v)", d))
 				o.onProcessEnd(ctx)
 			}
 		// is cancelling

--- a/internal/topo/node/join_align_node.go
+++ b/internal/topo/node/join_align_node.go
@@ -89,7 +89,7 @@ func (n *JoinAlignNode) Exec(ctx api.StreamContext, errCh chan<- error) {
 					if processed {
 						break
 					}
-					n.onProcessStart(ctx)
+					n.onProcessStart(ctx, data)
 					switch d := data.(type) {
 					case *xsql.Tuple:
 						log.Debugf("JoinAlignNode receive tuple input %v", d)
@@ -108,9 +108,7 @@ func (n *JoinAlignNode) Exec(ctx api.StreamContext, errCh chan<- error) {
 						log.Debugf("JoinAlignNode receive window input %v", d)
 						n.alignBatch(ctx, d)
 					default:
-						e := fmt.Errorf("run JoinAlignNode error: invalid input type but got %[1]T(%[1]v)", d)
-						n.Broadcast(e)
-						n.statManager.IncTotalExceptions(e.Error())
+						n.onError(ctx, fmt.Errorf("run JoinAlignNode error: invalid input type but got %[1]T(%[1]v)", d))
 					}
 					n.onProcessEnd(ctx)
 				case <-ctx.Done():

--- a/internal/topo/node/rate_limit.go
+++ b/internal/topo/node/rate_limit.go
@@ -136,7 +136,7 @@ func (o *RateLimitOp) Exec(ctx api.StreamContext, errCh chan<- error) {
 					if processed {
 						continue
 					}
-					o.onProcessStart(ctx)
+					o.onProcessStart(ctx, dd)
 					o.latest = dd
 					o.onProcessEnd(ctx)
 					o.statManager.SetBufferLength(int64(len(o.input)))
@@ -161,7 +161,7 @@ func (o *RateLimitOp) Exec(ctx api.StreamContext, errCh chan<- error) {
 					if processed {
 						continue
 					}
-					o.onProcessStart(ctx)
+					o.onProcessStart(ctx, dd)
 					var (
 						val any
 						err error
@@ -180,8 +180,7 @@ func (o *RateLimitOp) Exec(ctx api.StreamContext, errCh chan<- error) {
 						err = fmt.Errorf("rate limit merge only supports raw but got %v", d)
 					}
 					if err != nil {
-						o.statManager.IncTotalExceptions(err.Error())
-						o.Broadcast(err)
+						o.onError(ctx, err)
 					}
 					o.onProcessEnd(ctx)
 					o.statManager.SetBufferLength(int64(len(o.input)))
@@ -231,7 +230,7 @@ func (o *RateLimitOp) Exec(ctx api.StreamContext, errCh chan<- error) {
 					if processed {
 						continue
 					}
-					o.onProcessStart(ctx)
+					o.onProcessStart(ctx, dd)
 					var err error
 					switch dt := dd.(type) {
 					case *xsql.RawTuple:
@@ -243,8 +242,7 @@ func (o *RateLimitOp) Exec(ctx api.StreamContext, errCh chan<- error) {
 						err = fmt.Errorf("rate limit merge only supports raw but got %v", d)
 					}
 					if err != nil {
-						o.statManager.IncTotalExceptions(err.Error())
-						o.Broadcast(err)
+						o.onError(ctx, err)
 					}
 					o.onProcessEnd(ctx)
 					o.statManager.SetBufferLength(int64(len(o.input)))

--- a/internal/topo/node/source_node.go
+++ b/internal/topo/node/source_node.go
@@ -74,7 +74,7 @@ func (m *SourceNode) Open(ctx api.StreamContext, ctrlCh chan<- error) {
 
 func (m *SourceNode) ingestBytes(ctx api.StreamContext, data []byte, meta map[string]any, ts time.Time) {
 	ctx.GetLogger().Debugf("source connector %s receive data %+v", m.name, data)
-	m.onProcessStart(ctx)
+	m.onProcessStart(ctx, nil)
 	tuple := &xsql.RawTuple{Emitter: m.name, Rawdata: data, Timestamp: ts, Metadata: meta}
 	if ctx.IsTraceEnabled() {
 		traceCtx, ok := meta["traceCtx"].(api.StreamContext)
@@ -91,7 +91,7 @@ func (m *SourceNode) ingestBytes(ctx api.StreamContext, data []byte, meta map[st
 
 func (m *SourceNode) ingestAnyTuple(ctx api.StreamContext, data any, meta map[string]any, ts time.Time) {
 	ctx.GetLogger().Debugf("source connector %s receive data %+v", m.name, data)
-	m.onProcessStart(ctx)
+	m.onProcessStart(ctx, nil)
 	switch mess := data.(type) {
 	// Maps are expected from user extension
 	case map[string]any:
@@ -148,9 +148,7 @@ func (m *SourceNode) ingestTuple(t *xsql.Tuple, ts time.Time) {
 }
 
 func (m *SourceNode) ingestError(ctx api.StreamContext, err error) {
-	ctx.GetLogger().Error(err)
-	m.Broadcast(err)
-	m.statManager.IncTotalExceptions(err.Error())
+	m.onError(ctx, err)
 }
 
 func (m *SourceNode) ingestEof(ctx api.StreamContext) {

--- a/internal/topo/node/tracenode/trace_node.go
+++ b/internal/topo/node/tracenode/trace_node.go
@@ -1,3 +1,17 @@
+// Copyright 2024 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package tracenode
 
 import (

--- a/internal/topo/node/watermark_op.go
+++ b/internal/topo/node/watermark_op.go
@@ -113,7 +113,7 @@ func (w *WatermarkOp) Exec(ctx api.StreamContext, errCh chan<- error) {
 					if processed {
 						break
 					}
-					w.onProcessStart(ctx)
+					w.onProcessStart(ctx, data)
 					switch d := data.(type) {
 					case *xsql.Tuple:
 						// whether to drop the late event
@@ -122,9 +122,7 @@ func (w *WatermarkOp) Exec(ctx api.StreamContext, errCh chan<- error) {
 							w.addAndTrigger(ctx, d)
 						}
 					default:
-						e := fmt.Errorf("run watermark op error: expect *xsql.Tuple type but got %[1]T(%[1]v)", d)
-						w.Broadcast(e)
-						w.statManager.IncTotalExceptions(e.Error())
+						w.onError(ctx, fmt.Errorf("run watermark op error: expect *xsql.Tuple type but got %[1]T(%[1]v)", d))
 					}
 					w.onProcessEnd(ctx)
 				}

--- a/internal/topo/operator/projectset_operator.go
+++ b/internal/topo/operator/projectset_operator.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/lf-edge/ekuiper/contract/v2/api"
 
-	"github.com/lf-edge/ekuiper/v2/internal/topo/node/tracenode"
 	"github.com/lf-edge/ekuiper/v2/internal/xsql"
 )
 
@@ -133,7 +132,6 @@ func (ps *ProjectSetOperator) handleSRFRow(ctx api.StreamContext, row xsql.Row) 
 	for i, v := range aValues {
 		newRow := row.Clone().(xsql.Row)
 		newRow.SetTracerCtx(row.GetTracerCtx())
-		traced, _, span := tracenode.TraceInput(ctx, newRow, ctx.GetOpId())
 		// clear original column value
 		newRow.Del(srfName)
 		if mv, ok := v.(map[string]interface{}); ok {
@@ -142,10 +140,6 @@ func (ps *ProjectSetOperator) handleSRFRow(ctx api.StreamContext, row xsql.Row) 
 			}
 		} else {
 			newRow.Set(srfName, v)
-		}
-		if traced {
-			tracenode.RecordRowOrCollection(newRow, span)
-			span.End()
 		}
 		res.appendTuple(i, newRow)
 	}

--- a/internal/xsql/collection.go
+++ b/internal/xsql/collection.go
@@ -645,6 +645,23 @@ func (l *TransformedTupleList) ToMaps() []map[string]any {
 	return l.Maps
 }
 
+func (l *TransformedTupleList) Clone() *TransformedTupleList {
+	ng := make([]api.MessageTuple, len(l.Content))
+	for i, g := range l.Content {
+		switch gt := g.(type) {
+		case Row:
+			ng[i] = gt.Clone()
+		default:
+			ng[i] = g
+		}
+	}
+	return &TransformedTupleList{
+		Ctx:     l.Ctx,
+		Content: ng,
+		Props:   l.Props,
+	}
+}
+
 func (l *TransformedTupleList) RangeOfTuples(f func(index int, tuple api.MessageTuple) bool) {
 	for i, v := range l.Content {
 		if !f(i, v) {


### PR DESCRIPTION
- In node hook start functions, only record data when ingesting (the output data will be recorded as the input/data of the next operatore).
- also trace error