### PR TITLE
feat(schema): allow any type

### DIFF
--- a/pkg/ast/sourceStmt.go
+++ b/pkg/ast/sourceStmt.go
@@ -129,8 +129,8 @@ func convertFieldType(sf FieldType) *JsonStreamField {
 			Type:       "struct",
 			Properties: convertSchema(t.StreamFields),
 		}
-	default: // should never happen
-		return nil
+	default:
+		return &JsonStreamField{}
 	}
 }
 

--- a/pkg/ast/sourceStmt_test.go
+++ b/pkg/ast/sourceStmt_test.go
@@ -72,11 +72,13 @@ func TestToJsonFields(t *testing.T) {
 		{
 			input: StreamFields{
 				{Name: "STREET_NAME", FieldType: &BasicType{Type: STRINGS}},
+				{Name: "Any_Val"},
 			},
 			output: map[string]*JsonStreamField{
 				"STREET_NAME": {
 					Type: "string",
 				},
+				"Any_Val": {},
 			},
 		}, {
 			input: []StreamField{


### PR DESCRIPTION
Allow to not specify type in the external schema. Because some schema does not have type information