### PR TITLE
feat(metrics): support rule cpu usage counter

### DIFF
--- a/etc/kuiper.yaml
+++ b/etc/kuiper.yaml
@@ -68,8 +68,10 @@ basic:
   gracefulShutdownTimeout: 3s
   connection:
     backoffMaxElapsedDuration: 3m
-  # enableResourceProfiling indicates whether to enable resource profiling for eKuiper. If it is enabled, the cpu usage of the rule will be recorded.
-  enableResourceProfiling: false
+  # If it is enabled, the cpu time of the rule will be recorded.
+  ResourceProfileConfig:
+    enable: false
+    interval: 5s
   metricsDumpConfig:
     enable: false
     retainedDuration: 6h

--- a/internal/server/pprof_init.go
+++ b/internal/server/pprof_init.go
@@ -38,7 +38,7 @@ func (p pprofComp) serve() {
 	if conf.Config.Basic.Pprof {
 		go func() {
 			addr := cast.JoinHostPortInt(conf.Config.Basic.PprofIp, conf.Config.Basic.PprofPort)
-			if conf.Config.Basic.EnableResourceProfiling {
+			if conf.Config.Basic.ResourceProfileConfig.Enable {
 				cpuprofile.WebProfile(addr)
 				return
 			}

--- a/internal/server/rest.go
+++ b/internal/server/rest.go
@@ -1024,7 +1024,7 @@ func testRuleStopHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func rulesTopCpuUsageHandler(w http.ResponseWriter, r *http.Request) {
-	if !conf.Config.Basic.EnableResourceProfiling {
+	if !conf.Config.Basic.ResourceProfileConfig.Enable {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("cpu usage not enabled"))
 		return

--- a/internal/server/rule_init.go
+++ b/internal/server/rule_init.go
@@ -327,10 +327,10 @@ func (e *ekuiperProfile) RegisterTag(tag string, receiveChan chan *cpuprofile.Da
 	cpuprofile.RegisterTag(tag, receiveChan)
 }
 
-func StartCPUProfiling(ctx context.Context, cpuProfile Profiler) error {
+func StartCPUProfiling(ctx context.Context, cpuProfile Profiler, interval time.Duration) error {
 	recvCh := make(chan *cpuprofile.DataSetAggregate)
 	cpuProfile.RegisterTag("rule", recvCh)
-	if err := cpuProfile.StartCPUProfiler(ctx, time.Second); err != nil {
+	if err := cpuProfile.StartCPUProfiler(ctx, interval); err != nil {
 		return err
 	}
 	go func(ctx context.Context) {

--- a/internal/server/rule_init.go
+++ b/internal/server/rule_init.go
@@ -306,6 +306,7 @@ type Profiler interface {
 	StartCPUProfiler(context.Context, time.Duration) error
 	EnableWindowAggregator(int)
 	GetWindowData() cpuprofile.DataSetAggregateMap
+	RegisterTag(string, chan *cpuprofile.DataSetAggregate)
 }
 
 type ekuiperProfile struct{}
@@ -322,31 +323,27 @@ func (e *ekuiperProfile) GetWindowData() cpuprofile.DataSetAggregateMap {
 	return cpuprofile.GetWindowData()
 }
 
+func (e *ekuiperProfile) RegisterTag(tag string, receiveChan chan *cpuprofile.DataSetAggregate) {
+	cpuprofile.RegisterTag(tag, receiveChan)
+}
+
 func StartCPUProfiling(ctx context.Context, cpuProfile Profiler) error {
-	cpuProfile.EnableWindowAggregator(30)
-	if err := cpuProfile.StartCPUProfiler(ctx, 1000*time.Millisecond); err != nil {
+	recvCh := make(chan *cpuprofile.DataSetAggregate)
+	cpuProfile.RegisterTag("rule", recvCh)
+	if err := cpuProfile.StartCPUProfiler(ctx, time.Second); err != nil {
 		return err
 	}
 	go func(ctx context.Context) {
-		ticker := time.NewTicker(15 * time.Second)
-		defer ticker.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case <-ticker.C:
-				if conf.Config.Basic.Prometheus {
-					data := cpuProfile.GetWindowData()
-					if data == nil {
-						continue
-					}
-					ruleUsage, ok := data["rule"]
-					if !ok {
-						continue
-					}
-					for labelValue, t := range ruleUsage.Stats {
-						metrics.SetRuleCPUUsageGauge(labelValue, t)
-					}
+			case dataset := <-recvCh:
+				if dataset == nil {
+					return
+				}
+				for ruleID, cpuTimeMs := range dataset.Stats {
+					metrics.AddRuleCPUTime(ruleID, float64(cpuTimeMs)/1000)
 				}
 			}
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -169,8 +169,8 @@ func StartUp(Version string) {
 	}
 
 	serverCtx, serverCancel := context.WithCancel(context.Background())
-	if conf.Config.Basic.EnableResourceProfiling {
-		err := StartCPUProfiling(serverCtx, cpuProfiler)
+	if conf.Config.Basic.ResourceProfileConfig.Enable {
+		err := StartCPUProfiling(serverCtx, cpuProfiler, conf.Config.Basic.ResourceProfileConfig.Interval)
 		conf.Log.Warn(err)
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -249,7 +249,7 @@ func TestStartCPUProfiling(t *testing.T) {
 	}
 
 	profiler := &testProfile{}
-	err := StartCPUProfiling(ctx, profiler)
+	err := StartCPUProfiling(ctx, profiler, time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/topo/context/default.go
+++ b/internal/topo/context/default.go
@@ -71,7 +71,7 @@ type DefaultContext struct {
 }
 
 func RuleBackground(ruleName string) *DefaultContext {
-	if !conf.Config.Basic.EnableResourceProfiling {
+	if !conf.Config.Basic.ResourceProfileConfig.Enable {
 		return Background()
 	}
 	ctx := pprof.WithLabels(context.Background(), pprof.Labels("rule", ruleName))

--- a/internal/topo/context/default_test.go
+++ b/internal/topo/context/default_test.go
@@ -273,7 +273,7 @@ func TestParseTemplate(t *testing.T) {
 
 func TestRuleBackground(t *testing.T) {
 	conf.InitConf()
-	conf.Config.Basic.EnableResourceProfiling = true
+	conf.Config.Basic.ResourceProfileConfig.Enable = true
 	c := RuleBackground("test")
 	ctx := pprof.WithLabels(context.Background(), pprof.Labels("rule", "test"))
 	assert.Equal(t, c.ctx, ctx)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -53,11 +53,11 @@ var (
 		Help:      "gauge of rule status",
 	}, []string{LblRuleIDType})
 
-	RuleCPUUsageGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+	RuleCPUTimeCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "kuiper",
 		Subsystem: "rule",
-		Name:      "cpu_ms",
-		Help:      "gauge of rule CPU usage",
+		Name:      "cpu_time_seconds_total",
+		Help:      "Total accumulated CPU time (in seconds) used by each rule",
 	}, []string{LblRuleIDType})
 )
 
@@ -65,7 +65,7 @@ func init() {
 	RegisterSyncCache()
 	prometheus.MustRegister(RuleStatusCountGauge)
 	prometheus.MustRegister(RuleStatusGauge)
-	prometheus.MustRegister(RuleCPUUsageGauge)
+	prometheus.MustRegister(RuleCPUTimeCounter)
 }
 
 func SetRuleStatusCountGauge(isRunning bool, count int) {
@@ -85,6 +85,6 @@ func RemoveRuleStatus(ruleID string) {
 	RuleStatusGauge.DeleteLabelValues(ruleID)
 }
 
-func SetRuleCPUUsageGauge(ruleID string, value int) {
-	RuleCPUUsageGauge.WithLabelValues(ruleID).Set(float64(value))
+func AddRuleCPUTime(ruleID string, seconds float64) {
+	RuleCPUTimeCounter.WithLabelValues(ruleID).Add(seconds)
 }

--- a/pkg/model/conf.go
+++ b/pkg/model/conf.go
@@ -30,37 +30,37 @@ type KuiperConf struct {
 		Cold bool `yaml:"cold"`
 	}
 	Basic struct {
-		LogLevel                string            `yaml:"logLevel"`
-		Debug                   bool              `yaml:"debug"`
-		ConsoleLog              bool              `yaml:"consoleLog"`
-		FileLog                 bool              `yaml:"fileLog"`
-		LogDisableTimestamp     bool              `yaml:"logDisableTimestamp"`
-		Syslog                  *SyslogConf       `yaml:"syslog"`
-		RotateTime              int               `yaml:"rotateTime"`
-		MaxAge                  int               `yaml:"maxAge"`
-		RotateSize              int64             `yaml:"rotateSize"`
-		RotateCount             int               `yaml:"rotateCount"`
-		TimeZone                string            `yaml:"timezone"`
-		Ip                      string            `yaml:"ip"`
-		Port                    int               `yaml:"port"`
-		RestIp                  string            `yaml:"restIp"`
-		RestPort                int               `yaml:"restPort"`
-		RestTls                 *TlsConf          `yaml:"restTls"`
-		Prometheus              bool              `yaml:"prometheus"`
-		PrometheusPort          int               `yaml:"prometheusPort"`
-		Pprof                   bool              `yaml:"pprof"`
-		PprofIp                 string            `yaml:"pprofIp"`
-		PprofPort               int               `yaml:"pprofPort"`
-		PluginHosts             string            `yaml:"pluginHosts"`
-		Authentication          bool              `yaml:"authentication"`
-		IgnoreCase              bool              `yaml:"ignoreCase"`
-		SQLConf                 *SQLConf          `yaml:"sql"`
-		RulePatrolInterval      cast.DurationConf `yaml:"rulePatrolInterval"`
-		EnableOpenZiti          bool              `yaml:"enableOpenZiti"`
-		AesKey                  string            `yaml:"aesKey"`
-		GracefulShutdownTimeout cast.DurationConf `yaml:"gracefulShutdownTimeout"`
-		EnableResourceProfiling bool              `yaml:"enableResourceProfiling"`
-		MetricsDumpConfig       MetricsDumpConfig `yaml:"metricsDumpConfig"`
+		LogLevel                string                `yaml:"logLevel"`
+		Debug                   bool                  `yaml:"debug"`
+		ConsoleLog              bool                  `yaml:"consoleLog"`
+		FileLog                 bool                  `yaml:"fileLog"`
+		LogDisableTimestamp     bool                  `yaml:"logDisableTimestamp"`
+		Syslog                  *SyslogConf           `yaml:"syslog"`
+		RotateTime              int                   `yaml:"rotateTime"`
+		MaxAge                  int                   `yaml:"maxAge"`
+		RotateSize              int64                 `yaml:"rotateSize"`
+		RotateCount             int                   `yaml:"rotateCount"`
+		TimeZone                string                `yaml:"timezone"`
+		Ip                      string                `yaml:"ip"`
+		Port                    int                   `yaml:"port"`
+		RestIp                  string                `yaml:"restIp"`
+		RestPort                int                   `yaml:"restPort"`
+		RestTls                 *TlsConf              `yaml:"restTls"`
+		Prometheus              bool                  `yaml:"prometheus"`
+		PrometheusPort          int                   `yaml:"prometheusPort"`
+		Pprof                   bool                  `yaml:"pprof"`
+		PprofIp                 string                `yaml:"pprofIp"`
+		PprofPort               int                   `yaml:"pprofPort"`
+		PluginHosts             string                `yaml:"pluginHosts"`
+		Authentication          bool                  `yaml:"authentication"`
+		IgnoreCase              bool                  `yaml:"ignoreCase"`
+		SQLConf                 *SQLConf              `yaml:"sql"`
+		RulePatrolInterval      cast.DurationConf     `yaml:"rulePatrolInterval"`
+		EnableOpenZiti          bool                  `yaml:"enableOpenZiti"`
+		AesKey                  string                `yaml:"aesKey"`
+		GracefulShutdownTimeout cast.DurationConf     `yaml:"gracefulShutdownTimeout"`
+		ResourceProfileConfig   ResourceProfileConfig `yaml:"ResourceProfileConfig"`
+		MetricsDumpConfig       MetricsDumpConfig     `yaml:"metricsDumpConfig"`
 	}
 	Rule   def.RuleOption
 	Sink   *SinkConf
@@ -214,6 +214,11 @@ func (s *SyslogConf) Validate() error {
 type MetricsDumpConfig struct {
 	Enable           bool          `yaml:"enable"`
 	RetainedDuration time.Duration `yaml:"retainedDuration"`
+}
+
+type ResourceProfileConfig struct {
+	Enable   bool          `yaml:"enable"`
+	Interval time.Duration `yaml:"interval"`
 }
 
 type OpenTelemetry struct {


### PR DESCRIPTION
Replaced the `rule_cpu_usage` gauge metric with a new counter metric `rule_cpu_time_seconds_total`, which accumulates total CPU time per rule.
This enables Prometheus to use functions like increase() to calculate the processing time of each rule over a recent period, and to easily compute the CPU usage share of each rule.

Run ekuiper and use [test tool](https://github.com/Yisaer/kuiper-nexmark-test) as shown below:

![image](https://github.com/user-attachments/assets/dd10bc91-dbeb-40d5-8ffe-df300ac57f22)

You can observe rule_cpu_time_seconds_total in prometheus as shown below:

![image](https://github.com/user-attachments/assets/43346731-e333-4ac2-bc8e-d72b1829b78f)

The CPU usage time of each rule within the first 30 seconds as shown below:
![image](https://github.com/user-attachments/assets/17f35531-d78c-44cf-b99f-39a6f52abe7d)
