### PR TITLE
fix(schema): compatible with path schema id

### DIFF
--- a/internal/converter/ext_mock_test.go
+++ b/internal/converter/ext_mock_test.go
@@ -60,7 +60,7 @@ func TestGetConverter(t *testing.T) {
 	require.NoError(t, err)
 	ctx := mockContext.NewMockContext("test", "op1")
 	_, err = GetOrCreateConverter(ctx, "mock", "a.b", nil, map[string]any{})
-	require.EqualError(t, err, "schema type protobuf, file a not found")
+	require.NoError(t, err)
 	_, err = GetOrCreateConverter(ctx, "mock", "a.b.c.d", nil, map[string]any{})
-	require.EqualError(t, err, "schema type protobuf, file a not found")
+	require.NoError(t, err)
 }

--- a/internal/schema/registry.go
+++ b/internal/schema/registry.go
@@ -240,6 +240,7 @@ func GetSchema(schemaType string, name string) (*Info, error) {
 	}
 }
 
+// GetSchemaFile return main schema file if schema id is defined; otherwise return the original schema id (possibly the file path)
 func GetSchemaFile(schemaType string, name string) (*modules.Files, error) {
 	registry.RLock()
 	defer registry.RUnlock()
@@ -247,7 +248,8 @@ func GetSchemaFile(schemaType string, name string) (*modules.Files, error) {
 		return nil, fmt.Errorf("schema type %s not found in registry", schemaType)
 	}
 	if _, ok := registry.schemas[schemaType][name]; !ok {
-		return nil, fmt.Errorf("schema type %s, file %s not found", schemaType, name)
+		// If schema id is not defined, just return as is
+		return &modules.Files{SchemaFile: name}, nil
 	}
 	schemaFile := registry.schemas[schemaType][name]
 	return schemaFile, nil


### PR DESCRIPTION
User should use pre-defined schema id. For backward compatibility, we still support path as schema id.