### PR TITLE
fix(planner): strict share conn

### DIFF
--- a/internal/io/mqtt/source.go
+++ b/internal/io/mqtt/source.go
@@ -143,6 +143,19 @@ func GetSource() api.Source {
 	return &SourceConnector{}
 }
 
+// SubId the mqtt connection can only sub to a topic once
+func (ms *SourceConnector) SubId(props map[string]any) string {
+	tpc, ok := props["datasource"]
+	if !ok {
+		return ""
+	}
+	topic, ok := tpc.(string)
+	if !ok {
+		return ""
+	}
+	return topic
+}
+
 var (
 	_ api.BytesSource   = &SourceConnector{}
 	_ api.Bounded       = &SourceConnector{}

--- a/internal/topo/planner/planner_source_test.go
+++ b/internal/topo/planner/planner_source_test.go
@@ -208,9 +208,9 @@ func TestPlanTopo(t *testing.T) {
 			name: "testSharedConnSplit",
 			sql:  `SELECT * FROM src3`,
 			topo: &def.PrintableTopo{
-				Sources: []string{"source_mqtt.localConnection/topic1testSharedConnSplit"},
+				Sources: []string{"source_mqtt.localConnection/topic1"},
 				Edges: map[string][]any{
-					"source_mqtt.localConnection/topic1testSharedConnSplit": {
+					"source_mqtt.localConnection/topic1": {
 						"op_2_emitter",
 					},
 					"op_2_emitter": {
@@ -340,12 +340,12 @@ func TestPlanTopo(t *testing.T) {
 			},
 		},
 		{
-			name: "testmqttmerger",
+			name: "test mqtt merger",
 			sql:  `SELECT * FROM src5`,
 			topo: &def.PrintableTopo{
-				Sources: []string{"source_mqtt.localConnection/topic1testmqttmerger"},
+				Sources: []string{"source_mqtt.localConnection/topic1"},
 				Edges: map[string][]any{
-					"source_mqtt.localConnection/topic1testmqttmerger": {
+					"source_mqtt.localConnection/topic1": {
 						"op_2_emitter",
 					},
 					"op_2_emitter": {
@@ -373,9 +373,9 @@ func TestPlanTopo(t *testing.T) {
 			name: "testNngConnSplit",
 			sql:  `SELECT * FROM neuron1`,
 			topo: &def.PrintableTopo{
-				Sources: []string{"source_nng:pairtcp://127.0.0.1:7777/singletontestNngConnSplit"},
+				Sources: []string{"source_nng:pairtcp://127.0.0.1:7777/singleton"},
 				Edges: map[string][]any{
-					"source_nng:pairtcp://127.0.0.1:7777/singletontestNngConnSplit": {
+					"source_nng:pairtcp://127.0.0.1:7777/singleton": {
 						"op_2_emitter",
 					},
 					"op_2_emitter": {


### PR DESCRIPTION
Only share conn if it must, like neuron stream