### PR TITLE
fix(planner): sql sink should handle fields

### DIFF
--- a/extensions/impl/sql/sink.go
+++ b/extensions/impl/sql/sink.go
@@ -1,4 +1,4 @@
-// Copyright 2024 EMQ Technologies Co., Ltd.
+// Copyright 2024-2025 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import (
 	"github.com/lf-edge/ekuiper/v2/pkg/cast"
 	"github.com/lf-edge/ekuiper/v2/pkg/connection"
 	"github.com/lf-edge/ekuiper/v2/pkg/errorx"
+	"github.com/lf-edge/ekuiper/v2/pkg/model"
 )
 
 const (
@@ -132,6 +133,11 @@ func (s *SQLSinkConnector) Provision(ctx api.StreamContext, configs map[string]a
 	s.config = c
 	s.props = configs
 	return nil
+}
+
+// Consume This is run after provision. Discard common confs that will only be handled in sink itself
+func (s *SQLSinkConnector) Consume(props map[string]any) {
+	delete(props, "fields")
 }
 
 func (s *SQLSinkConnector) Connect(ctx api.StreamContext, sc api.StatusChangeHandler) error {
@@ -324,6 +330,7 @@ func GetSink() api.Sink {
 }
 
 var (
-	_ api.TupleCollector = &SQLSinkConnector{}
-	_ util.PingableConn  = &SQLSinkConnector{}
+	_ api.TupleCollector  = &SQLSinkConnector{}
+	_ util.PingableConn   = &SQLSinkConnector{}
+	_ model.PropsConsumer = &SQLSinkConnector{}
 )

--- a/extensions/impl/sql/sink_test.go
+++ b/extensions/impl/sql/sink_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 EMQ Technologies Co., Ltd.
+// Copyright 2024-2025 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -330,4 +330,49 @@ func TestSQLSinkReconnect(t *testing.T) {
 		"action": "update",
 	}))
 	require.False(t, sqlSink.needReconnect)
+}
+
+func TestConsume(t *testing.T) {
+	tests := []struct {
+		name  string
+		props map[string]any
+		exp   map[string]any
+	}{
+		{
+			name: "has fields",
+			props: map[string]any{
+				"actionField": "action",
+				"keyField":    "a",
+				"fields":      []string{"a", "b"},
+				"other":       "other",
+			},
+			exp: map[string]any{
+				"actionField": "action",
+				"keyField":    "a",
+				"other":       "other",
+			},
+		},
+		{
+			name: "no fields",
+			props: map[string]any{
+				"actionField": "action",
+				"keyField":    "a",
+				"dumbfields":  []string{"a", "b"},
+				"other":       "other",
+			},
+			exp: map[string]any{
+				"actionField": "action",
+				"keyField":    "a",
+				"dumbfields":  []string{"a", "b"},
+				"other":       "other",
+			},
+		},
+	}
+	s := &SQLSinkConnector{}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s.Consume(test.props)
+			require.Equal(t, test.exp, test.props)
+		})
+	}
 }

--- a/internal/topo/planner/planner_sink.go
+++ b/internal/topo/planner/planner_sink.go
@@ -80,6 +80,14 @@ func SinkToComp(tp *topo.Topo, sinkType string, sinkName string, props map[strin
 	if s == nil {
 		return nil, fmt.Errorf("sink %s is not defined", sinkType)
 	}
+	if err := s.Provision(tp.GetContext(), props); err != nil {
+		return nil, err
+	}
+	tp.GetContext().GetLogger().Infof("provision sink %s with props %+v", sinkName, props)
+	// consume common conf in sink itself, swallow and not pass it to common conf
+	if pc, ok := s.(model.PropsConsumer); ok {
+		pc.Consume(props)
+	}
 	commonConf, err := node.ParseConf(tp.GetContext().GetLogger(), props)
 	if err != nil {
 		return nil, fmt.Errorf("fail to parse sink configuration: %v", err)
@@ -90,10 +98,6 @@ func SinkToComp(tp *topo.Topo, sinkType string, sinkName string, props map[strin
 	if err != nil {
 		return nil, err
 	}
-	if err = s.Provision(tp.GetContext(), props); err != nil {
-		return nil, err
-	}
-	tp.GetContext().GetLogger().Infof("provision sink %s with props %+v", sinkName, props)
 
 	result := &SinkCompNode{
 		name:  sinkName,

--- a/pkg/model/io.go
+++ b/pkg/model/io.go
@@ -59,3 +59,8 @@ type UniqueSub interface {
 type UniqueConn interface {
 	ConnId(props map[string]any) string
 }
+
+// PropsConsumer Read in properties, swallow some and return new props
+type PropsConsumer interface {
+	Consume(props map[string]any)
+}


### PR DESCRIPTION
Some sink need to handle common properties by itself instead of delegate to the transform op or other sink splitted op