### PR TITLE
fix(kv): prepare ts query

### DIFF
--- a/internal/pkg/store/sql/sqlTs.go
+++ b/internal/pkg/store/sql/sqlTs.go
@@ -39,12 +39,12 @@ func createSqlTs(database Database, table string) (*ts, error) {
 		last:     getLast(database, table),
 	}
 	err := store.database.Apply(func(db *sql.DB) error {
-		query := fmt.Sprintf("CREATE TABLE IF NOT EXISTS '%s'('key' INTEGER PRIMARY KEY, 'val' BLOB);", table)
+		query := fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s ('key' INTEGER PRIMARY KEY, 'val' BLOB);", table)
 		stmt, err := db.Prepare(query)
 		if err != nil {
 			return err
 		}
-		_, err = stmt.Exec(query)
+		_, err = stmt.Exec()
 		return err
 	})
 	if err != nil {
@@ -158,13 +158,16 @@ func (t ts) Drop() error {
 
 func getLast(d Database, table string) int64 {
 	var last int64 = 0
+	if !isValidTableName(table) {
+		return 0 // or handle the error appropriately
+	}
 	_ = d.Apply(func(db *sql.DB) error {
-		query := fmt.Sprintf("SELECT key FROM %s Order by key DESC Limit 1;", table)
+		query := fmt.Sprintf("SELECT key FROM %s ORDER BY key DESC LIMIT 1;", table)
 		stmt, err := db.Prepare(query)
 		if err != nil {
 			return err
 		}
-		row := stmt.QueryRow(query)
+		row := stmt.QueryRow()
 		return row.Scan(&last)
 	})
 	return last


### PR DESCRIPTION
https://github.com/lf-edge/ekuiper/blob/163809ee5191827223759fd820883a361ba3d274/internal/pkg/store/sql/sqlTs.go#L163-L163

fix the issue, the SQL query should be constructed using parameterized queries or prepared statements. However, since SQL drivers typically do not allow parameterized table names, the `table` parameter must be validated explicitly to ensure it contains only safe characters (e.g., alphanumeric characters and underscores). This validation should be implemented in the `isValidTableName` function. additionally, the `getLast` function should avoid constructing the query string dynamically. Instead, it should use a safe and validated table name.

If a database query (such as an SQL or NoSQL query) is built from user-provided data without sufficient sanitization, a malicious user may be able to run commands that exfiltrate, tamper with, or destroy data stored in the database.