### PR TITLE
refactor(server): do not catch fatal sigs

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -296,7 +296,7 @@ func StartUp(Version string) {
 
 	// Stop the services
 	sigint := make(chan os.Signal, 1)
-	signal.Notify(sigint, syscall.SIGTERM, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGHUP, syscall.SIGABRT, syscall.SIGILL, syscall.SIGTRAP, syscall.SIGSEGV)
+	signal.Notify(sigint, os.Interrupt, syscall.SIGTERM)
 	select {
 	case ss := <-sigint:
 		conf.Log.Infof("eKuiper stopped by %v", ss)


### PR DESCRIPTION
Removed an unnecessary nil check for the channel reference in the Close method. Simplifies the code logic while maintaining its intended functionality.