### PR TITLE
fix(util): safe unzip

### DIFF
--- a/internal/plugin/native/manager.go
+++ b/internal/plugin/native/manager.go
@@ -48,6 +48,32 @@ import (
 	"github.com/lf-edge/ekuiper/v2/pkg/kv"
 )
 
+// isSafeArchiveEntry checks if the entry name is safe for extraction
+func isSafeArchiveEntry(name string) bool {
+	// Disallow absolute paths
+	if strings.HasPrefix(name, "/") || strings.HasPrefix(name, "\\") {
+		return false
+	}
+	// Disallow parent traversal
+	parts := strings.Split(name, "/")
+	for _, p := range parts {
+		if p == ".." {
+			return false
+		}
+	}
+	parts = strings.Split(name, "\\")
+	for _, p := range parts {
+		if p == ".." {
+			return false
+		}
+	}
+	// Prevent special device files (on Windows)
+	if strings.HasPrefix(name, "CON") || strings.HasPrefix(name, "PRN") || strings.HasPrefix(name, "AUX") || strings.HasPrefix(name, "NUL") {
+		return false
+	}
+	return true
+}
+
 // Manager Initialized in the binder
 var (
 	manager *Manager
@@ -536,6 +562,11 @@ func (rr *Manager) install(t plugin2.PluginType, name, src string, shellParas []
 	for _, file := range r.File {
 		zipFiles = append(zipFiles, file.Name)
 		fileName := file.Name
+		// Prevent Zip Slip: only allow safe archive entries
+		if !isSafeArchiveEntry(fileName) {
+			conf.Log.Errorf("Refuse to extract potentially unsafe archive entry: %s", fileName)
+			continue
+		}
 		switch {
 		case yamlFile == fileName:
 			yamlFileChecked = true


### PR DESCRIPTION
Potential fix for [https://github.com/lf-edge/ekuiper/security/code-scanning/56](https://github.com/lf-edge/ekuiper/security/code-scanning/56)

To fix this issue, sanitize and validate each zip archive entry name before using it in any filesystem operation. Specifically, check entry names for any components with directory traversal (`..`), absolute paths, or path separators that could escape the extraction target directory. You can do this by (1) ensuring that `file.Name` does not contain "`..`" components and does not begin with a forward slash or backslash, and (2) creating its absolute path, then verifying that it still resides within the intended target directory after joining and resolving. The best practice is to add a check at the start of the loop (or before each extraction/file operation) and skip or refuse to extract any suspicious entries. 

You need to: 
- Add a method to sanitize/check archive entry names.
- Check each `file.Name` before extraction or any operation (including adding to `revokeFiles`).
- Only allow paths that do not escape the intended extraction directory.
- If entries are skipped, log or handle them as suspicious.
- This fix should go just before any usage of `file.Name` for file operations in the loop in internal/plugin/native/manager.go.
- You may need to import `"path/filepath"` and `"strings"` (already imported).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
