### PR TITLE
feat(func): lag ignoreNull defaults to true

### DIFF
--- a/internal/binder/function/funcs_analytic.go
+++ b/internal/binder/function/funcs_analytic.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 EMQ Technologies Co., Ltd.
+// Copyright 2022-2025 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -138,7 +138,7 @@ func registerAnalyticFunc() {
 			if !ok {
 				return fmt.Errorf("when arg is not a bool but got %v", args[len(args)-2]), false
 			}
-			ignoreNull := false
+			ignoreNull := true
 			if l == 4 {
 				ignoreNull, ok = args[3].(bool)
 				if !ok {

--- a/internal/topo/operator/analyticfuncs_operator_test.go
+++ b/internal/topo/operator/analyticfuncs_operator_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 EMQ Technologies Co., Ltd.
+// Copyright 2022-2025 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ func TestAnalyticFuncs(t *testing.T) {
 			}, {
 				"$$a_lag_0": "a1", "$$a_lag_1": "b2",
 			}, {
-				"$$a_lag_0": "a1", "$$a_lag_1": interface{}(nil),
+				"$$a_lag_0": "a1", "$$a_lag_1": "b2",
 			}},
 		},
 		{ // 1 changed test
@@ -163,9 +163,9 @@ func TestAnalyticFuncs(t *testing.T) {
 				}, {
 					"$$a_changed_col_0": nil, "$$a_had_changed_0": true, "$$a_lag_1": "b1",
 				}, {
-					"$$a_changed_col_0": nil, "$$a_had_changed_0": false, "$$a_lag_1": nil,
+					"$$a_changed_col_0": nil, "$$a_had_changed_0": false, "$$a_lag_1": "b1",
 				}, {
-					"$$a_changed_col_0": nil, "$$a_had_changed_0": true, "$$a_lag_1": nil,
+					"$$a_changed_col_0": nil, "$$a_had_changed_0": true, "$$a_lag_1": "b1",
 				},
 			},
 		},

--- a/internal/topo/operator/misc_func_test.go
+++ b/internal/topo/operator/misc_func_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 EMQ Technologies Co., Ltd.
+// Copyright 2022-2025 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1051,6 +1051,7 @@ func TestLagFuncs_Apply1(t *testing.T) {
 				"b": "b2",
 			}}, {{
 				"a": "a1",
+				"b": "b2",
 			}}},
 		},
 


### PR DESCRIPTION
This is a breaking change. But in most cases in IoT, null just mean the same value as the previous one. So just ignore it.