### PR TITLE
docs: fix conf api example

### DIFF
--- a/docs/en_US/api/restapi/configKey.md
+++ b/docs/en_US/api/restapi/configKey.md
@@ -85,11 +85,9 @@ PUT http://localhost:9081/metadata/sources/{name}/confKeys/{confKey}
 Register the Config Key named demo_conf under the MQTT source
 
 ```shell
- curl -X PUT http://localhost:9081/metadata/sources/mqtt/confKeys/demo_conf
- {
-   "demo_conf": {
+ curl -X PUT http://localhost:9081/metadata/sources/mqtt/confKeys/demo_conf \
+    -d '{
         "qos": 0,
         "server": "tcp://10.211.55.6:1883"
-    }
- }
+    }'
 ```

--- a/docs/zh_CN/api/restapi/configKey.md
+++ b/docs/zh_CN/api/restapi/configKey.md
@@ -84,11 +84,9 @@ PUT http://localhost:9081/metadata/sources/{name}/confKeys/{confKey}
 在 MQTT 源下注册名为 demo_conf 的 Config Key
 
 ```shell
- curl -X PUT http://localhost:9081/metadata/sources/mqtt/confKeys/demo_conf
- {
-   "demo_conf": {
+ curl -X PUT http://localhost:9081/metadata/sources/mqtt/confKeys/demo_conf \
+    -d '{
         "qos": 0,
         "server": "tcp://10.211.55.6:1883"
-    }
- }
+    }'
 ```


### PR DESCRIPTION
Previous example led to parsing error. This commit fixes the curl http put request, letting the user simply copy and paste it to create a demo configuration key.