### PR TITLE
refactor(build): native arm and qemu update

### DIFF
--- a/.github/workflows/build_base_image.yaml
+++ b/.github/workflows/build_base_image.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: github.repository == 'lf-edge/ekuiper'
 
     strategy:
@@ -32,7 +32,7 @@ jobs:
       - uses: docker/setup-buildx-action@v3
       - uses: docker/setup-qemu-action@v3
         with:
-          image: tonistiigi/binfmt:qemu-v7.0.0-28
+          image: tonistiigi/binfmt:qemu-v9.2.2-52
       - uses: actions/cache@v3
         with:
           path: /tmp/.docker-buildx-cache

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   prepare:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       arch: ${{ steps.arch.outputs.arch }}
 
@@ -21,13 +21,13 @@ jobs:
       - id: arch
         run: |
           if ${{ contains(fromJSON('["release", "workflow_dispatch"]'), github.event_name) }}; then
-            echo "arch=[\"linux/amd64\", \"linux/arm64\", \"linux/arm/v7\"]" >> $GITHUB_OUTPUT
+            echo "arch=[\"linux/amd64\", \"linux/arm64\"]" >> $GITHUB_OUTPUT
           else
             echo "arch=[\"linux/amd64\"]" >> $GITHUB_OUTPUT
           fi
 
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.arch == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     needs: prepare
 
     strategy:
@@ -42,10 +42,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - uses: docker/setup-qemu-action@v3
-      with:
-        image: tonistiigi/binfmt:qemu-v7.0.0-28
-    - uses: docker/setup-buildx-action@v3
     - name: build
       if: matrix.os == 'debian'
       run: |
@@ -107,21 +103,21 @@ jobs:
         path: _packages/
 
   build-docker-images:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     strategy:
-        fail-fast: false
-        matrix:
-            suffix:
-            - ""
-            - "-alpine"
-            - "-alpine-python"
-            - "-dev"
-            - "-slim"
-            - "-slim-python"
-            - "-full"
-            golang:
-              - 1.23.4
+      fail-fast: false
+      matrix:
+        suffix:
+          - ""
+          - "-alpine"
+          - "-alpine-python"
+          - "-dev"
+          - "-slim"
+          - "-slim-python"
+          - "-full"
+        golang:
+          - 1.23.4
 
     steps:
     - uses: actions/checkout@v4
@@ -130,7 +126,7 @@ jobs:
     - uses: docker/setup-buildx-action@v3
     - uses: docker/setup-qemu-action@v3
       with:
-        image: tonistiigi/binfmt:qemu-v7.0.0-28
+        image: tonistiigi/binfmt:qemu-v9.2.2-52
         platforms: all
     - name: Build single platform image
       if: endsWith( matrix.suffix, 'python') == false
@@ -184,7 +180,7 @@ jobs:
         file: deploy/docker/Dockerfile${{ matrix.suffix }}
 
   build-plugins:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.arch == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     needs: prepare
 
     strategy:
@@ -229,11 +225,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/setup-qemu-action@v3
-        with:
-          image: tonistiigi/binfmt:qemu-v7.0.0-28
-          platforms: all
       - name: build plugins
         run: |
           docker run -i --rm \
@@ -304,7 +295,7 @@ jobs:
           path: _plugins/
 
   build-kubernetes-tool:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
@@ -313,7 +304,7 @@ jobs:
     - uses: docker/setup-buildx-action@v3
     - uses: docker/setup-qemu-action@v3
       with:
-        image: tonistiigi/binfmt:qemu-v7.0.0-28
+        image: tonistiigi/binfmt:qemu-v9.2.2-52
         platforms: all
     - name: Build single platform image
       uses: docker/build-push-action@v6

--- a/deploy/docker/Dockerfile-slim-python
+++ b/deploy/docker/Dockerfile-slim-python
@@ -21,23 +21,32 @@ WORKDIR /go/kuiper
 
 RUN make build_with_edgex_and_script
 
-FROM python:3.12-slim-bookworm
+FROM python:3.12-bookworm AS python-builder
 
-COPY --from=builder /go/kuiper/_build/kuiper-* /kuiper/
-COPY ./deploy/docker/docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
 COPY ./sdk/python /sdk/python
 
 ARG DEBIAN_FRONTEND="noninteractive"
 
+# Install build dependencies for pynng (including nng and mbedtls)
 RUN apt-get update \
-    && apt-get install -y wget cmake libffi-dev git\
+    && apt-get install -y --no-install-recommends \
+        wget cmake libffi-dev git \
+        build-essential gcc g++ libc-dev \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && python3 -m ensurepip --upgrade \
+    && python3 -m pip install --no-cache-dir setuptools
 
 WORKDIR /sdk/python
 RUN python3 setup.py sdist && python3 setup.py install
 
+FROM python:3.12-slim-bookworm
+
+COPY --from=builder /go/kuiper/_build/kuiper-* /kuiper/
+COPY --from=python-builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+
 WORKDIR /kuiper
+COPY ./deploy/docker/docker-entrypoint.sh /usr/bin/docker-entrypoint.sh
 
 ENV MAINTAINER="emqx.io"
 ENV KUIPER_HOME="/kuiper"


### PR DESCRIPTION
- Use Github native arm runner to run arm64 binary (non-docker) build. Remove armv7 binary support
- Use ubuntu runner version 24.04 + qemu latest 9.2.2
- Update python version and fix incompatibility
- Slim-python docker file refactor to 3 layers, build pip in python-builder layer