### PR TITLE
fix gob not register map[string]time.Time{} bug

### DIFF
--- a/internal/topo/node/window_op.go
+++ b/internal/topo/node/window_op.go
@@ -88,6 +88,7 @@ const (
 func init() {
 	gob.Register([]xsql.EventRow{})
 	gob.Register([]map[string]interface{}{})
+	gob.Register(map[string]time.Time{})
 }
 
 func NewWindowOp(name string, w WindowConfig, options *def.RuleOption) (*WindowOperator, error) {


### PR DESCRIPTION
fix gob not register map[string]time.Time{} bug , when use event time.