### PR TITLE
fix(kv): arbitrary file access during archive extraction internal service

### DIFF
--- a/internal/pkg/filex/zip.go
+++ b/internal/pkg/filex/zip.go
@@ -32,6 +32,21 @@ func UnzipTo(f *zip.File, folder, name string) (err error) {
 		})
 	}()
 	fpath := filepath.Join(folder, name)
+	absFolder, err := filepath.Abs(folder)
+	if err != nil {
+		return err
+	}
+	absFpath, err := filepath.Abs(fpath)
+	if err != nil {
+		return err
+	}
+	rel, err := filepath.Rel(absFolder, absFpath)
+	if err != nil {
+		return err
+	}
+	if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || rel == ".." {
+		return errors.New("zip slip: illegal file path detected: " + name)
+	}
 	_, err = os.Stat(fpath)
 
 	if f.FileInfo().IsDir() {


### PR DESCRIPTION
https://github.com/lf-edge/ekuiper/blob/a191c3231f82ea79adf126c51bbd1359f5d0dec4/internal/service/manager.go#L454-L459


https://github.com/lf-edge/ekuiper/blob/a191c3231f82ea79adf126c51bbd1359f5d0dec4/internal/plugin/portable/manager.go#L360-L388


Extracting files from a malicious zip file, or similar type of archive, is at risk of directory traversal attacks if filenames from the archive are not properly validated. archive paths. zip archives contain archive entries representing each file in the archive. These entries include a file path for the entry, but these file paths are not restricted and may contain unexpected special elements such as the directory traversal element (..). If these file paths are used to create a filesystem path, then a file operation may happen in an unexpected location. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.

---

fix this vulnerability, we need to ensure that the paths derived from zip archive entries do not allow files to be written outside the intended extraction directory. The best way to do this is to check that the cleaned, joined path is still within the target directory after joining, and to reject any entry that would escape the target directory. This can be done by:

- After joining the extraction folder and the entry name, use `filepath.Clean` and `filepath.Abs` to get the absolute path of the target file.
- Use `filepath.Abs` on the extraction folder as well.
- Check that the resulting file path has the extraction folder as its prefix (using `strings.HasPrefix` or `filepath.Rel` to ensure the file is within the intended directory).
- If the check fails, skip extraction and return an error.
- For each file entry, compute the absolute path where it would be extracted.
- Ensure that this path is within the intended destination directory (i.e., the path after joining and cleaning does not escape the base directory).
- Skip or reject any file whose extraction path would escape the destination directory.

This check should be implemented in the `filex.UnzipTo` function in `internal/pkg/filex/zip.go`, since this is the function that actually writes files to disk. This ensures that all calls to `UnzipTo` are protected, regardless of where they originate. The fix should be implemented in `internal/service/manager.go` within the `unzip` method, by adding a check before calling `filex.UnzipTo`. We can use `filepath.Join` and `filepath.Clean` to compute the extraction path, and then verify that it has the intended directory as its prefix. If the check fails, we should return an error or skip the file.


