### PR TITLE
fix(schema): enable schema init

### DIFF
--- a/internal/server/schema_init.go
+++ b/internal/server/schema_init.go
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build schema || !core
-
 package server
 
 import (


### PR DESCRIPTION
Because analyzer and planner now depends on external schema. Only hide protobuf schema by default