### PR TITLE
modify nil != nil bug

### DIFF
--- a/internal/server/rpc_plugin.go
+++ b/internal/server/rpc_plugin.go
@@ -37,9 +37,6 @@ func (t *Server) CreatePlugin(arg *model.PluginDesc, reply *string) error {
 	// define according to the build tag
 	err = t.doRegister(pt, p)
 	if err != nil {
-		return err
-	}
-	if err != nil {
 		return fmt.Errorf("Create plugin error: %s", err)
 	} else {
 		*reply = fmt.Sprintf("Plugin %s is created.", p.GetName())


### PR DESCRIPTION
internal/server/rpc_plugin.go
line: 42

code current:
// define according to the build tag
err = t.doRegister(pt, p)
if err != nil {
return err
}
if err != nil {
return fmt.Errorf("Create plugin error: %s", err)
} else {
*reply = fmt.Sprintf("Plugin %s is created.", p.GetName())
}

code modified:
err = t.doRegister(pt, p)
if err != nil {
return fmt.Errorf("Create plugin error: %s", err)
} else {
*reply = fmt.Sprintf("Plugin %s is created.", p.GetName())
}