### PR TITLE
feat(rule): rule upsert & init rule migration

### DIFF
--- a/fvt/rulestate_test.go
+++ b/fvt/rulestate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 EMQ Technologies Co., Ltd.
+// Copyright 2024-2025 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ func (s *RuleStateTestSuite) TestUpdate() {
 		ruleSql := `{
   "id": "rule1",
   "name": "keep rule",
+  "version": "123456",
   "sql": "SELECT * FROM simStream",
   "actions": [
     {
@@ -62,6 +63,15 @@ func (s *RuleStateTestSuite) TestUpdate() {
 		s.Require().NoError(err)
 		s.T().Log(GetResponseText(resp))
 		s.Require().Equal(http.StatusCreated, resp.StatusCode)
+
+		resp, err = client.Get("rules/rule1")
+		s.Require().NoError(err)
+		m, err := GetResponseResultMap(resp)
+		s.Require().NoError(err)
+		vv, ok := m["version"]
+		s.Require().True(ok)
+		version := "123456"
+		s.Require().Equal(version, vv)
 
 		ruleSql2 := `{
   "id": "rule2",

--- a/fvt/rulestate_test.go
+++ b/fvt/rulestate_test.go
@@ -59,10 +59,29 @@ func (s *RuleStateTestSuite) TestUpdate() {
     "sendError": false
   }
 }`
-		resp, err = client.CreateRule(ruleSql)
+		// test upsert
+		resp, err = client.UpdateRule("rule1", ruleSql)
 		s.Require().NoError(err)
 		s.T().Log(GetResponseText(resp))
-		s.Require().Equal(http.StatusCreated, resp.StatusCode)
+		s.Require().Equal(http.StatusOK, resp.StatusCode)
+		// test upsert with lower version
+		ruleSql = `{
+  "id": "rule1",
+  "name": "keep rule",
+  "version": "023456",
+  "sql": "SELECT * FROM simStream",
+  "actions": [
+    {
+      "nop":{}
+    }
+  ],
+  "options": {
+    "sendError": false
+  }
+}`
+		resp, err = client.UpdateRule("rule1", ruleSql)
+		s.Require().NoError(err)
+		s.Require().Equal(http.StatusBadRequest, resp.StatusCode)
 
 		resp, err = client.Get("rules/rule1")
 		s.Require().NoError(err)

--- a/internal/io/mqtt/source_sink_test.go
+++ b/internal/io/mqtt/source_sink_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 EMQ Technologies Co., Ltd.
+// Copyright 2024-2025 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package mqtt
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/lf-edge/ekuiper/contract/v2/api"
 	mqtt "github.com/mochi-mqtt/server/v2"
@@ -34,7 +33,7 @@ import (
 	"github.com/lf-edge/ekuiper/v2/pkg/model"
 )
 
-func TestSourceSinkRecon(t *testing.T) {
+func TestSourceSink(t *testing.T) {
 	// Create the new MQTT Server.
 	server := mqtt.New(nil)
 	// Allow all connections.
@@ -86,7 +85,7 @@ func TestSourceSinkRecon(t *testing.T) {
 		"qos":        0,
 		"topic":      "demo",
 	}, result, func() {
-		err := mock.RunBytesSinkCollect(sk, data[:1], map[string]any{
+		err := mock.RunBytesSinkCollect(sk, data, map[string]any{
 			"server":   url,
 			"topic":    "demo",
 			"qos":      0,
@@ -98,21 +97,6 @@ func TestSourceSinkRecon(t *testing.T) {
 		assert.NoError(t, err)
 		err = server.Close()
 		tcp.Close(nil)
-		assert.NoError(t, err)
-		go func() {
-			tcp := listeners.NewTCP(listeners.Config{Address: url})
-			err := server.AddListener(tcp)
-			require.NoError(t, err)
-			err = server.Serve()
-			require.NoError(t, err)
-		}()
-		time.Sleep(time.Millisecond * 100)
-		err = mock.RunBytesSinkCollect(sk, data[1:], map[string]any{
-			"server":   url,
-			"topic":    "demo",
-			"qos":      0,
-			"retained": false,
-		})
 		assert.NoError(t, err)
 	})
 }

--- a/internal/io/mqtt/v5_test.go
+++ b/internal/io/mqtt/v5_test.go
@@ -16,7 +16,6 @@ package mqtt
 
 import (
 	"testing"
-	"time"
 
 	"github.com/lf-edge/ekuiper/contract/v2/api"
 	mqtt "github.com/mochi-mqtt/server/v2"
@@ -33,7 +32,7 @@ import (
 	"github.com/lf-edge/ekuiper/v2/pkg/model"
 )
 
-func TestV5SourceSinkRecon(t *testing.T) {
+func TestV5SourceSink(t *testing.T) {
 	// Create the new MQTT Server.
 	server := mqtt.New(nil)
 	// Allow all connections.
@@ -46,7 +45,6 @@ func TestV5SourceSinkRecon(t *testing.T) {
 		err = server.Serve()
 		require.NoError(t, err)
 	}()
-	addr := tcp.Address()
 	url := "mqtt://127.0.0.1:12883"
 	dataDir, err := conf.GetDataLoc()
 	require.NoError(t, err)
@@ -87,7 +85,7 @@ func TestV5SourceSinkRecon(t *testing.T) {
 		"qos":             0,
 		"topic":           "demo",
 	}, result, func() {
-		err := mock.RunBytesSinkCollect(sk, data[:1], map[string]any{
+		err := mock.RunBytesSinkCollect(sk, data, map[string]any{
 			"server":          url,
 			"topic":           "demo",
 			"qos":             0,
@@ -97,26 +95,6 @@ func TestV5SourceSinkRecon(t *testing.T) {
 		assert.NoError(t, err)
 		err = server.Close()
 		tcp.Close(nil)
-		assert.NoError(t, err)
-		time.Sleep(time.Millisecond * 100)
-		go func() {
-			tcp := listeners.NewTCP(listeners.Config{Address: addr})
-			err := server.AddListener(tcp)
-			require.NoError(t, err)
-			err = server.Serve()
-			require.NoError(t, err)
-		}()
-		time.Sleep(time.Millisecond * 500)
-		err = mock.RunBytesSinkCollect(sk, data[1:], map[string]any{
-			"server":          url,
-			"topic":           "demo",
-			"qos":             0,
-			"protocolVersion": "5",
-			"retained":        false,
-			"properties": map[string]string{
-				"prop2": "val2",
-			},
-		})
 		assert.NoError(t, err)
 	})
 }

--- a/internal/pkg/def/rule.go
+++ b/internal/pkg/def/rule.go
@@ -1,4 +1,4 @@
-// Copyright 2024 EMQ Technologies Co., Ltd.
+// Copyright 2024-2025 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -97,7 +97,8 @@ type RuleGraph struct {
 type Rule struct {
 	Triggered bool                     `json:"triggered" yaml:"triggered"`
 	Id        string                   `json:"id,omitempty" yaml:"id,omitempty"`
-	Name      string                   `json:"name,omitempty" yaml:"name,omitempty"` // The display name of a rule
+	Name      string                   `json:"name,omitempty" yaml:"name,omitempty"`       // The display name of a rule
+	Version   string                   `json:"version,omitempty" yaml:"version,omitempty"` // The display name of a rule
 	Sql       string                   `json:"sql,omitempty" yaml:"sql,omitempty"`
 	Graph     *RuleGraph               `json:"graph,omitempty" yaml:"graph,omitempty"`
 	Actions   []map[string]interface{} `json:"actions,omitempty" yaml:"actions,omitempty"`

--- a/internal/processor/ruleset.go
+++ b/internal/processor/ruleset.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 EMQ Technologies Co., Ltd.
+// Copyright 2022-2025 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -114,7 +114,7 @@ func (rs *RulesetProcessor) Import(content []byte) ([]string, []int, error) {
 	for k, v := range all.Streams {
 		_, e := rs.s.ExecStreamSql(v)
 		if e != nil {
-			conf.Log.Errorf("Fail to import stream %s(%s) with error: %v", k, v, e)
+			conf.Log.Warnf("Fail to import stream %s with error: %v", k, e)
 		} else {
 			counts[0]++
 		}
@@ -123,7 +123,7 @@ func (rs *RulesetProcessor) Import(content []byte) ([]string, []int, error) {
 	for k, v := range all.Tables {
 		_, e := rs.s.ExecStreamSql(v)
 		if e != nil {
-			conf.Log.Errorf("Fail to import table %s(%s) with error: %v", k, v, e)
+			conf.Log.Warnf("Fail to import table %s with error: %v", k, e)
 		} else {
 			counts[1]++
 		}
@@ -133,7 +133,7 @@ func (rs *RulesetProcessor) Import(content []byte) ([]string, []int, error) {
 	for k, v := range all.Rules {
 		_, e := rs.r.ExecCreateWithValidation(k, v)
 		if e != nil {
-			conf.Log.Errorf("Fail to import rule %s(%s) with error: %v", k, v, e)
+			conf.Log.Warnf("Fail to import rule %s with error: %v", k, e)
 		} else {
 			rules = append(rules, k)
 			counts[2]++

--- a/internal/server/import_export.go
+++ b/internal/server/import_export.go
@@ -1,4 +1,4 @@
-// Copyright 2024 EMQ Technologies Co., Ltd.
+// Copyright 2024-2025 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -613,21 +613,10 @@ func importRuleSetPartial(all processor.Ruleset) processor.Ruleset {
 	}
 
 	for k, v := range all.Rules {
-		_, err := ruleProcessor.GetRuleJson(k)
-		if err == nil {
-			// the rule already exist, update
-			err = registry.UpdateRule(k, v)
-			if err != nil {
-				ruleSetRsp.Rules[k] = err.Error()
-				continue
-			}
-		} else {
-			// not found, create
-			_, err2 := registry.CreateRule(k, v)
-			if err2 != nil {
-				ruleSetRsp.Rules[k] = err2.Error()
-				continue
-			}
+		err := registry.UpsertRule(k, v)
+		if err != nil {
+			ruleSetRsp.Rules[k] = err.Error()
+			continue
 		}
 	}
 

--- a/internal/server/rest.go
+++ b/internal/server/rest.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2024 EMQ Technologies Co., Ltd.
+// Copyright 2021-2025 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -719,18 +719,12 @@ func ruleHandler(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = fmt.Fprintf(w, "Rule %s is dropped.", name)
 	case http.MethodPut:
-		_, err := ruleProcessor.GetRuleById(name)
-		if err != nil {
-			handleError(w, err, "Rule not found", logger)
-			return
-		}
-
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			handleError(w, err, "Invalid body", logger)
 			return
 		}
-		err = registry.UpdateRule(name, string(body))
+		err = registry.UpsertRule(name, string(body))
 		if err != nil {
 			handleError(w, err, "Update rule error", logger)
 			return

--- a/internal/server/rule_manager_test.go
+++ b/internal/server/rule_manager_test.go
@@ -25,11 +25,10 @@ import (
 
 func TestErrors(t *testing.T) {
 	// update invalid rule
-	err := registry.UpdateRule("test", "selectabc")
+	err := registry.UpsertRule("test", "selectabc")
 	assert.EqualError(t, err, "Invalid rule json: Parse rule selectabc error : invalid character 's' looking for beginning of value.")
-	// update rule, no id
-	err = registry.UpdateRule("test", `{"id":"test","sql":"SELECT * FROM demo","actions":[{"log":{}}]}`)
-	assert.EqualError(t, err, "Rule test is not found in registry, please check if it is created")
+	err = registry.UpsertRule("test", `{"id":"test","sql":"SELECT * FROM demo","actions":[{"log":{}}]}`)
+	assert.EqualError(t, err, "fail to get stream demo, please check if stream is created")
 	// delete rule, no id
 	err = registry.DeleteRule("test")
 	assert.EqualError(t, err, "rule test not found")


### PR DESCRIPTION
- Rule add version property
- Rule update API now do upsert (breaking change)
- Rule update (both update API and partial import API) will check version, only do update when version is newer
- init.json can use to migrate rules preset, also check version for preset migration