### PR TITLE
feat: add DEFAULT clause

### DIFF
--- a/docs/en_US/guide/streams/overview.md
+++ b/docs/en_US/guide/streams/overview.md
@@ -41,6 +41,8 @@ Below is the list of data types supported.
 | 7   | array     | The array type, can be any simple types or array and type.                                                                |
 | 8   | struct    | The complex type.                                 |
 
+eKuiper allows inserting a default clause next to a type definition. The DEFAULT clause allows the engine to insert a default value in absence of the field. This check is done only if strict validation is activated. The DEFAULT clause supports only the following types: STRING, BOOLEAN, FLOAT and BIGINT.
+
 ### Stream Properties
 
 | Property name    | Optional | Description                                                                                                                                                                                                                                 |
@@ -236,4 +238,15 @@ please refer to the [Versioning Logic](../../guide/rules/overview.md#versioning-
 ```sql
 version_stream
 () WITH ( datasource = "topic", FORMAT = "json", VERSION = "1756436910");
+```
+
+### Creating a stream with DEFAULT fields
+
+```sql
+CREATE STREAM demo (
+    temperature FLOAT DEFAULT 12.0,
+    status STRING DEFAULT "unknown",
+    active BOOLEAN DEFAULT false,
+    user_id BIGINT DEFAULT 2
+) WITH (DATASOURCE="sensor/data", FORMAT="JSON", StrictValidation="true");
 ```

--- a/docs/en_US/guide/streams/overview.md
+++ b/docs/en_US/guide/streams/overview.md
@@ -248,5 +248,5 @@ CREATE STREAM demo (
     status STRING DEFAULT "unknown",
     active BOOLEAN DEFAULT false,
     user_id BIGINT DEFAULT 2
-) WITH (DATASOURCE="sensor/data", FORMAT="JSON", StrictValidation="true");
+) WITH (DATASOURCE="sensor/data", FORMAT="JSON", STRICT_VALIDATION="true");
 ```

--- a/fvt/rule_test.go
+++ b/fvt/rule_test.go
@@ -301,9 +301,9 @@ func (s *RuleTestSuite) TestStreamSchema() {
 	schema, err := client.GetStreamSchema(streamName)
 	s.Require().NoError(err)
 	expected := map[string]any{
-		"age":  map[string]any{"type": "string", "index": float64(0)},
-		"id":   map[string]any{"type": "bigint", "index": float64(0)},
-		"name": map[string]any{"type": "string", "index": float64(0)},
+		"age":  map[string]any{"type": "string", "default": "", "hasDefaultValue": false, "index": float64(0)},
+		"id":   map[string]any{"type": "bigint", "default": "", "hasDefaultValue": false, "index": float64(0)},
+		"name": map[string]any{"type": "string", "default": "", "hasDefaultValue": false, "index": float64(0)},
 	}
 	s.Require().Equal(expected, schema)
 }

--- a/fvt/rule_test.go
+++ b/fvt/rule_test.go
@@ -301,9 +301,9 @@ func (s *RuleTestSuite) TestStreamSchema() {
 	schema, err := client.GetStreamSchema(streamName)
 	s.Require().NoError(err)
 	expected := map[string]any{
-		"age":  map[string]any{"type": "string", "default": "", "hasDefaultValue": false, "index": float64(0)},
-		"id":   map[string]any{"type": "bigint", "default": "", "hasDefaultValue": false, "index": float64(0)},
-		"name": map[string]any{"type": "string", "default": "", "hasDefaultValue": false, "index": float64(0)},
+		"age":  map[string]any{"type": "string", "index": float64(0)},
+		"id":   map[string]any{"type": "bigint", "index": float64(0)},
+		"name": map[string]any{"type": "string", "index": float64(0)},
 	}
 	s.Require().Equal(expected, schema)
 }

--- a/internal/processor/stream.go
+++ b/internal/processor/stream.go
@@ -452,7 +452,12 @@ func (p *StreamProcessor) execDescribe(stmt ast.NameNode, st ast.StreamType) (r 
 		buff.WriteString("Fields\n--------------------------------------------------------------------------------\n")
 		for _, f := range s.StreamFields {
 			buff.WriteString(f.Name + "\t")
-			buff.WriteString(printFieldType(f.FieldType))
+
+			ft := printFieldType(f.FieldType)
+			if f.Default != nil {
+				ft += fmt.Sprintf(" DEFAULT %s", f.Default.String())
+			}
+			buff.WriteString(ft)
 			buff.WriteString("\n")
 		}
 		buff.WriteString("\n")
@@ -712,7 +717,7 @@ func DescribeToJson(s string) string {
 	sections := strings.Split(q, "\n\n")
 	fields, options := sections[0], sections[1]
 	type field struct {
-		Name, Type string
+		Name, Type, DefaultClause string
 	}
 	type output struct {
 		Fields  []field
@@ -722,7 +727,12 @@ func DescribeToJson(s string) string {
 	for _, f := range strings.Split(fields, "\n") {
 		split := strings.Split(f, "\t")
 		n, t := split[0], split[1]
-		o.Fields = append(o.Fields, field{Name: n, Type: t})
+		fld := field{Name: n, Type: t}
+		if len(split) >= 4 {
+			d := split[3]
+			fld.DefaultClause = d
+		}
+		o.Fields = append(o.Fields, fld)
 	}
 	for _, f := range strings.Split(strings.Trim(options, "\n"), "\n") {
 		split := strings.Split(f, " ")

--- a/internal/processor/stream.go
+++ b/internal/processor/stream.go
@@ -727,6 +727,9 @@ func DescribeToJson(s string) string {
 	o := output{Options: make(map[string]string)}
 	for _, f := range strings.Split(fields, "\n") {
 		split := strings.Split(f, "\t")
+		if len(split) < 2 {
+			continue
+		}
 		n, t := split[0], split[1]
 		fld := field{Name: n, Type: t}
 		if len(split) >= 4 {

--- a/internal/processor/stream.go
+++ b/internal/processor/stream.go
@@ -717,7 +717,8 @@ func DescribeToJson(s string) string {
 	sections := strings.Split(q, "\n\n")
 	fields, options := sections[0], sections[1]
 	type field struct {
-		Name, Type, DefaultClause string
+		Name, Type    string
+		DefaultClause string `json:",omitempty"`
 	}
 	type output struct {
 		Fields  []field

--- a/internal/processor/stream.go
+++ b/internal/processor/stream.go
@@ -454,10 +454,10 @@ func (p *StreamProcessor) execDescribe(stmt ast.NameNode, st ast.StreamType) (r 
 			buff.WriteString(f.Name + "\t")
 
 			ft := printFieldType(f.FieldType)
-			if f.Default != nil {
-				ft += fmt.Sprintf(" DEFAULT %s", f.Default.String())
-			}
 			buff.WriteString(ft)
+			if f.Default != nil {
+				buff.WriteString(fmt.Sprintf("\tDEFAULT\t%s", f.Default.String()))
+			}
 			buff.WriteString("\n")
 		}
 		buff.WriteString("\n")

--- a/internal/processor/stream_test.go
+++ b/internal/processor/stream_test.go
@@ -358,33 +358,39 @@ func TestDescribeToJson(t *testing.T) {
 	}{
 		{
 			s: "Fields\n--------------------------------------------------------------------------------\n" +
-				"USERID\tbigint\nFIRST_NAME\tstring\nLAST_NAME\tstring\nNICKNAMES\tarray(string)\nGender\tboolean\nADDRESS\t" +
+				"USERID\tbigint\tDEFAULT\t22\nFIRST_NAME\tstring\nLAST_NAME\tstring\nNICKNAMES\tarray(string)\nGender\tboolean\nADDRESS\t" +
 				"struct(STREET_NAME string, NUMBER bigint)\n\nDATASOURCE: users\nFORMAT: JSON\nKEY: USERID\n",
 			r: `{
 	"Fields": [
 		{
 			"Name": "USERID",
-			"Type": "bigint"
+			"Type": "bigint",
+			"DefaultClause": "22"
 		},
 		{
 			"Name": "FIRST_NAME",
-			"Type": "string"
+			"Type": "string",
+			"DefaultClause": ""
 		},
 		{
 			"Name": "LAST_NAME",
-			"Type": "string"
+			"Type": "string",
+			"DefaultClause": ""
 		},
 		{
 			"Name": "NICKNAMES",
-			"Type": "array(string)"
+			"Type": "array(string)",
+			"DefaultClause": ""
 		},
 		{
 			"Name": "Gender",
-			"Type": "boolean"
+			"Type": "boolean",
+			"DefaultClause": ""
 		},
 		{
 			"Name": "ADDRESS",
-			"Type": "struct(STREET_NAME string, NUMBER bigint)"
+			"Type": "struct(STREET_NAME string, NUMBER bigint)",
+			"DefaultClause": ""
 		}
 	],
 	"Options": {

--- a/internal/processor/stream_test.go
+++ b/internal/processor/stream_test.go
@@ -369,28 +369,23 @@ func TestDescribeToJson(t *testing.T) {
 		},
 		{
 			"Name": "FIRST_NAME",
-			"Type": "string",
-			"DefaultClause": ""
+			"Type": "string"
 		},
 		{
 			"Name": "LAST_NAME",
-			"Type": "string",
-			"DefaultClause": ""
+			"Type": "string"
 		},
 		{
 			"Name": "NICKNAMES",
-			"Type": "array(string)",
-			"DefaultClause": ""
+			"Type": "array(string)"
 		},
 		{
 			"Name": "Gender",
-			"Type": "boolean",
-			"DefaultClause": ""
+			"Type": "boolean"
 		},
 		{
 			"Name": "ADDRESS",
-			"Type": "struct(STREET_NAME string, NUMBER bigint)",
-			"DefaultClause": ""
+			"Type": "struct(STREET_NAME string, NUMBER bigint)"
 		}
 	],
 	"Options": {

--- a/internal/topo/operator/field_processor.go
+++ b/internal/topo/operator/field_processor.go
@@ -40,9 +40,25 @@ func (p *defaultFieldProcessor) validateAndConvert(tuple *xsql.Tuple) error {
 func (p *defaultFieldProcessor) validateAndConvertMessage(schema map[string]*ast.JsonStreamField, message xsql.Message) (map[string]interface{}, error) {
 	for name, sf := range schema {
 		v, ok := message.Value(name, "")
-		if !ok {
+		if !ok && sf.DefaultValue == "" {
 			return nil, fmt.Errorf("field %s is not found", name)
 		}
+
+		// If the field is missing and a default value is defined,
+		// set the field value using the default.
+		if !ok && sf.DefaultValue != "" {
+			switch val := ast.GetTypeOfDefault(sf.DefaultValue).(type) {
+			case *ast.IntegerLiteral:
+				v = val.Val
+			case *ast.NumberLiteral:
+				v = val.Val
+			case *ast.BooleanLiteral:
+				v = val.Val
+			case *ast.StringLiteral:
+				v = val.Val
+			}
+		}
+
 		if nv, err := p.validateAndConvertField(sf, v); err != nil {
 			return nil, fmt.Errorf("field %s type mismatch: %v", name, err)
 		} else {
@@ -61,6 +77,7 @@ func (p *defaultFieldProcessor) validateAndConvertField(sf *ast.JsonStreamField,
 		if jtype == reflect.Int64 {
 			return t, nil
 		}
+
 		return cast.ToInt64(t, cast.CONVERT_SAMEKIND)
 	case (ast.FLOAT).String():
 		if jtype == reflect.Float64 {

--- a/internal/topo/operator/field_processor.go
+++ b/internal/topo/operator/field_processor.go
@@ -40,13 +40,13 @@ func (p *defaultFieldProcessor) validateAndConvert(tuple *xsql.Tuple) error {
 func (p *defaultFieldProcessor) validateAndConvertMessage(schema map[string]*ast.JsonStreamField, message xsql.Message) (map[string]interface{}, error) {
 	for name, sf := range schema {
 		v, ok := message.Value(name, "")
-		if !ok && !sf.HasDefaultValue {
+		if !ok && sf.DefaultValue == nil {
 			return nil, fmt.Errorf("field %s is not found", name)
 		}
 
 		// If the field is missing and a default value is defined,
 		// set the field value using the default.
-		if !ok && sf.HasDefaultValue {
+		if !ok && sf.DefaultValue != nil {
 			lit, err := ast.GetTypeOfDefault(sf.DefaultValue, sf.Type)
 			if err != nil {
 				return nil, err

--- a/internal/topo/operator/field_processor.go
+++ b/internal/topo/operator/field_processor.go
@@ -47,7 +47,7 @@ func (p *defaultFieldProcessor) validateAndConvertMessage(schema map[string]*ast
 		// If the field is missing and a default value is defined,
 		// set the field value using the default.
 		if !ok && sf.DefaultValue != "" {
-			switch val := ast.GetTypeOfDefault(sf.DefaultValue).(type) {
+			switch val := ast.GetTypeOfDefault(sf.DefaultValue, sf.Type).(type) {
 			case *ast.IntegerLiteral:
 				v = val.Val
 			case *ast.NumberLiteral:

--- a/internal/topo/operator/field_processor.go
+++ b/internal/topo/operator/field_processor.go
@@ -47,7 +47,12 @@ func (p *defaultFieldProcessor) validateAndConvertMessage(schema map[string]*ast
 		// If the field is missing and a default value is defined,
 		// set the field value using the default.
 		if !ok && sf.HasDefaultValue {
-			switch val := ast.GetTypeOfDefault(sf.DefaultValue, sf.Type).(type) {
+			lit, err := ast.GetTypeOfDefault(sf.DefaultValue, sf.Type)
+			if err != nil {
+				return nil, err
+			}
+
+			switch val := lit.(type) {
 			case *ast.IntegerLiteral:
 				v = val.Val
 			case *ast.NumberLiteral:

--- a/internal/topo/operator/field_processor.go
+++ b/internal/topo/operator/field_processor.go
@@ -61,7 +61,16 @@ func (p *defaultFieldProcessor) validateAndConvertMessage(schema map[string]*ast
 				v = val.Val
 			case *ast.StringLiteral:
 				v = val.Val
+			default:
+				err = fmt.Errorf("unsupported default literal type %T", lit)
 			}
+
+			if err != nil {
+				return nil, err
+			}
+
+			message[name] = v
+			continue
 		}
 
 		if nv, err := p.validateAndConvertField(sf, v); err != nil {

--- a/internal/topo/operator/field_processor.go
+++ b/internal/topo/operator/field_processor.go
@@ -47,7 +47,7 @@ func (p *defaultFieldProcessor) validateAndConvertMessage(schema map[string]*ast
 		// If the field is missing and a default value is defined,
 		// set the field value using the default.
 		if !ok && sf.DefaultValue != nil {
-			lit, err := ast.GetTypeOfDefault(sf.DefaultValue, sf.Type)
+			lit, err := ast.GetDefaultClause(sf.DefaultValue, sf.Type)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/topo/operator/field_processor.go
+++ b/internal/topo/operator/field_processor.go
@@ -40,13 +40,13 @@ func (p *defaultFieldProcessor) validateAndConvert(tuple *xsql.Tuple) error {
 func (p *defaultFieldProcessor) validateAndConvertMessage(schema map[string]*ast.JsonStreamField, message xsql.Message) (map[string]interface{}, error) {
 	for name, sf := range schema {
 		v, ok := message.Value(name, "")
-		if !ok && sf.DefaultValue == "" {
+		if !ok && !sf.HasDefaultValue {
 			return nil, fmt.Errorf("field %s is not found", name)
 		}
 
 		// If the field is missing and a default value is defined,
 		// set the field value using the default.
-		if !ok && sf.DefaultValue != "" {
+		if !ok && sf.HasDefaultValue {
 			switch val := ast.GetTypeOfDefault(sf.DefaultValue, sf.Type).(type) {
 			case *ast.IntegerLiteral:
 				v = val.Val

--- a/internal/topo/operator/preprocessor_test.go
+++ b/internal/topo/operator/preprocessor_test.go
@@ -543,6 +543,58 @@ func TestPreprocessor_Apply(t *testing.T) {
 				},
 			},
 		},
+		{ // 29
+			stmt: &ast.StreamStmt{
+				Name: ast.StreamName("demo"),
+				StreamFields: []ast.StreamField{
+					{Name: "ab", FieldType: &ast.BasicType{Type: ast.BIGINT}, Default: &ast.IntegerLiteral{Val: 22}},
+					{Name: "cd", FieldType: &ast.BasicType{Type: ast.STRINGS}},
+				},
+			},
+			data: []byte(`{"cd": "hello"}`),
+			result: &xsql.Tuple{
+				Message: xsql.Message{
+					"ab": int64(22),
+					"cd": "hello",
+				},
+			},
+		},
+		{ // 30
+			stmt: &ast.StreamStmt{
+				Name: ast.StreamName("demo"),
+				StreamFields: []ast.StreamField{
+					{Name: "ab", FieldType: &ast.BasicType{Type: ast.STRINGS}, Default: &ast.StringLiteral{Val: "foo"}},
+					{Name: "cd", FieldType: &ast.BasicType{Type: ast.FLOAT}},
+				},
+			},
+			data: []byte(`{"cd": 44.4}`),
+			result: &xsql.Tuple{
+				Message: xsql.Message{
+					"ab": "foo",
+					"cd": float64(44.4),
+				},
+			},
+		},
+		{ // 31
+			stmt: &ast.StreamStmt{
+				Name: ast.StreamName("demo"),
+				StreamFields: []ast.StreamField{
+					{Name: "ab", FieldType: &ast.BasicType{Type: ast.BIGINT}, Default: &ast.IntegerLiteral{Val: 22}},
+					{Name: "cd", FieldType: &ast.BasicType{Type: ast.FLOAT}, Default: &ast.NumberLiteral{Val: 55.23}},
+					{Name: "ef", FieldType: &ast.BasicType{Type: ast.BOOLEAN}, Default: &ast.BooleanLiteral{Val: false}},
+					{Name: "gh", FieldType: &ast.BasicType{Type: ast.STRINGS}, Default: &ast.StringLiteral{Val: "foo bar"}},
+				},
+			},
+			data: []byte(`{}`),
+			result: &xsql.Tuple{
+				Message: xsql.Message{
+					"ab": int64(22),
+					"cd": float64(55.23),
+					"ef": false,
+					"gh": "foo bar",
+				},
+			},
+		},
 	}
 
 	fmt.Printf("The test bucket size is %d.\n\n", len(tests))

--- a/internal/topo/operator/preprocessor_test.go
+++ b/internal/topo/operator/preprocessor_test.go
@@ -611,6 +611,20 @@ func TestPreprocessor_Apply(t *testing.T) {
 				},
 			},
 		},
+		{ // 33
+			stmt: &ast.StreamStmt{
+				Name: ast.StreamName("demo"),
+				StreamFields: []ast.StreamField{
+					{Name: "aa", FieldType: &ast.BasicType{Type: ast.STRINGS}, Default: &ast.StringLiteral{Val: ""}},
+				},
+			},
+			data: []byte(`{}`),
+			result: &xsql.Tuple{
+				Message: xsql.Message{
+					"aa": "",
+				},
+			},
+		},
 	}
 
 	fmt.Printf("The test bucket size is %d.\n\n", len(tests))

--- a/internal/topo/operator/preprocessor_test.go
+++ b/internal/topo/operator/preprocessor_test.go
@@ -595,6 +595,20 @@ func TestPreprocessor_Apply(t *testing.T) {
 				},
 			},
 		},
+		{
+			stmt: &ast.StreamStmt{
+				Name: ast.StreamName("demo"),
+				StreamFields: []ast.StreamField{
+					{Name: "bb", FieldType: &ast.BasicType{Type: ast.STRINGS}, Default: &ast.StringLiteral{Val: "10"}},
+				},
+			},
+			data: []byte(`{}`),
+			result: &xsql.Tuple{
+				Message: xsql.Message{
+					"bb": "10",
+				},
+			},
+		},
 	}
 
 	fmt.Printf("The test bucket size is %d.\n\n", len(tests))

--- a/internal/topo/operator/preprocessor_test.go
+++ b/internal/topo/operator/preprocessor_test.go
@@ -595,17 +595,19 @@ func TestPreprocessor_Apply(t *testing.T) {
 				},
 			},
 		},
-		{
+		{ // 32
 			stmt: &ast.StreamStmt{
 				Name: ast.StreamName("demo"),
 				StreamFields: []ast.StreamField{
 					{Name: "bb", FieldType: &ast.BasicType{Type: ast.STRINGS}, Default: &ast.StringLiteral{Val: "10"}},
+					{Name: "cc", FieldType: &ast.BasicType{Type: ast.STRINGS}, Default: &ast.StringLiteral{Val: "false"}},
 				},
 			},
 			data: []byte(`{}`),
 			result: &xsql.Tuple{
 				Message: xsql.Message{
 					"bb": "10",
+					"cc": "false",
 				},
 			},
 		},

--- a/internal/xsql/lexical.go
+++ b/internal/xsql/lexical.go
@@ -211,6 +211,8 @@ func (s *Scanner) ScanIdent() (tok ast.Token, lit string) {
 		return ast.WHEN, lit
 	case "THEN":
 		return ast.THEN, lit
+	case "DEFAULT":
+		return ast.DEFAULT, lit
 	case "ELSE":
 		return ast.ELSE, lit
 	case "END":

--- a/internal/xsql/parser.go
+++ b/internal/xsql/parser.go
@@ -1453,6 +1453,21 @@ func (p *Parser) parseStreamField() (*ast.StreamField, error) {
 
 		if tok2, lit2 := p.scanIgnoreWhitespace(); tok2 == ast.COMMA {
 			// Just consume the comma.
+		} else if tok2 == ast.DEFAULT {
+			if f, err := p.parseStreamDefaultClause(field.FieldType); err != nil {
+				return nil, err
+			} else {
+				field.Default = f
+			}
+
+			if tok3, lit3 := p.scanIgnoreWhitespace(); tok3 == ast.COMMA {
+				// consume COMMA token
+			} else if tok3 == ast.RPAREN {
+				p.unscan()
+			} else {
+				return nil, fmt.Errorf("found %q, expect comma or rparen.", lit3)
+			}
+
 		} else if tok2 == ast.RPAREN {
 			p.unscan()
 		} else {
@@ -1462,6 +1477,21 @@ func (p *Parser) parseStreamField() (*ast.StreamField, error) {
 		return nil, fmt.Errorf("found %q, expect stream field name.", lit)
 	}
 	return field, nil
+}
+
+func (p *Parser) parseStreamDefaultClause(fieldType ast.FieldType) (ast.Literal, error) {
+	tok, lit := p.scanIgnoreWhitespace()
+	switch tok {
+	case ast.INTEGER, ast.NUMBER, ast.STRING, ast.SINGLEQUOTE, ast.TRUE, ast.FALSE:
+		literalValue, err := ast.PruneDefaultConstraintValue(lit, fieldType)
+		if err != nil {
+			return nil, err
+		}
+
+		return literalValue, nil
+	default:
+		return nil, fmt.Errorf("found %q, expect default constraint value.", lit)
+	}
 }
 
 func (p *Parser) parseStreamArrayType() (ast.FieldType, error) {

--- a/internal/xsql/parser.go
+++ b/internal/xsql/parser.go
@@ -1480,7 +1480,7 @@ func (p *Parser) parseStreamField() (*ast.StreamField, error) {
 }
 
 func (p *Parser) parseStreamDefaultClause(fieldType ast.FieldType) (ast.Literal, error) {
-	tok, lit := p.scanIgnoreWhitespace()
+	tok, lit := p.scanIgnoreWhiteSpaceWithNegativeNum()
 	switch tok {
 	case ast.INTEGER, ast.NUMBER, ast.STRING, ast.SINGLEQUOTE, ast.TRUE, ast.FALSE:
 		literalValue, err := ast.PruneDefaultConstraintValue(lit, fieldType)

--- a/internal/xsql/parser.go
+++ b/internal/xsql/parser.go
@@ -1483,7 +1483,7 @@ func (p *Parser) parseStreamDefaultClause(fieldType ast.FieldType) (ast.Literal,
 	tok, lit := p.scanIgnoreWhiteSpaceWithNegativeNum()
 	switch tok {
 	case ast.INTEGER, ast.NUMBER, ast.STRING, ast.SINGLEQUOTE, ast.TRUE, ast.FALSE:
-		literalValue, err := ast.PruneDefaultConstraintValue(lit, fieldType)
+		literalValue, err := ast.GetDefaultClause(&lit, fieldType)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/xsql/parser_stream_test.go
+++ b/internal/xsql/parser_stream_test.go
@@ -471,6 +471,79 @@ func TestParser_ParseCreateStream(t *testing.T) {
 				},
 			},
 		},
+		{
+			s: `CREATE STREAM demo (
+					USERID BIGINT DEFAULT 10,
+					FIRST_NAME STRING DEFAULT "foo bar",
+					LAST_NAME STRING DEFAULT "bar mock",
+					PICTURE BYTEA,
+				) WITH (DATASOURCE="users", FORMAT="JSON");`,
+			stmt: &ast.StreamStmt{
+				Name: ast.StreamName("demo"),
+				StreamFields: []ast.StreamField{
+					{Name: "USERID", FieldType: &ast.BasicType{Type: ast.BIGINT}, Default: &ast.IntegerLiteral{Val: 10}},
+					{Name: "FIRST_NAME", FieldType: &ast.BasicType{Type: ast.STRINGS}, Default: &ast.StringLiteral{Val: "foo bar"}},
+					{Name: "LAST_NAME", FieldType: &ast.BasicType{Type: ast.STRINGS}, Default: &ast.StringLiteral{Val: "bar mock"}},
+					{Name: "PICTURE", FieldType: &ast.BasicType{Type: ast.BYTEA}},
+				},
+				Options: &ast.Options{
+					DATASOURCE: "users",
+					FORMAT:     "JSON",
+				},
+			},
+		},
+		{
+			s: `CREATE STREAM demo (
+					USERID BIGINT,
+					FLAG BOOLEAN DEFAULT TRUE,
+					NICKNAMES ARRAY(STRING) DEFAULT "foo bar"
+				) WITH (DATASOURCE="users", FORMAT="JSON");`,
+			stmt: &ast.StreamStmt{
+				Name: ast.StreamName("demo"),
+				StreamFields: []ast.StreamField{
+					{Name: "USERID", FieldType: &ast.BasicType{Type: ast.BIGINT}},
+					{Name: "FLAG", FieldType: &ast.BasicType{Type: ast.BOOLEAN}, Default: &ast.BooleanLiteral{Val: true}},
+					{Name: "NICKNAMES", FieldType: &ast.ArrayType{Type: ast.STRINGS}, Default: &ast.StringLiteral{Val: "foo bar"}},
+				},
+				Options: &ast.Options{
+					DATASOURCE: "users",
+					FORMAT:     "JSON",
+				},
+			},
+			err: `DEFAULT clause is not supported for *ast.ArrayType`,
+		},
+		{
+			s: `CREATE STREAM demo (
+					PICTURE BYTEA DEFAULT "foo"
+				) WITH (DATASOURCE="users", FORMAT="JSON");`,
+			stmt: &ast.StreamStmt{
+				Name: ast.StreamName("demo"),
+				StreamFields: []ast.StreamField{
+					{Name: "PICTURE", FieldType: &ast.BasicType{Type: ast.BYTEA}, Default: &ast.StringLiteral{Val: "foo"}},
+				},
+				Options: &ast.Options{
+					DATASOURCE: "users",
+					FORMAT:     "JSON",
+				},
+			},
+			err: `DEFAULT clause is not supported for bytea`,
+		},
+		{
+			s: `CREATE STREAM demo (
+					USERID BIGINT DEFAULT "bar",
+				) WITH (DATASOURCE="users", FORMAT="JSON");`,
+			stmt: &ast.StreamStmt{
+				Name: ast.StreamName("demo"),
+				StreamFields: []ast.StreamField{
+					{Name: "USEIR", FieldType: &ast.BasicType{Type: ast.BIGINT}, Default: &ast.StringLiteral{Val: "bar"}},
+				},
+				Options: &ast.Options{
+					DATASOURCE: "users",
+					FORMAT:     "JSON",
+				},
+			},
+			err: `cannot convert string(bar) to int64`,
+		},
 	}
 
 	fmt.Printf("The test bucket size is %d.\n\n", len(tests))

--- a/internal/xsql/parser_stream_test.go
+++ b/internal/xsql/parser_stream_test.go
@@ -500,35 +500,15 @@ func TestParser_ParseCreateStream(t *testing.T) {
 					FLAG BOOLEAN DEFAULT TRUE,
 					NICKNAMES ARRAY(STRING) DEFAULT "foo bar"
 				) WITH (DATASOURCE="users", FORMAT="JSON");`,
-			stmt: &ast.StreamStmt{
-				Name: ast.StreamName("demo"),
-				StreamFields: []ast.StreamField{
-					{Name: "USERID", FieldType: &ast.BasicType{Type: ast.BIGINT}, Default: &ast.IntegerLiteral{Val: -23}},
-					{Name: "FLAG", FieldType: &ast.BasicType{Type: ast.BOOLEAN}, Default: &ast.BooleanLiteral{Val: true}},
-					{Name: "NICKNAMES", FieldType: &ast.ArrayType{Type: ast.STRINGS}, Default: &ast.StringLiteral{Val: "foo bar"}},
-				},
-				Options: &ast.Options{
-					DATASOURCE: "users",
-					FORMAT:     "JSON",
-				},
-			},
-			err: `DEFAULT clause is not supported for *ast.ArrayType`,
+			stmt: nil,
+			err:  `DEFAULT clause is not supported for *ast.ArrayType`,
 		},
 		{
 			s: `CREATE STREAM demo (
 					PICTURE BYTEA DEFAULT "foo"
 				) WITH (DATASOURCE="users", FORMAT="JSON");`,
-			stmt: &ast.StreamStmt{
-				Name: ast.StreamName("demo"),
-				StreamFields: []ast.StreamField{
-					{Name: "PICTURE", FieldType: &ast.BasicType{Type: ast.BYTEA}, Default: &ast.StringLiteral{Val: "foo"}},
-				},
-				Options: &ast.Options{
-					DATASOURCE: "users",
-					FORMAT:     "JSON",
-				},
-			},
-			err: `DEFAULT clause is not supported for bytea`,
+			stmt: nil,
+			err:  `DEFAULT clause is not supported for bytea`,
 		},
 		{
 			s: `CREATE STREAM demo (

--- a/internal/xsql/parser_stream_test.go
+++ b/internal/xsql/parser_stream_test.go
@@ -535,7 +535,7 @@ func TestParser_ParseCreateStream(t *testing.T) {
 			stmt: &ast.StreamStmt{
 				Name: ast.StreamName("demo"),
 				StreamFields: []ast.StreamField{
-					{Name: "USEIR", FieldType: &ast.BasicType{Type: ast.BIGINT}, Default: &ast.StringLiteral{Val: "bar"}},
+					{Name: "USERID", FieldType: &ast.BasicType{Type: ast.BIGINT}, Default: &ast.StringLiteral{Val: "bar"}},
 				},
 				Options: &ast.Options{
 					DATASOURCE: "users",

--- a/internal/xsql/parser_stream_test.go
+++ b/internal/xsql/parser_stream_test.go
@@ -476,6 +476,7 @@ func TestParser_ParseCreateStream(t *testing.T) {
 					USERID BIGINT DEFAULT 10,
 					FIRST_NAME STRING DEFAULT "foo bar",
 					LAST_NAME STRING DEFAULT "bar mock",
+					MOCK_VALUE FLOAT DEFAULT 90.22,
 					PICTURE BYTEA,
 				) WITH (DATASOURCE="users", FORMAT="JSON");`,
 			stmt: &ast.StreamStmt{
@@ -484,6 +485,7 @@ func TestParser_ParseCreateStream(t *testing.T) {
 					{Name: "USERID", FieldType: &ast.BasicType{Type: ast.BIGINT}, Default: &ast.IntegerLiteral{Val: 10}},
 					{Name: "FIRST_NAME", FieldType: &ast.BasicType{Type: ast.STRINGS}, Default: &ast.StringLiteral{Val: "foo bar"}},
 					{Name: "LAST_NAME", FieldType: &ast.BasicType{Type: ast.STRINGS}, Default: &ast.StringLiteral{Val: "bar mock"}},
+					{Name: "MOCK_VALUE", FieldType: &ast.BasicType{Type: ast.FLOAT}, Default: &ast.NumberLiteral{Val: 90.22}},
 					{Name: "PICTURE", FieldType: &ast.BasicType{Type: ast.BYTEA}},
 				},
 				Options: &ast.Options{

--- a/internal/xsql/parser_stream_test.go
+++ b/internal/xsql/parser_stream_test.go
@@ -476,7 +476,7 @@ func TestParser_ParseCreateStream(t *testing.T) {
 					USERID BIGINT DEFAULT 10,
 					FIRST_NAME STRING DEFAULT "foo bar",
 					LAST_NAME STRING DEFAULT "bar mock",
-					MOCK_VALUE FLOAT DEFAULT 90.22,
+					MOCK_VALUE FLOAT DEFAULT -90.22,
 					PICTURE BYTEA,
 				) WITH (DATASOURCE="users", FORMAT="JSON");`,
 			stmt: &ast.StreamStmt{
@@ -485,7 +485,7 @@ func TestParser_ParseCreateStream(t *testing.T) {
 					{Name: "USERID", FieldType: &ast.BasicType{Type: ast.BIGINT}, Default: &ast.IntegerLiteral{Val: 10}},
 					{Name: "FIRST_NAME", FieldType: &ast.BasicType{Type: ast.STRINGS}, Default: &ast.StringLiteral{Val: "foo bar"}},
 					{Name: "LAST_NAME", FieldType: &ast.BasicType{Type: ast.STRINGS}, Default: &ast.StringLiteral{Val: "bar mock"}},
-					{Name: "MOCK_VALUE", FieldType: &ast.BasicType{Type: ast.FLOAT}, Default: &ast.NumberLiteral{Val: 90.22}},
+					{Name: "MOCK_VALUE", FieldType: &ast.BasicType{Type: ast.FLOAT}, Default: &ast.NumberLiteral{Val: -90.22}},
 					{Name: "PICTURE", FieldType: &ast.BasicType{Type: ast.BYTEA}},
 				},
 				Options: &ast.Options{
@@ -496,14 +496,14 @@ func TestParser_ParseCreateStream(t *testing.T) {
 		},
 		{
 			s: `CREATE STREAM demo (
-					USERID BIGINT,
+					USERID BIGINT DEFAULT -23,
 					FLAG BOOLEAN DEFAULT TRUE,
 					NICKNAMES ARRAY(STRING) DEFAULT "foo bar"
 				) WITH (DATASOURCE="users", FORMAT="JSON");`,
 			stmt: &ast.StreamStmt{
 				Name: ast.StreamName("demo"),
 				StreamFields: []ast.StreamField{
-					{Name: "USERID", FieldType: &ast.BasicType{Type: ast.BIGINT}},
+					{Name: "USERID", FieldType: &ast.BasicType{Type: ast.BIGINT}, Default: &ast.IntegerLiteral{Val: -23}},
 					{Name: "FLAG", FieldType: &ast.BasicType{Type: ast.BOOLEAN}, Default: &ast.BooleanLiteral{Val: true}},
 					{Name: "NICKNAMES", FieldType: &ast.ArrayType{Type: ast.STRINGS}, Default: &ast.StringLiteral{Val: "foo bar"}},
 				},

--- a/pkg/ast/sourceStmt.go
+++ b/pkg/ast/sourceStmt.go
@@ -17,6 +17,8 @@ package ast
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/lf-edge/ekuiper/v2/pkg/cast"
 )
 
 const (
@@ -48,14 +50,16 @@ type StreamStmt struct {
 type StreamField struct {
 	Name string
 	FieldType
+	Default Literal // the DEFAULT clause is optional
 }
 
 type JsonStreamField struct {
-	Type       string                      `json:"type,omitempty"`
-	Items      *JsonStreamField            `json:"items,omitempty"`
-	Properties map[string]*JsonStreamField `json:"properties,omitempty"`
-	HasIndex   bool                        `json:"hasIndex,omitempty"`
-	Index      int                         `json:"index"`
+	Type         string                      `json:"type,omitempty"`
+	DefaultValue string                      `json:"default,omitempty"`
+	Items        *JsonStreamField            `json:"items,omitempty"`
+	Properties   map[string]*JsonStreamField `json:"properties,omitempty"`
+	HasIndex     bool                        `json:"hasIndex,omitempty"`
+	Index        int                         `json:"index"`
 
 	Selected bool `json:"selected,omitempty"`
 }
@@ -97,7 +101,11 @@ func convertSchema(sfs StreamFields) map[string]*JsonStreamField {
 	if len(sfs) > 0 {
 		result := make(map[string]*JsonStreamField, len(sfs))
 		for _, sf := range sfs {
-			result[sf.Name] = convertFieldType(sf.FieldType)
+			jsonField := convertFieldType(sf.FieldType)
+			if sf.Default != nil {
+				jsonField.DefaultValue = sf.Default.String()
+			}
+			result[sf.Name] = jsonField
 		}
 		return result
 	}
@@ -141,12 +149,74 @@ func fieldsTypeFromSchema(mjsf map[string]*JsonStreamField) (StreamFields, error
 		if err != nil {
 			return nil, err
 		}
-		sfs = append(sfs, StreamField{
+
+		field := StreamField{
 			Name:      k,
 			FieldType: ft,
-		})
+		}
+
+		var def Literal
+		def, err = fieldDefaultClauseFromSchema(v)
+		if def != nil && err == nil {
+			field.Default = def
+		}
+
+		sfs = append(sfs, field)
 	}
 	return sfs, nil
+}
+
+func fieldDefaultClauseFromSchema(v *JsonStreamField) (Literal, error) {
+	if v.DefaultValue == "" {
+		return nil, nil
+	}
+
+	var lit Literal
+	switch v.Type {
+	case "bigint":
+		val, err := cast.ToInt64(v.DefaultValue, cast.CONVERT_ALL)
+		if err != nil {
+			return nil, err
+		}
+
+		lit = &IntegerLiteral{Val: val}
+	case "string":
+		lit = &StringLiteral{Val: v.DefaultValue}
+	case "boolean":
+		val, err := cast.ToBool(v.DefaultValue, cast.CONVERT_ALL)
+		if err != nil {
+			return nil, err
+		}
+
+		lit = &BooleanLiteral{Val: val}
+	case "float":
+		val, err := cast.ToFloat64(v.DefaultValue, cast.CONVERT_ALL)
+		if err != nil {
+			return nil, err
+		}
+
+		lit = &NumberLiteral{Val: val}
+	default:
+		return nil, fmt.Errorf("unsupported type %s", v.Type)
+	}
+
+	return lit, nil
+}
+
+func GetTypeOfDefault(defClause string) Literal {
+	if val, err := cast.ToInt64(defClause, cast.CONVERT_ALL); err == nil {
+		return &IntegerLiteral{Val: val}
+	}
+
+	if val, err := cast.ToFloat64(defClause, cast.CONVERT_ALL); err == nil {
+		return &NumberLiteral{Val: val}
+	}
+
+	if val, err := cast.ToBool(defClause, cast.CONVERT_ALL); err == nil {
+		return &BooleanLiteral{Val: val}
+	}
+
+	return &StringLiteral{Val: defClause}
 }
 
 func fieldTypeFromSchema(v *JsonStreamField) (FieldType, error) {
@@ -364,4 +434,40 @@ func CheckSchemaIndex(schema map[string]*JsonStreamField) bool {
 		return field != nil && field.HasIndex
 	}
 	return false
+}
+
+func PruneDefaultConstraintValue(constraintValue string, fieldType FieldType) (Literal, error) {
+	var matchErr error
+
+	switch t := fieldType.(type) {
+	case *BasicType:
+		switch t.Type {
+		case BIGINT:
+			var value int64
+			value, matchErr = cast.ToInt64(constraintValue, cast.CONVERT_ALL)
+			if matchErr == nil {
+				return &IntegerLiteral{Val: value}, nil
+			}
+		case FLOAT:
+			var value float64
+			value, matchErr = cast.ToFloat64(constraintValue, cast.CONVERT_ALL)
+			if matchErr == nil {
+				return &NumberLiteral{Val: value}, nil
+			}
+		case STRINGS:
+			return &StringLiteral{Val: constraintValue}, nil
+		case BOOLEAN:
+			var value bool
+			value, matchErr = cast.ToBool(constraintValue, cast.CONVERT_ALL)
+			if matchErr == nil {
+				return &BooleanLiteral{Val: value}, nil
+			}
+		default:
+			matchErr = fmt.Errorf("DEFAULT clause is not supported for %s", t.Type.String())
+		}
+	default:
+		matchErr = fmt.Errorf("DEFAULT clause is not supported for %T", t)
+	}
+
+	return nil, matchErr
 }

--- a/pkg/ast/sourceStmt.go
+++ b/pkg/ast/sourceStmt.go
@@ -203,7 +203,7 @@ func fieldDefaultClauseFromSchema(v *JsonStreamField) (Literal, error) {
 
 		lit = &NumberLiteral{Val: val}
 	default:
-		return nil, fmt.Errorf("unsupported type %s", v.Type)
+		return nil, fmt.Errorf("DEFAULT clause is not supported for %s", v.Type)
 	}
 
 	return lit, nil

--- a/pkg/ast/sourceStmt.go
+++ b/pkg/ast/sourceStmt.go
@@ -208,34 +208,6 @@ func fieldDefaultClauseFromSchema(v *JsonStreamField) (Literal, error) {
 	return lit, nil
 }
 
-func GetTypeOfDefault(defClause *string, fieldType string) (Literal, error) {
-	var err error
-
-	switch fieldType {
-	case BIGINT.String():
-		var val int64
-		if val, err = cast.ToInt64(*defClause, cast.CONVERT_ALL); err == nil {
-			return &IntegerLiteral{Val: val}, nil
-		}
-	case FLOAT.String():
-		var val float64
-		if val, err = cast.ToFloat64(*defClause, cast.CONVERT_ALL); err == nil {
-			return &NumberLiteral{Val: val}, nil
-		}
-	case STRINGS.String():
-		return &StringLiteral{Val: *defClause}, nil
-	case BOOLEAN.String():
-		var val bool
-		if val, err = cast.ToBool(*defClause, cast.CONVERT_ALL); err == nil {
-			return &BooleanLiteral{Val: val}, nil
-		}
-	default:
-		err = fmt.Errorf("field type %s is not valid for DEFAULT clause", fieldType)
-	}
-
-	return nil, err
-}
-
 func fieldTypeFromSchema(v *JsonStreamField) (FieldType, error) {
 	var ft FieldType
 	switch v.Type {
@@ -453,38 +425,58 @@ func CheckSchemaIndex(schema map[string]*JsonStreamField) bool {
 	return false
 }
 
-func PruneDefaultConstraintValue(constraintValue string, fieldType FieldType) (Literal, error) {
+func GetDefaultClause(constraintValue *string, fieldType any) (Literal, error) {
 	var matchErr error
 
 	switch t := fieldType.(type) {
-	case *BasicType:
-		switch t.Type {
-		case BIGINT:
-			var value int64
-			value, matchErr = cast.ToInt64(constraintValue, cast.CONVERT_ALL)
-			if matchErr == nil {
-				return &IntegerLiteral{Val: value}, nil
+	case FieldType:
+		switch ft := fieldType.(type) {
+		case *BasicType:
+			lit, err := getClause(*constraintValue, ft.Type.String())
+			if err != nil {
+				return nil, err
 			}
-		case FLOAT:
-			var value float64
-			value, matchErr = cast.ToFloat64(constraintValue, cast.CONVERT_ALL)
-			if matchErr == nil {
-				return &NumberLiteral{Val: value}, nil
-			}
-		case STRINGS:
-			return &StringLiteral{Val: constraintValue}, nil
-		case BOOLEAN:
-			var value bool
-			value, matchErr = cast.ToBool(constraintValue, cast.CONVERT_ALL)
-			if matchErr == nil {
-				return &BooleanLiteral{Val: value}, nil
-			}
+			return lit, err
 		default:
-			matchErr = fmt.Errorf("DEFAULT clause is not supported for %s", t.Type.String())
+			matchErr = fmt.Errorf("DEFAULT clause is not supported for %T", ft)
 		}
+	case string:
+		lit, err := getClause(*constraintValue, t)
+		if err != nil {
+			return nil, err
+		}
+		return lit, err
 	default:
-		matchErr = fmt.Errorf("DEFAULT clause is not supported for %T", t)
+		matchErr = fmt.Errorf("unsupported type %T", t)
 	}
 
 	return nil, matchErr
+}
+
+func getClause(clauseValue string, fieldType string) (Literal, error) {
+	var err error
+
+	switch fieldType {
+	case BIGINT.String():
+		var val int64
+		if val, err = cast.ToInt64(clauseValue, cast.CONVERT_ALL); err == nil {
+			return &IntegerLiteral{Val: val}, nil
+		}
+	case FLOAT.String():
+		var val float64
+		if val, err = cast.ToFloat64(clauseValue, cast.CONVERT_ALL); err == nil {
+			return &NumberLiteral{Val: val}, nil
+		}
+	case STRINGS.String():
+		return &StringLiteral{Val: clauseValue}, nil
+	case BOOLEAN.String():
+		var val bool
+		if val, err = cast.ToBool(clauseValue, cast.CONVERT_ALL); err == nil {
+			return &BooleanLiteral{Val: val}, nil
+		}
+	default:
+		err = fmt.Errorf("DEFAULT clause is not supported for %s", fieldType)
+	}
+
+	return nil, err
 }

--- a/pkg/ast/sourceStmt.go
+++ b/pkg/ast/sourceStmt.go
@@ -54,13 +54,12 @@ type StreamField struct {
 }
 
 type JsonStreamField struct {
-	Type            string                      `json:"type,omitempty"`
-	DefaultValue    string                      `json:"default"`
-	HasDefaultValue bool                        `json:"hasDefaultValue"`
-	Items           *JsonStreamField            `json:"items,omitempty"`
-	Properties      map[string]*JsonStreamField `json:"properties,omitempty"`
-	HasIndex        bool                        `json:"hasIndex,omitempty"`
-	Index           int                         `json:"index"`
+	Type         string                      `json:"type,omitempty"`
+	DefaultValue *string                     `json:"default,omitempty"`
+	Items        *JsonStreamField            `json:"items,omitempty"`
+	Properties   map[string]*JsonStreamField `json:"properties,omitempty"`
+	HasIndex     bool                        `json:"hasIndex,omitempty"`
+	Index        int                         `json:"index"`
 
 	Selected bool `json:"selected,omitempty"`
 }
@@ -104,8 +103,8 @@ func convertSchema(sfs StreamFields) map[string]*JsonStreamField {
 		for _, sf := range sfs {
 			jsonField := convertFieldType(sf.FieldType)
 			if sf.Default != nil {
-				jsonField.DefaultValue = sf.Default.String()
-				jsonField.HasDefaultValue = true
+				defaultValue := sf.Default.String()
+				jsonField.DefaultValue = &defaultValue
 			}
 			result[sf.Name] = jsonField
 		}
@@ -173,7 +172,7 @@ func fieldsTypeFromSchema(mjsf map[string]*JsonStreamField) (StreamFields, error
 }
 
 func fieldDefaultClauseFromSchema(v *JsonStreamField) (Literal, error) {
-	if !v.HasDefaultValue {
+	if v.DefaultValue == nil {
 		return nil, nil
 	}
 
@@ -187,7 +186,7 @@ func fieldDefaultClauseFromSchema(v *JsonStreamField) (Literal, error) {
 
 		lit = &IntegerLiteral{Val: val}
 	case "string":
-		lit = &StringLiteral{Val: v.DefaultValue}
+		lit = &StringLiteral{Val: *v.DefaultValue}
 	case "boolean":
 		val, err := cast.ToBool(v.DefaultValue, cast.CONVERT_ALL)
 		if err != nil {
@@ -209,25 +208,25 @@ func fieldDefaultClauseFromSchema(v *JsonStreamField) (Literal, error) {
 	return lit, nil
 }
 
-func GetTypeOfDefault(defClause string, fieldType string) (Literal, error) {
+func GetTypeOfDefault(defClause *string, fieldType string) (Literal, error) {
 	var err error
 
 	switch fieldType {
 	case BIGINT.String():
 		var val int64
-		if val, err = cast.ToInt64(defClause, cast.CONVERT_ALL); err == nil {
+		if val, err = cast.ToInt64(*defClause, cast.CONVERT_ALL); err == nil {
 			return &IntegerLiteral{Val: val}, nil
 		}
 	case FLOAT.String():
 		var val float64
-		if val, err = cast.ToFloat64(defClause, cast.CONVERT_ALL); err == nil {
+		if val, err = cast.ToFloat64(*defClause, cast.CONVERT_ALL); err == nil {
 			return &NumberLiteral{Val: val}, nil
 		}
 	case STRINGS.String():
-		return &StringLiteral{Val: defClause}, nil
+		return &StringLiteral{Val: *defClause}, nil
 	case BOOLEAN.String():
 		var val bool
-		if val, err = cast.ToBool(defClause, cast.CONVERT_ALL); err == nil {
+		if val, err = cast.ToBool(*defClause, cast.CONVERT_ALL); err == nil {
 			return &BooleanLiteral{Val: val}, nil
 		}
 	default:

--- a/pkg/ast/sourceStmt.go
+++ b/pkg/ast/sourceStmt.go
@@ -157,7 +157,11 @@ func fieldsTypeFromSchema(mjsf map[string]*JsonStreamField) (StreamFields, error
 
 		var def Literal
 		def, err = fieldDefaultClauseFromSchema(v)
-		if def != nil && err == nil {
+		if err != nil {
+			return nil, err
+		}
+
+		if def != nil {
 			field.Default = def
 		}
 

--- a/pkg/ast/sourceStmt.go
+++ b/pkg/ast/sourceStmt.go
@@ -65,12 +65,28 @@ type JsonStreamField struct {
 }
 
 func (u *StreamField) MarshalJSON() ([]byte, error) {
+	var defaultValue *string
+
+	if u.Default != nil {
+		def := u.Default.String()
+
+		// validate that the default value is compatible with the field type
+		_, err := GetDefaultClause(&def, u.FieldType)
+		if err != nil {
+			return nil, err
+		}
+
+		defaultValue = &def
+	}
+
 	return json.Marshal(&struct {
-		FieldType interface{}
-		Name      string
+		FieldType     interface{}
+		Name          string
+		DefaultClause *string `json:",omitempty"`
 	}{
-		FieldType: printFieldTypeForJson(u.FieldType),
-		Name:      u.Name,
+		FieldType:     printFieldTypeForJson(u.FieldType),
+		Name:          u.Name,
+		DefaultClause: defaultValue,
 	})
 }
 
@@ -176,36 +192,7 @@ func fieldDefaultClauseFromSchema(v *JsonStreamField) (Literal, error) {
 		return nil, nil
 	}
 
-	var lit Literal
-	switch v.Type {
-	case "bigint":
-		val, err := cast.ToInt64(v.DefaultValue, cast.CONVERT_ALL)
-		if err != nil {
-			return nil, err
-		}
-
-		lit = &IntegerLiteral{Val: val}
-	case "string":
-		lit = &StringLiteral{Val: *v.DefaultValue}
-	case "boolean":
-		val, err := cast.ToBool(v.DefaultValue, cast.CONVERT_ALL)
-		if err != nil {
-			return nil, err
-		}
-
-		lit = &BooleanLiteral{Val: val}
-	case "float":
-		val, err := cast.ToFloat64(v.DefaultValue, cast.CONVERT_ALL)
-		if err != nil {
-			return nil, err
-		}
-
-		lit = &NumberLiteral{Val: val}
-	default:
-		return nil, fmt.Errorf("DEFAULT clause is not supported for %s", v.Type)
-	}
-
-	return lit, nil
+	return getClause(*v.DefaultValue, v.Type)
 }
 
 func fieldTypeFromSchema(v *JsonStreamField) (FieldType, error) {

--- a/pkg/ast/sourceStmt.go
+++ b/pkg/ast/sourceStmt.go
@@ -209,26 +209,26 @@ func fieldDefaultClauseFromSchema(v *JsonStreamField) (Literal, error) {
 	return lit, nil
 }
 
-func GetTypeOfDefault(defClause string, fieldType string) Literal {
+func GetTypeOfDefault(defClause string, fieldType string) (Literal, error) {
 	switch fieldType {
 	case BIGINT.String():
 		if val, err := cast.ToInt64(defClause, cast.CONVERT_ALL); err == nil {
-			return &IntegerLiteral{Val: val}
+			return &IntegerLiteral{Val: val}, nil
 		}
 
 	case FLOAT.String():
 		if val, err := cast.ToFloat64(defClause, cast.CONVERT_ALL); err == nil {
-			return &NumberLiteral{Val: val}
+			return &NumberLiteral{Val: val}, nil
 		}
 	case STRINGS.String():
-		return &StringLiteral{Val: defClause}
+		return &StringLiteral{Val: defClause}, nil
 	case BOOLEAN.String():
 		if val, err := cast.ToBool(defClause, cast.CONVERT_ALL); err == nil {
-			return &BooleanLiteral{Val: val}
+			return &BooleanLiteral{Val: val}, nil
 		}
 	}
 
-	return nil
+	return nil, fmt.Errorf("field type %s is not valid for DEFAULT clause", fieldType)
 }
 
 func fieldTypeFromSchema(v *JsonStreamField) (FieldType, error) {

--- a/pkg/ast/sourceStmt.go
+++ b/pkg/ast/sourceStmt.go
@@ -54,12 +54,13 @@ type StreamField struct {
 }
 
 type JsonStreamField struct {
-	Type         string                      `json:"type,omitempty"`
-	DefaultValue string                      `json:"default,omitempty"`
-	Items        *JsonStreamField            `json:"items,omitempty"`
-	Properties   map[string]*JsonStreamField `json:"properties,omitempty"`
-	HasIndex     bool                        `json:"hasIndex,omitempty"`
-	Index        int                         `json:"index"`
+	Type            string                      `json:"type,omitempty"`
+	DefaultValue    string                      `json:"default"`
+	HasDefaultValue bool                        `json:"hasDefaultValue"`
+	Items           *JsonStreamField            `json:"items,omitempty"`
+	Properties      map[string]*JsonStreamField `json:"properties,omitempty"`
+	HasIndex        bool                        `json:"hasIndex,omitempty"`
+	Index           int                         `json:"index"`
 
 	Selected bool `json:"selected,omitempty"`
 }
@@ -104,6 +105,7 @@ func convertSchema(sfs StreamFields) map[string]*JsonStreamField {
 			jsonField := convertFieldType(sf.FieldType)
 			if sf.Default != nil {
 				jsonField.DefaultValue = sf.Default.String()
+				jsonField.HasDefaultValue = true
 			}
 			result[sf.Name] = jsonField
 		}

--- a/pkg/ast/sourceStmt.go
+++ b/pkg/ast/sourceStmt.go
@@ -203,20 +203,26 @@ func fieldDefaultClauseFromSchema(v *JsonStreamField) (Literal, error) {
 	return lit, nil
 }
 
-func GetTypeOfDefault(defClause string) Literal {
-	if val, err := cast.ToInt64(defClause, cast.CONVERT_ALL); err == nil {
-		return &IntegerLiteral{Val: val}
+func GetTypeOfDefault(defClause string, fieldType string) Literal {
+	switch fieldType {
+	case BIGINT.String():
+		if val, err := cast.ToInt64(defClause, cast.CONVERT_ALL); err == nil {
+			return &IntegerLiteral{Val: val}
+		}
+
+	case FLOAT.String():
+		if val, err := cast.ToFloat64(defClause, cast.CONVERT_ALL); err == nil {
+			return &NumberLiteral{Val: val}
+		}
+	case STRINGS.String():
+		return &StringLiteral{Val: defClause}
+	case BOOLEAN.String():
+		if val, err := cast.ToBool(defClause, cast.CONVERT_ALL); err == nil {
+			return &BooleanLiteral{Val: val}
+		}
 	}
 
-	if val, err := cast.ToFloat64(defClause, cast.CONVERT_ALL); err == nil {
-		return &NumberLiteral{Val: val}
-	}
-
-	if val, err := cast.ToBool(defClause, cast.CONVERT_ALL); err == nil {
-		return &BooleanLiteral{Val: val}
-	}
-
-	return &StringLiteral{Val: defClause}
+	return nil
 }
 
 func fieldTypeFromSchema(v *JsonStreamField) (FieldType, error) {

--- a/pkg/ast/sourceStmt.go
+++ b/pkg/ast/sourceStmt.go
@@ -173,7 +173,7 @@ func fieldsTypeFromSchema(mjsf map[string]*JsonStreamField) (StreamFields, error
 }
 
 func fieldDefaultClauseFromSchema(v *JsonStreamField) (Literal, error) {
-	if v.DefaultValue == "" {
+	if !v.HasDefaultValue {
 		return nil, nil
 	}
 

--- a/pkg/ast/sourceStmt.go
+++ b/pkg/ast/sourceStmt.go
@@ -210,25 +210,31 @@ func fieldDefaultClauseFromSchema(v *JsonStreamField) (Literal, error) {
 }
 
 func GetTypeOfDefault(defClause string, fieldType string) (Literal, error) {
+	var err error
+
 	switch fieldType {
 	case BIGINT.String():
-		if val, err := cast.ToInt64(defClause, cast.CONVERT_ALL); err == nil {
+		var val int64
+		if val, err = cast.ToInt64(defClause, cast.CONVERT_ALL); err == nil {
 			return &IntegerLiteral{Val: val}, nil
 		}
-
 	case FLOAT.String():
-		if val, err := cast.ToFloat64(defClause, cast.CONVERT_ALL); err == nil {
+		var val float64
+		if val, err = cast.ToFloat64(defClause, cast.CONVERT_ALL); err == nil {
 			return &NumberLiteral{Val: val}, nil
 		}
 	case STRINGS.String():
 		return &StringLiteral{Val: defClause}, nil
 	case BOOLEAN.String():
-		if val, err := cast.ToBool(defClause, cast.CONVERT_ALL); err == nil {
+		var val bool
+		if val, err = cast.ToBool(defClause, cast.CONVERT_ALL); err == nil {
 			return &BooleanLiteral{Val: val}, nil
 		}
+	default:
+		err = fmt.Errorf("field type %s is not valid for DEFAULT clause", fieldType)
 	}
 
-	return nil, fmt.Errorf("field type %s is not valid for DEFAULT clause", fieldType)
+	return nil, err
 }
 
 func fieldTypeFromSchema(v *JsonStreamField) (FieldType, error) {

--- a/pkg/ast/sourceStmt_test.go
+++ b/pkg/ast/sourceStmt_test.go
@@ -82,12 +82,12 @@ func TestToJsonFields(t *testing.T) {
 			},
 		}, {
 			input: []StreamField{
-				{Name: "USERID", FieldType: &BasicType{Type: BIGINT}},
-				{Name: "FIRST_NAME", FieldType: &BasicType{Type: STRINGS}},
-				{Name: "LAST_NAME", FieldType: &BasicType{Type: STRINGS}},
+				{Name: "USERID", FieldType: &BasicType{Type: BIGINT}, Default: &IntegerLiteral{Val: 10}},
+				{Name: "FIRST_NAME", FieldType: &BasicType{Type: STRINGS}, Default: &StringLiteral{Val: "foo"}},
+				{Name: "LAST_NAME", FieldType: &BasicType{Type: STRINGS}, Default: &StringLiteral{Val: "bar"}},
 				{Name: "NICKNAMES", FieldType: &ArrayType{Type: STRINGS}},
 				{Name: "data", FieldType: &BasicType{Type: BYTEA}},
-				{Name: "Gender", FieldType: &BasicType{Type: BOOLEAN}},
+				{Name: "Gender", FieldType: &BasicType{Type: BOOLEAN}, Default: &BooleanLiteral{Val: true}},
 				{Name: "ADDRESS", FieldType: &RecType{
 					StreamFields: []StreamField{
 						{Name: "STREET_NAME", FieldType: &BasicType{Type: STRINGS}},
@@ -96,12 +96,12 @@ func TestToJsonFields(t *testing.T) {
 				}},
 			},
 			output: map[string]*JsonStreamField{
-				"USERID":     {Type: "bigint"},
-				"FIRST_NAME": {Type: "string"},
-				"LAST_NAME":  {Type: "string"},
+				"USERID":     {Type: "bigint", DefaultValue: "10"},
+				"FIRST_NAME": {Type: "string", DefaultValue: "foo"},
+				"LAST_NAME":  {Type: "string", DefaultValue: "bar"},
 				"NICKNAMES":  {Type: "array", Items: &JsonStreamField{Type: "string"}},
 				"data":       {Type: "bytea"},
-				"Gender":     {Type: "boolean"},
+				"Gender":     {Type: "boolean", DefaultValue: "true"},
 				"ADDRESS": {Type: "struct", Properties: map[string]*JsonStreamField{
 					"STREET_NAME": {Type: "string"},
 					"NUMBER":      {Type: "bigint"},

--- a/pkg/ast/sourceStmt_test.go
+++ b/pkg/ast/sourceStmt_test.go
@@ -15,6 +15,8 @@
 package ast
 
 import (
+	"encoding/json"
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -60,6 +62,96 @@ func TestPrintFieldType(t *testing.T) {
 		result, _ := doPrintFieldTypeForJson(tt.ft)
 		if !reflect.DeepEqual(tt.printed, result) {
 			t.Errorf("%d. \nstmt mismatch:\n\nexp=%#v\n\ngot=%#v\n\n", i, tt.printed, result)
+		}
+	}
+}
+
+func TestMarshalJSON(t *testing.T) {
+	tests := []struct {
+		input  StreamField
+		output string
+		err    error
+	}{
+		{
+			input: StreamField{
+				Name:      "id",
+				FieldType: &BasicType{Type: BIGINT},
+				Default:   &IntegerLiteral{Val: 10},
+			},
+			output: `{"FieldType":"bigint","Name":"id","DefaultClause":"10"}`,
+			err:    nil,
+		},
+		{
+			input: StreamField{
+				Name:      "foo",
+				FieldType: &BasicType{Type: FLOAT},
+				Default:   &NumberLiteral{Val: -55.340},
+			},
+			output: `{"FieldType":"float","Name":"foo","DefaultClause":"-55.340000"}`,
+			err:    nil,
+		},
+		{
+			input: StreamField{
+				Name:      "bar",
+				FieldType: &BasicType{Type: STRINGS},
+				Default:   &StringLiteral{Val: ""},
+			},
+			output: `{"FieldType":"string","Name":"bar","DefaultClause":""}`,
+			err:    nil,
+		},
+		{
+			input: StreamField{
+				Name:      "mock",
+				FieldType: &BasicType{Type: STRINGS},
+			},
+			output: `{"FieldType":"string","Name":"mock"}`,
+			err:    nil,
+		},
+		{
+			input: StreamField{
+				Name:      "motion",
+				FieldType: &BasicType{Type: BOOLEAN},
+				Default:   &BooleanLiteral{Val: false},
+			},
+			output: `{"FieldType":"boolean","Name":"motion","DefaultClause":"false"}`,
+			err:    nil,
+		},
+		{
+			input: StreamField{
+				Name:      "clock",
+				FieldType: &BasicType{Type: DATETIME},
+				Default:   &StringLiteral{Val: "something"},
+			},
+			output: "",
+			err:    errors.New("DEFAULT clause is not supported for datetime"),
+		},
+	}
+
+	t.Logf("The test bucket size is %d.", len(tests))
+	for i, test := range tests {
+		var got, exp map[string]any
+		result, err := test.input.MarshalJSON()
+		if err != nil {
+			if test.err != nil {
+				if err.Error() != test.err.Error() {
+					t.Errorf("%d. \nstmt mismatch:\n\nexp=%#v\n\ngot=%#v\n\n", i, test.err, err)
+				}
+			} else {
+				t.Fatalf("failed to marshal json object %v", err)
+			}
+			continue
+		}
+
+		if err1 := json.Unmarshal(result, &got); err1 != nil {
+			t.Fatalf("failed to unmarshal result got %v", err1)
+		}
+
+		if err2 := json.Unmarshal([]byte(test.output), &exp); err2 != nil {
+			t.Fatalf("failed to unmarshal result got %v", err2)
+		}
+
+		if !reflect.DeepEqual(got, exp) {
+			t.Errorf("%d. \nstmt mismatch:\n\nexp=%#v\n\ngot=%#v\n\n", i, test.output, string(result))
 		}
 	}
 }

--- a/pkg/ast/sourceStmt_test.go
+++ b/pkg/ast/sourceStmt_test.go
@@ -65,6 +65,17 @@ func TestPrintFieldType(t *testing.T) {
 }
 
 func TestToJsonFields(t *testing.T) {
+	defaultValues := struct {
+		userId              string
+		firstName, lastName string
+		gender              string
+	}{
+		userId:    "10",
+		firstName: "foo",
+		lastName:  "bar",
+		gender:    "true",
+	}
+
 	tests := []struct {
 		input  StreamFields
 		output map[string]*JsonStreamField
@@ -96,12 +107,12 @@ func TestToJsonFields(t *testing.T) {
 				}},
 			},
 			output: map[string]*JsonStreamField{
-				"USERID":     {Type: "bigint", HasDefaultValue: true, DefaultValue: "10"},
-				"FIRST_NAME": {Type: "string", HasDefaultValue: true, DefaultValue: "foo"},
-				"LAST_NAME":  {Type: "string", HasDefaultValue: true, DefaultValue: "bar"},
+				"USERID":     {Type: "bigint", DefaultValue: &defaultValues.userId},
+				"FIRST_NAME": {Type: "string", DefaultValue: &defaultValues.firstName},
+				"LAST_NAME":  {Type: "string", DefaultValue: &defaultValues.lastName},
 				"NICKNAMES":  {Type: "array", Items: &JsonStreamField{Type: "string"}},
 				"data":       {Type: "bytea"},
-				"Gender":     {Type: "boolean", HasDefaultValue: true, DefaultValue: "true"},
+				"Gender":     {Type: "boolean", DefaultValue: &defaultValues.gender},
 				"ADDRESS": {Type: "struct", Properties: map[string]*JsonStreamField{
 					"STREET_NAME": {Type: "string"},
 					"NUMBER":      {Type: "bigint"},

--- a/pkg/ast/sourceStmt_test.go
+++ b/pkg/ast/sourceStmt_test.go
@@ -96,12 +96,12 @@ func TestToJsonFields(t *testing.T) {
 				}},
 			},
 			output: map[string]*JsonStreamField{
-				"USERID":     {Type: "bigint", DefaultValue: "10"},
-				"FIRST_NAME": {Type: "string", DefaultValue: "foo"},
-				"LAST_NAME":  {Type: "string", DefaultValue: "bar"},
+				"USERID":     {Type: "bigint", HasDefaultValue: true, DefaultValue: "10"},
+				"FIRST_NAME": {Type: "string", HasDefaultValue: true, DefaultValue: "foo"},
+				"LAST_NAME":  {Type: "string", HasDefaultValue: true, DefaultValue: "bar"},
 				"NICKNAMES":  {Type: "array", Items: &JsonStreamField{Type: "string"}},
 				"data":       {Type: "bytea"},
-				"Gender":     {Type: "boolean", DefaultValue: "true"},
+				"Gender":     {Type: "boolean", HasDefaultValue: true, DefaultValue: "true"},
 				"ADDRESS": {Type: "struct", Properties: map[string]*JsonStreamField{
 					"STREET_NAME": {Type: "string"},
 					"NUMBER":      {Type: "bigint"},

--- a/pkg/ast/token.go
+++ b/pkg/ast/token.go
@@ -110,6 +110,7 @@ const (
 	OVER
 	PARTITION
 	INVISIBLE
+	DEFAULT
 
 	TRUE
 	FALSE
@@ -188,6 +189,7 @@ var Tokens = []string{
 	OVER:      "OVER",
 	PARTITION: "PARTITION",
 	INVISIBLE: "INVISIBLE",
+	DEFAULT:   "DEFAULT",
 
 	AND:        "AND",
 	OR:         "OR",


### PR DESCRIPTION
@ngjaying @Yisaer 
This PR introduces support for the `DEFAULT` clause. At the moment, the implementation covers only the following data types:

* STRING
* FLOAT
* BOOLEAN
* BIGINT

If this approach looks good to you, I can extend the support to all the other available data types.

From a design perspective, and to avoid large refactors, the `DEFAULT` clause is currently enabled only when `STRICT_VALIDATION` is set to `true`. This means the feature relies on the preprocessor to work properly.

Let me know your thoughts or if you'd like me to adjust anything.

Related Issue: #2293 
