### PR TITLE
fix(logger): discard log if disabled

### DIFF
--- a/internal/conf/logger/logger.go
+++ b/internal/conf/logger/logger.go
@@ -1,4 +1,4 @@
-// Copyright 2023 EMQ Technologies Co., Ltd.
+// Copyright 2023-2024 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package logger
 
 import (
+	"io"
 	"os"
 	"strings"
 
@@ -39,6 +40,7 @@ func InitLogger() {
 		return
 	}
 	Log = logrus.New()
+	Log.SetOutput(io.Discard)
 	filenameHook := filename.NewHook()
 	filenameHook.Field = "file"
 	Log.AddHook(filenameHook)


### PR DESCRIPTION
When both fileLog and consoleLog are disabled, should discard the log.