### PR TITLE
feat: add monitoring for kafka message metadata

### DIFF
--- a/extensions/impl/kafka/metrics.go
+++ b/extensions/impl/kafka/metrics.go
@@ -51,8 +51,8 @@ var (
 		Namespace: "kuiper",
 		Subsystem: "kafka_source",
 		Name:      "messages_counter",
-		Help:      "Kafka messages processed per rule, labeled by topic, partition, key and headers",
-	}, []string{LblTopic, LblPartition, LblKey, LblHeaders, metrics.LblRuleIDType, metrics.LblOpIDType})
+		Help:      "Kafka messages processed per rule, labeled by topic and partition",
+	}, []string{LblTopic, LblPartition, metrics.LblRuleIDType, metrics.LblOpIDType})
 
 	KafkaSourceGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "kuiper",

--- a/extensions/impl/kafka/sink.go
+++ b/extensions/impl/kafka/sink.go
@@ -48,8 +48,6 @@ const (
 	LblBytes     = "bytes"
 	LblOffset    = "offset"
 	LblTopic     = "topic"
-	LblKey       = "key"
-	LblHeaders   = "headers"
 	LblPartition = "partition"
 )
 

--- a/extensions/impl/kafka/source.go
+++ b/extensions/impl/kafka/source.go
@@ -15,7 +15,6 @@
 package kafka
 
 import (
-	"bytes"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -217,45 +216,8 @@ func (k *KafkaSource) Subscribe(ctx api.StreamContext, ingest api.BytesIngest, i
 		KafkaSourceCounter.WithLabelValues(LblBytes, ctx.GetRuleId(), ctx.GetOpId()).Add(float64(len(msg.Value)))
 		KafkaSourceCounter.WithLabelValues(LblPartition, ctx.GetRuleId(), ctx.GetOpId()).Inc()
 		KafkaSourceGauge.WithLabelValues(LblOffset, ctx.GetRuleId(), ctx.GetOpId()).Set(float64(msg.Offset))
-		k.pushMsgMetadataToMonitoring(ctx, msg.Key, msg.Topic, msg.Headers, msg.Partition)
+		KafkaSourceMessageCounter.WithLabelValues(msg.Topic, strconv.Itoa(msg.Partition), ctx.GetRuleId(), ctx.GetOpId()).Inc()
 		ingest(ctx, msg.Value, nil, timex.GetNow())
-	}
-}
-
-func (k *KafkaSource) pushMsgMetadataToMonitoring(
-	ctx api.StreamContext,
-	key []byte,
-	topic string,
-	headers []kafkago.Header,
-	partition int,
-) {
-	var (
-		buf          = bytes.NewBuffer(key)
-		convertedKey = buf.String()
-	)
-
-	if len(headers) == 0 {
-		KafkaSourceMessageCounter.WithLabelValues(
-			topic,
-			strconv.Itoa(partition),
-			convertedKey,
-			"none",
-			ctx.GetRuleId(),
-			ctx.GetOpId(),
-		).Inc()
-		return
-	}
-
-	for _, header := range headers {
-		joinedHeader := fmt.Sprintf("%s:%s", header.Key, header.Value)
-		KafkaSourceMessageCounter.WithLabelValues(
-			topic,
-			strconv.Itoa(partition),
-			convertedKey,
-			joinedHeader,
-			ctx.GetRuleId(),
-			ctx.GetOpId(),
-		).Inc()
 	}
 }
 


### PR DESCRIPTION
This PR introduces monitoring for Kafka message metadata to improve observability 
and traceability of message processing.

Related Issue: #3491 