### PR TITLE
fix: shared MQTT source issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ go.work.sum
 pycache
 fix_cve.md
 ekuiper240b5.csv
+tmp

--- a/fvt/conn_test.go
+++ b/fvt/conn_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/mochi-mqtt/server/v2/hooks/auth"
 	"github.com/mochi-mqtt/server/v2/listeners"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/lf-edge/ekuiper/v2/internal/io/memory/pubsub"
 )
 
 type ConnectionTestSuite struct {
@@ -253,6 +255,247 @@ func (s *ConnectionTestSuite) TestConnStatus() {
 		})
 		s.Require().True(r)
 	})
+}
+
+func (s *ConnectionTestSuite) TestSharedConnectionPeerRuleStopImpactRepro() {
+	const brokerAddr = ":5883"
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	connID := "connSharedStop" + suffix
+	confKey := "sharedStopConf" + suffix
+	streamName := "sharedStopStream" + suffix
+	ruleActive := "ruleSharedStopActive" + suffix
+	rulePeer := "ruleSharedStopPeer" + suffix
+	sourceTpc := "fvt/shared/stop/" + suffix
+	memActive := "fvt/shared/stop/active/" + suffix
+	memPeer := "fvt/shared/stop/peer/" + suffix
+
+	activeSub := pubsub.CreateSub(memActive, nil, memActive, 1024)
+	defer pubsub.CloseSourceConsumerChannel(memActive, memActive)
+	peerSub := pubsub.CreateSub(memPeer, nil, memPeer, 1024)
+	defer pubsub.CloseSourceConsumerChannel(memPeer, memPeer)
+
+	server, tcp := s.startInlineBroker("sharedStopBroker", brokerAddr)
+	defer func() {
+		err := server.Close()
+		s.Require().NoError(err)
+		tcp.Close(nil)
+	}()
+
+	s.createSharedConnectionArtifacts(connID, confKey, streamName, tcp.Address(), sourceTpc)
+	defer s.cleanupSharedConnectionArtifacts(ruleActive, rulePeer, streamName, confKey, connID)
+
+	s.createMemoryRule(ruleActive, streamName, memActive)
+	s.createMemoryRule(rulePeer, streamName, memPeer)
+
+	s.requireSharedSourceReady(server, sourceTpc, peerSub, activeSub, 1)
+
+	resp, err := client.StopRule(rulePeer)
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	err = server.Publish(sourceTpc, []byte(`{"seq":2}`), false, 0)
+	s.Require().NoError(err)
+	activeGot := s.waitForMemoryTuple(activeSub, 2, 3*time.Second)
+	s.False(activeGot, "expected reproduction: after stopping peer rule, active rule should stop receiving on shared mqtt connection")
+}
+
+func (s *ConnectionTestSuite) TestSharedConnectionPeerRuleRestartImpactRepro() {
+	const brokerAddr = ":5884"
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	connID := "connSharedRestart" + suffix
+	confKey := "sharedRestartConf" + suffix
+	streamName := "sharedRestartStream" + suffix
+	ruleActive := "ruleSharedRestartActive" + suffix
+	rulePeer := "ruleSharedRestartPeer" + suffix
+	sourceTpc := "fvt/shared/restart/" + suffix
+	memActive := "fvt/shared/restart/active/" + suffix
+	memPeer := "fvt/shared/restart/peer/" + suffix
+
+	activeSub := pubsub.CreateSub(memActive, nil, memActive, 1024)
+	defer pubsub.CloseSourceConsumerChannel(memActive, memActive)
+	peerSub := pubsub.CreateSub(memPeer, nil, memPeer, 1024)
+	defer pubsub.CloseSourceConsumerChannel(memPeer, memPeer)
+
+	server, tcp := s.startInlineBroker("sharedRestartBroker", brokerAddr)
+	defer func() {
+		err := server.Close()
+		s.Require().NoError(err)
+		tcp.Close(nil)
+	}()
+
+	s.createSharedConnectionArtifacts(connID, confKey, streamName, tcp.Address(), sourceTpc)
+	defer s.cleanupSharedConnectionArtifacts(ruleActive, rulePeer, streamName, confKey, connID)
+
+	s.createMemoryRule(ruleActive, streamName, memActive)
+	s.createMemoryRule(rulePeer, streamName, memPeer)
+
+	s.requireSharedSourceReady(server, sourceTpc, peerSub, activeSub, 1)
+
+	resp, err := client.RestartRule(rulePeer)
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	err = server.Publish(sourceTpc, []byte(`{"seq":2}`), false, 0)
+	s.Require().NoError(err)
+	peerGot := s.waitForMemoryTuple(peerSub, 2, 3*time.Second)
+	activeGot := s.waitForMemoryTuple(activeSub, 2, 3*time.Second)
+	s.False(peerGot && activeGot, "expected reproduction: after restarting peer rule, at least one rule should stop receiving on shared mqtt connection")
+	s.T().Logf("restart reproduction result: peerGot=%v, activeGot=%v", peerGot, activeGot)
+}
+
+func (s *ConnectionTestSuite) startInlineBroker(id, addr string) (*mqtt.Server, *listeners.TCP) {
+	server := mqtt.New(&mqtt.Options{InlineClient: true})
+	_ = server.AddHook(new(auth.AllowHook), nil)
+	tcp := listeners.NewTCP(listeners.Config{ID: id, Address: addr})
+	err := server.AddListener(tcp)
+	s.Require().NoError(err)
+	go func() {
+		err = server.Serve()
+		fmt.Println(err)
+	}()
+	return server, tcp
+}
+
+func (s *ConnectionTestSuite) createSharedConnectionArtifacts(connID, confKey, streamName, brokerURL, sourceTopic string) {
+	connStr := fmt.Sprintf(`{
+		"id": %q,
+		"typ":"mqtt",
+		"props": {
+			"server": %q,
+			"protocolVersion": "3.1.1"
+		}
+	}`, connID, brokerURL)
+	resp, err := client.Post("connections", connStr)
+	s.Require().NoError(err)
+	body, readErr := GetResponseText(resp)
+	s.Require().NoError(readErr)
+	s.Require().Equalf(http.StatusCreated, resp.StatusCode, "create connection failed: %s", body)
+
+	conf := map[string]any{
+		"connectionSelector": connID,
+		"qos":                0,
+	}
+	resp, err = client.CreateConf("sources/mqtt/confKeys/"+confKey, conf)
+	s.Require().NoError(err)
+	body, readErr = GetResponseText(resp)
+	s.Require().NoError(readErr)
+	s.Require().Equalf(http.StatusOK, resp.StatusCode, "create source conf failed: %s", body)
+
+	streamSQL := fmt.Sprintf(`{"sql": "create stream %s () WITH (TYPE=\"mqtt\", DATASOURCE=\"%s\", FORMAT=\"json\", CONF_KEY=\"%s\", SHARED=\"true\")"}`, streamName, sourceTopic, confKey)
+	resp, err = client.CreateStream(streamSQL)
+	s.Require().NoError(err)
+	body, readErr = GetResponseText(resp)
+	s.Require().NoError(readErr)
+	s.Require().Equalf(http.StatusCreated, resp.StatusCode, "create stream failed: %s", body)
+}
+
+func (s *ConnectionTestSuite) createMemoryRule(ruleName, streamName, memoryTopic string) {
+	ruleSQL := fmt.Sprintf(`{
+	  "id": %q,
+	  "sql": "SELECT * FROM %s",
+	  "actions": [
+		{
+		  "memory": {
+			"topic": %q
+		  }
+		}
+	  ]
+	}`, ruleName, streamName, memoryTopic)
+	resp, err := client.CreateRule(ruleSQL)
+	s.Require().NoError(err)
+	body, readErr := GetResponseText(resp)
+	s.Require().NoError(readErr)
+	s.Require().Equalf(http.StatusCreated, resp.StatusCode, "create rule failed: %s", body)
+}
+
+func (s *ConnectionTestSuite) cleanupSharedConnectionArtifacts(ruleActive, rulePeer, streamName, confKey, connID string) {
+	res, err := client.Delete("rules/" + rulePeer)
+	s.NoError(err)
+	if err == nil {
+		s.True(res.StatusCode == http.StatusOK || res.StatusCode == http.StatusNotFound)
+	}
+
+	res, err = client.Delete("rules/" + ruleActive)
+	s.NoError(err)
+	if err == nil {
+		s.True(res.StatusCode == http.StatusOK || res.StatusCode == http.StatusNotFound)
+	}
+
+	res, err = client.Delete("streams/" + streamName)
+	s.NoError(err)
+	if err == nil {
+		s.True(res.StatusCode == http.StatusOK || res.StatusCode == http.StatusNotFound)
+	}
+
+	res, err = client.Delete("metadata/sources/mqtt/confKeys/" + confKey)
+	s.NoError(err)
+	if err == nil {
+		if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNotFound {
+			body, _ := GetResponseText(res)
+			s.T().Logf("cleanup confKey %s returned %d: %s", confKey, res.StatusCode, body)
+		}
+	}
+
+	_ = TryAssert(10, ConstantInterval, func() bool {
+		res, err = client.Delete("connections/" + connID)
+		s.NoError(err)
+		if err != nil {
+			return false
+		}
+		return res.StatusCode == http.StatusOK || res.StatusCode == http.StatusNotFound
+	})
+}
+
+func (s *ConnectionTestSuite) requireMemoryTuple(ch chan any, seq int, timeout time.Duration) {
+	s.Require().True(s.waitForMemoryTuple(ch, seq, timeout), "did not receive expected memory tuple")
+}
+
+func (s *ConnectionTestSuite) requireSharedSourceReady(server *mqtt.Server, sourceTopic string, peerSub, activeSub chan any, seq int) {
+	deadline := time.Now().Add(5 * time.Second)
+	peerReady := false
+	activeReady := false
+	payload := []byte(fmt.Sprintf(`{"seq":%d}`, seq))
+	time.Sleep(300 * time.Millisecond)
+	for time.Now().Before(deadline) && !(peerReady && activeReady) {
+		err := server.Publish(sourceTopic, payload, false, 0)
+		s.Require().NoError(err)
+		if !peerReady {
+			peerReady = s.waitForMemoryTuple(peerSub, seq, 300*time.Millisecond)
+		}
+		if !activeReady {
+			activeReady = s.waitForMemoryTuple(activeSub, seq, 300*time.Millisecond)
+		}
+	}
+	s.True(peerReady, "peer rule did not receive baseline tuple")
+	s.True(activeReady, "active rule did not receive baseline tuple")
+}
+
+func (s *ConnectionTestSuite) waitForMemoryTuple(ch chan any, seq int, timeout time.Duration) bool {
+	deadline := time.After(timeout)
+	for {
+		select {
+		case msg := <-ch:
+			mt, ok := msg.([]pubsub.MemTuple)
+			if !ok || len(mt) != 1 {
+				continue
+			}
+			m := mt[0].ToMap()
+			if v, ok := m["seq"]; ok {
+				switch vt := v.(type) {
+				case float64:
+					if int(vt) == seq {
+						return true
+					}
+				case int:
+					if vt == seq {
+						return true
+					}
+				}
+			}
+		case <-deadline:
+			return false
+		}
+	}
 }
 
 func (s *ConnectionTestSuite) TestSourcePing() {

--- a/fvt/conn_test.go
+++ b/fvt/conn_test.go
@@ -257,7 +257,7 @@ func (s *ConnectionTestSuite) TestConnStatus() {
 	})
 }
 
-func (s *ConnectionTestSuite) TestSharedConnectionPeerRuleStopImpactRepro() {
+func (s *ConnectionTestSuite) TestSharedConnectionPeerRuleStopDoesNotImpactActiveRule() {
 	const brokerAddr = ":5883"
 	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
 	connID := "connSharedStop" + suffix
@@ -296,7 +296,7 @@ func (s *ConnectionTestSuite) TestSharedConnectionPeerRuleStopImpactRepro() {
 	err = server.Publish(sourceTpc, []byte(`{"seq":2}`), false, 0)
 	s.Require().NoError(err)
 	activeGot := s.waitForMemoryTuple(activeSub, 2, 3*time.Second)
-	s.False(activeGot, "expected reproduction: after stopping peer rule, active rule still stops receiving on shared stream")
+	s.True(activeGot, "active rule should keep receiving after stopping peer rule on shared stream")
 }
 
 func (s *ConnectionTestSuite) TestSharedConnectionPeerRuleRestartDoesNotImpactActiveRule() {

--- a/fvt/conn_test.go
+++ b/fvt/conn_test.go
@@ -296,10 +296,10 @@ func (s *ConnectionTestSuite) TestSharedConnectionPeerRuleStopImpactRepro() {
 	err = server.Publish(sourceTpc, []byte(`{"seq":2}`), false, 0)
 	s.Require().NoError(err)
 	activeGot := s.waitForMemoryTuple(activeSub, 2, 3*time.Second)
-	s.False(activeGot, "expected reproduction: after stopping peer rule, active rule should stop receiving on shared mqtt connection")
+	s.False(activeGot, "expected reproduction: after stopping peer rule, active rule still stops receiving on shared stream")
 }
 
-func (s *ConnectionTestSuite) TestSharedConnectionPeerRuleRestartImpactRepro() {
+func (s *ConnectionTestSuite) TestSharedConnectionPeerRuleRestartDoesNotImpactActiveRule() {
 	const brokerAddr = ":5884"
 	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
 	connID := "connSharedRestart" + suffix
@@ -335,12 +335,7 @@ func (s *ConnectionTestSuite) TestSharedConnectionPeerRuleRestartImpactRepro() {
 	s.Require().NoError(err)
 	s.Require().Equal(http.StatusOK, resp.StatusCode)
 
-	err = server.Publish(sourceTpc, []byte(`{"seq":2}`), false, 0)
-	s.Require().NoError(err)
-	peerGot := s.waitForMemoryTuple(peerSub, 2, 3*time.Second)
-	activeGot := s.waitForMemoryTuple(activeSub, 2, 3*time.Second)
-	s.False(peerGot && activeGot, "expected reproduction: after restarting peer rule, at least one rule should stop receiving on shared mqtt connection")
-	s.T().Logf("restart reproduction result: peerGot=%v, activeGot=%v", peerGot, activeGot)
+	s.requireSharedSourceReady(server, sourceTpc, peerSub, activeSub, 2)
 }
 
 func (s *ConnectionTestSuite) startInlineBroker(id, addr string) (*mqtt.Server, *listeners.TCP) {
@@ -476,19 +471,21 @@ func (s *ConnectionTestSuite) waitForMemoryTuple(ch chan any, seq int, timeout t
 		select {
 		case msg := <-ch:
 			mt, ok := msg.([]pubsub.MemTuple)
-			if !ok || len(mt) != 1 {
+			if !ok || len(mt) == 0 {
 				continue
 			}
-			m := mt[0].ToMap()
-			if v, ok := m["seq"]; ok {
-				switch vt := v.(type) {
-				case float64:
-					if int(vt) == seq {
-						return true
-					}
-				case int:
-					if vt == seq {
-						return true
+			for _, tuple := range mt {
+				m := tuple.ToMap()
+				if v, ok := m["seq"]; ok {
+					switch vt := v.(type) {
+					case float64:
+						if int(vt) == seq {
+							return true
+						}
+					case int:
+						if vt == seq {
+							return true
+						}
 					}
 				}
 			}

--- a/internal/io/mqtt/conn.go
+++ b/internal/io/mqtt/conn.go
@@ -16,7 +16,6 @@ package mqtt
 
 import (
 	"fmt"
-	"sync"
 	"sync/atomic"
 
 	"github.com/lf-edge/ekuiper/contract/v2/api"
@@ -31,21 +30,28 @@ import (
 	"github.com/lf-edge/ekuiper/v2/pkg/syncx"
 )
 
+type topicSubscription struct {
+	Qos     byte
+	Handler client.MessageHandler
+	Refs    map[string]struct{}
+}
+
 type Connection struct {
 	mu syncx.Mutex
+	sm syncx.RWMutex
 	client.Client
 	id        string
 	server    string
 	connected atomic.Bool
 	status    atomic.Value
 	scHandler api.StatusChangeHandler
-	// key is the topic. Each topic will have only one connector map[string]*client.SubscriptionInfo
-	subscriptions sync.Map
+	// key is the topic. Each topic maintains one physical subscription and a ref set of logical subscribers.
+	subscriptions map[string]*topicSubscription
 }
 
 func CreateConnection(_ api.StreamContext) modules.Connection {
 	return &Connection{
-		subscriptions: sync.Map{},
+		subscriptions: make(map[string]*topicSubscription),
 	}
 }
 
@@ -130,15 +136,12 @@ func (conn *Connection) onConnect(ctx api.StreamContext) {
 		ctx.GetLogger().Warnf("sc handler has not set yet")
 	}
 	ctx.GetLogger().Infof("The connection to mqtt broker is established")
-	conn.subscriptions.Range(func(k, v any) bool {
-		topic := k.(string)
-		info := v.(*client.SubscriptionInfo)
-		err := conn.Subscribe(ctx, topic, info.Qos, info.Handler)
+	for topic, info := range conn.getPhysicalSubscriptions() {
+		err := conn.subscribePhysical(ctx, topic, info.Qos, info.Handler)
 		if err != nil { // should never happen. If happens because of connection, it will retry later
 			ctx.GetLogger().Errorf("Failed to subscribe topic %s: %v", topic, err)
 		}
-		return true
-	})
+	}
 }
 
 func (conn *Connection) onConnectLost(ctx api.StreamContext, err error) {
@@ -170,7 +173,20 @@ func (conn *Connection) DetachSub(ctx api.StreamContext, props map[string]any) {
 		ctx.GetLogger().Warnf("cannot find topic to unsub: %v", props)
 		return
 	}
-	conn.subscriptions.Delete(topic)
+	refID := getSubscriberID(ctx)
+	shouldUnsubscribe := false
+	conn.sm.Lock()
+	if info, ok := conn.subscriptions[topic]; ok {
+		delete(info.Refs, refID)
+		if len(info.Refs) == 0 {
+			delete(conn.subscriptions, topic)
+			shouldUnsubscribe = true
+		}
+	}
+	conn.sm.Unlock()
+	if !shouldUnsubscribe {
+		return
+	}
 	if conn.Client != nil {
 		err = conn.Client.Unsubscribe(ctx, topic)
 		if err != nil {
@@ -209,11 +225,36 @@ func (conn *Connection) Publish(ctx api.StreamContext, topic string, qos byte, r
 }
 
 func (conn *Connection) Subscribe(ctx api.StreamContext, topic string, qos byte, callback client.MessageHandler) error {
-	conn.subscriptions.Store(topic, &client.SubscriptionInfo{
+	refID := getSubscriberID(ctx)
+	conn.sm.Lock()
+	if info, ok := conn.subscriptions[topic]; ok {
+		if info.Qos != qos {
+			conn.sm.Unlock()
+			return fmt.Errorf("topic %s already subscribed with qos %d, cannot subscribe with qos %d", topic, info.Qos, qos)
+		}
+		info.Refs[refID] = struct{}{}
+		conn.sm.Unlock()
+		return nil
+	}
+	conn.subscriptions[topic] = &topicSubscription{
 		Qos:     qos,
 		Handler: callback,
-	})
-	err := conn.Client.Subscribe(ctx, topic, qos, callback)
+		Refs: map[string]struct{}{
+			refID: {},
+		},
+	}
+	conn.sm.Unlock()
+	err := conn.subscribePhysical(ctx, topic, qos, callback)
+	if err != nil {
+		conn.sm.Lock()
+		if info, ok := conn.subscriptions[topic]; ok && info.Qos == qos {
+			delete(info.Refs, refID)
+			if len(info.Refs) == 0 {
+				delete(conn.subscriptions, topic)
+			}
+		}
+		conn.sm.Unlock()
+	}
 	return err
 }
 
@@ -231,6 +272,30 @@ func getTopicFromProps(props map[string]any) (string, error) {
 		return v.(string), nil
 	}
 	return "", fmt.Errorf("topic or datasource not defined")
+}
+
+func getSubscriberID(ctx api.StreamContext) string {
+	return fmt.Sprintf("%s/%s/%d", ctx.GetRuleId(), ctx.GetOpId(), ctx.GetInstanceId())
+}
+
+func (conn *Connection) subscribePhysical(ctx api.StreamContext, topic string, qos byte, callback client.MessageHandler) error {
+	return conn.Client.Subscribe(ctx, topic, qos, callback)
+}
+
+func (conn *Connection) getPhysicalSubscriptions() map[string]*client.SubscriptionInfo {
+	conn.sm.RLock()
+	defer conn.sm.RUnlock()
+	snapshot := make(map[string]*client.SubscriptionInfo, len(conn.subscriptions))
+	for topic, info := range conn.subscriptions {
+		if len(info.Refs) == 0 {
+			continue
+		}
+		snapshot[topic] = &client.SubscriptionInfo{
+			Qos:     info.Qos,
+			Handler: info.Handler,
+		}
+	}
+	return snapshot
 }
 
 var _ modules.StatefulDialer = &Connection{}

--- a/internal/io/mqtt/conn_test.go
+++ b/internal/io/mqtt/conn_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/lf-edge/ekuiper/v2/internal/testx"
+	"github.com/lf-edge/ekuiper/v2/internal/xsql"
+	"github.com/lf-edge/ekuiper/v2/pkg/connection"
 	"github.com/lf-edge/ekuiper/v2/pkg/errorx"
 	mockContext "github.com/lf-edge/ekuiper/v2/pkg/mock/context"
 	"github.com/lf-edge/ekuiper/v2/pkg/modules"
@@ -141,4 +143,178 @@ func TestNoClient(t *testing.T) {
 	assert.True(t, errorx.IsIOError(err))
 	err = c.Close(ctx)
 	assert.NoError(t, err)
+}
+
+func TestSharedConnectionCloseOneSourceStopsPeerSource(t *testing.T) {
+	url, cancelBroker, err := testx.InitBroker("TestSharedConnectionCloseOneSourceStopsPeerSource")
+	require.NoError(t, err)
+	defer cancelBroker()
+
+	require.NoError(t, connection.InitConnectionManager4Test())
+	setupCtx := mockContext.NewMockContext("setup", "setup")
+	cw, err := connection.CreateNamedConnection(setupCtx, "mqtt.shared.close-peer", "mqtt", map[string]any{
+		"server":          url,
+		"protocolVersion": "3.1.1",
+	})
+	require.NoError(t, err)
+	_, err = cw.Wait(setupCtx)
+	require.NoError(t, err)
+
+	props := map[string]any{
+		"server":             url,
+		"protocolVersion":    "3.1.1",
+		"connectionSelector": "mqtt.shared.close-peer",
+		"datasource":         "demo/shared/close-peer",
+		"qos":                0,
+	}
+
+	peerCtx := mockContext.NewMockContext("peerRule", "source")
+	peer := &SourceConnector{}
+	require.NoError(t, peer.Provision(peerCtx, props))
+	require.NoError(t, peer.Connect(peerCtx, func(status string, message string) {}))
+	peerClosed := false
+	defer func() {
+		if !peerClosed {
+			require.NoError(t, peer.Close(peerCtx))
+		}
+	}()
+
+	activeCtx := mockContext.NewMockContext("activeRule", "source")
+	active := &SourceConnector{}
+	require.NoError(t, active.Provision(activeCtx, props))
+	require.NoError(t, active.Connect(activeCtx, func(status string, message string) {}))
+	activeClosed := false
+	defer func() {
+		if !activeClosed {
+			require.NoError(t, active.Close(activeCtx))
+		}
+	}()
+
+	activeCh := make(chan []byte, 4)
+	require.NoError(t, active.Subscribe(activeCtx, func(ctx api.StreamContext, payload []byte, meta map[string]any, ts time.Time) {
+		activeCh <- append([]byte(nil), payload...)
+	}, nil))
+
+	publishMQTTMessage(t, url, "demo/shared/close-peer", []byte("before-close"))
+	require.Equal(t, []byte("before-close"), waitForMessage(t, activeCh, 5*time.Second))
+
+	require.NoError(t, peer.Close(peerCtx))
+	peerClosed = true
+	time.Sleep(200 * time.Millisecond)
+
+	publishMQTTMessage(t, url, "demo/shared/close-peer", []byte("after-close"))
+	assertNoMessage(t, activeCh, 800*time.Millisecond)
+}
+
+func TestSharedConnectionRestartSourceRecoversAfterPeerClose(t *testing.T) {
+	url, cancelBroker, err := testx.InitBroker("TestSharedConnectionRestartSourceRecoversAfterPeerClose")
+	require.NoError(t, err)
+	defer cancelBroker()
+
+	require.NoError(t, connection.InitConnectionManager4Test())
+	setupCtx := mockContext.NewMockContext("setup", "setup")
+	cw, err := connection.CreateNamedConnection(setupCtx, "mqtt.shared.restart-peer", "mqtt", map[string]any{
+		"server":          url,
+		"protocolVersion": "3.1.1",
+	})
+	require.NoError(t, err)
+	_, err = cw.Wait(setupCtx)
+	require.NoError(t, err)
+
+	props := map[string]any{
+		"server":             url,
+		"protocolVersion":    "3.1.1",
+		"connectionSelector": "mqtt.shared.restart-peer",
+		"datasource":         "demo/shared/restart-peer",
+		"qos":                0,
+	}
+
+	peerCtx := mockContext.NewMockContext("peerRule", "source")
+	peer := &SourceConnector{}
+	require.NoError(t, peer.Provision(peerCtx, props))
+	require.NoError(t, peer.Connect(peerCtx, func(status string, message string) {}))
+	peerClosed := false
+	defer func() {
+		if !peerClosed {
+			require.NoError(t, peer.Close(peerCtx))
+		}
+	}()
+
+	activeCtx := mockContext.NewMockContext("activeRule", "source")
+	active := &SourceConnector{}
+	require.NoError(t, active.Provision(activeCtx, props))
+	require.NoError(t, active.Connect(activeCtx, func(status string, message string) {}))
+	activeClosed := false
+	defer func() {
+		if !activeClosed {
+			require.NoError(t, active.Close(activeCtx))
+		}
+	}()
+	activeCh := make(chan []byte, 4)
+	require.NoError(t, active.Subscribe(activeCtx, func(ctx api.StreamContext, payload []byte, meta map[string]any, ts time.Time) {
+		activeCh <- append([]byte(nil), payload...)
+	}, nil))
+
+	publishMQTTMessage(t, url, "demo/shared/restart-peer", []byte("before-break"))
+	require.Equal(t, []byte("before-break"), waitForMessage(t, activeCh, 5*time.Second))
+
+	require.NoError(t, peer.Close(peerCtx))
+	peerClosed = true
+	time.Sleep(200 * time.Millisecond)
+	publishMQTTMessage(t, url, "demo/shared/restart-peer", []byte("dropped-after-peer-close"))
+	assertNoMessage(t, activeCh, 800*time.Millisecond)
+
+	require.NoError(t, active.Close(activeCtx))
+	activeClosed = true
+
+	restartCtx := mockContext.NewMockContext("activeRuleRestart", "source")
+	restarted := &SourceConnector{}
+	require.NoError(t, restarted.Provision(restartCtx, props))
+	require.NoError(t, restarted.Connect(restartCtx, func(status string, message string) {}))
+	defer func() {
+		require.NoError(t, restarted.Close(restartCtx))
+	}()
+
+	restartedCh := make(chan []byte, 4)
+	require.NoError(t, restarted.Subscribe(restartCtx, func(ctx api.StreamContext, payload []byte, meta map[string]any, ts time.Time) {
+		restartedCh <- append([]byte(nil), payload...)
+	}, nil))
+
+	publishMQTTMessage(t, url, "demo/shared/restart-peer", []byte("after-restart"))
+	require.Equal(t, []byte("after-restart"), waitForMessage(t, restartedCh, 5*time.Second))
+}
+
+func publishMQTTMessage(t *testing.T, url, topic string, payload []byte) {
+	t.Helper()
+	sinkCtx := mockContext.NewMockContext("publisher", "sink")
+	sink := &Sink{}
+	require.NoError(t, sink.Provision(sinkCtx, map[string]any{
+		"server":          url,
+		"protocolVersion": "3.1.1",
+		"topic":           topic,
+		"qos":             0,
+	}))
+	require.NoError(t, sink.Connect(sinkCtx, func(status string, message string) {}))
+	require.NoError(t, sink.Collect(sinkCtx, &xsql.RawTuple{Rawdata: payload, Timestamp: time.Now()}))
+	require.NoError(t, sink.Close(sinkCtx))
+}
+
+func waitForMessage(t *testing.T, ch <-chan []byte, timeout time.Duration) []byte {
+	t.Helper()
+	select {
+	case msg := <-ch:
+		return msg
+	case <-time.After(timeout):
+		t.Fatalf("timeout waiting for mqtt message")
+		return nil
+	}
+}
+
+func assertNoMessage(t *testing.T, ch <-chan []byte, timeout time.Duration) {
+	t.Helper()
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected mqtt message: %s", string(msg))
+	case <-time.After(timeout):
+	}
 }

--- a/internal/io/mqtt/conn_test.go
+++ b/internal/io/mqtt/conn_test.go
@@ -145,7 +145,7 @@ func TestNoClient(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestSharedConnectionCloseOneSourceStopsPeerSource(t *testing.T) {
+func TestSharedConnectionCloseOneSourceDoesNotStopPeerSource(t *testing.T) {
 	url, cancelBroker, err := testx.InitBroker("TestSharedConnectionCloseOneSourceStopsPeerSource")
 	require.NoError(t, err)
 	defer cancelBroker()
@@ -203,10 +203,10 @@ func TestSharedConnectionCloseOneSourceStopsPeerSource(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	publishMQTTMessage(t, url, "demo/shared/close-peer", []byte("after-close"))
-	assertNoMessage(t, activeCh, 800*time.Millisecond)
+	require.Equal(t, []byte("after-close"), waitForMessage(t, activeCh, 5*time.Second))
 }
 
-func TestSharedConnectionRestartSourceRecoversAfterPeerClose(t *testing.T) {
+func TestSharedConnectionRestartSourceStillReceivesAfterPeerClose(t *testing.T) {
 	url, cancelBroker, err := testx.InitBroker("TestSharedConnectionRestartSourceRecoversAfterPeerClose")
 	require.NoError(t, err)
 	defer cancelBroker()
@@ -261,8 +261,8 @@ func TestSharedConnectionRestartSourceRecoversAfterPeerClose(t *testing.T) {
 	require.NoError(t, peer.Close(peerCtx))
 	peerClosed = true
 	time.Sleep(200 * time.Millisecond)
-	publishMQTTMessage(t, url, "demo/shared/restart-peer", []byte("dropped-after-peer-close"))
-	assertNoMessage(t, activeCh, 800*time.Millisecond)
+	publishMQTTMessage(t, url, "demo/shared/restart-peer", []byte("after-peer-close"))
+	require.Equal(t, []byte("after-peer-close"), waitForMessage(t, activeCh, 5*time.Second))
 
 	require.NoError(t, active.Close(activeCtx))
 	activeClosed = true

--- a/internal/topo/schema/source.go
+++ b/internal/topo/schema/source.go
@@ -118,14 +118,10 @@ func (s *SharedLayer) Detach(ctx api.StreamContext, isClose bool) error {
 			delete(s.streamMap, ruleID)
 			delete(s.wildcardMap, ruleID)
 			delete(s.reg, ruleID)
-			newSchema := make(map[string]*ast.JsonStreamField)
-			for _, si := range s.reg {
-				newSchema, err = s.merge(newSchema, si.schema)
-				if err != nil {
-					return err
-				}
+			s.schema, err = s.rebuildSchema()
+			if err != nil {
+				return err
 			}
-			s.schema = newSchema
 			s.updateReg()
 		}
 	}
@@ -165,6 +161,26 @@ func (s *SharedLayer) merge(originSchema, newSchema map[string]*ast.JsonStreamFi
 		}
 	}
 	return ss, nil
+}
+
+func (s *SharedLayer) rebuildSchema() (map[string]*ast.JsonStreamField, error) {
+	if len(s.wildcardMap) > 0 {
+		for ruleID := range s.wildcardMap {
+			if info, ok := s.reg[ruleID]; ok {
+				return info.schema, nil
+			}
+		}
+		return nil, nil
+	}
+	newSchema := make(map[string]*ast.JsonStreamField)
+	for _, si := range s.reg {
+		var err error
+		newSchema, err = s.merge(newSchema, si.schema)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return newSchema, nil
 }
 
 func mergeSchema(originSchema, newSchema map[string]*ast.JsonStreamField) (map[string]*ast.JsonStreamField, error) {

--- a/internal/topo/schema/source_test.go
+++ b/internal/topo/schema/source_test.go
@@ -266,3 +266,23 @@ func TestAttachDetachSchema(t *testing.T) {
 	}
 	require.Equal(t, r, er)
 }
+
+func TestDetachKeepsWildcardSchemaWhenOtherWildcardRuleStillAttached(t *testing.T) {
+	f := newSharedLayer()
+	f.RegSchema("rule1", "demo", nil, true)
+	f.RegSchema("rule2", "demo", nil, true)
+
+	ctx1 := mockContext.NewMockContext("rule1", "t1")
+	ctx2 := mockContext.NewMockContext("rule2", "t1")
+
+	require.NoError(t, f.Attach(ctx1))
+	require.NoError(t, f.Attach(ctx2))
+	require.Nil(t, f.GetSchema())
+
+	require.NoError(t, f.Detach(ctx1, true))
+	require.Nil(t, f.GetSchema())
+
+	r := GetRuleSchema("rule2")
+	require.Nil(t, r.Schema["demo"])
+	require.True(t, r.Wildcard["demo"])
+}


### PR DESCRIPTION
  What was broken

  1. Shared MQTT connection / same topic

  When multiple rules shared the same MQTT connection and subscribed to the same topic, closing one source could unsubscribe the physical MQTT topic for all logical subscribers on
  that connection.

  As a result, the remaining rule could stay in running state but stop receiving source data. Restarting the affected rule could recover it because the subscription was created
  again.

  2. Shared stream with wildcard or schemaless JSON decoding

  When multiple rules used the same SHARED=true stream, and that shared stream was effectively schemaless or wildcard-based, stopping one rule could rebuild the shared schema
  incorrectly.

  The remaining rule still kept the shared source alive, but the shared decoder could be reset from nil schema semantics to an empty schema map. In that state, source messages were
  still consumed, but all fields were dropped during decode, so downstream sinks appeared to receive no data. Restarting the rule could recover it because schema attach ran again.

  What this PR changes

  - Add reference-based subscription tracking for shared MQTT connections, so a physical unsubscribe only happens after the last logical subscriber is detached.
  - Preserve wildcard or schemaless shared-stream schema semantics when one peer rule is detached, so the remaining active rule continues to decode and receive data correctly.
  - Convert the previous reproduction-style tests into regression tests that assert the active rule keeps receiving data after a peer rule is stopped or restarted.

  User-visible impact

  This fixes cases where:

  - two rules use the same MQTT connection and the same source topic
  - two rules use the same SHARED=true stream backed by MQTT
  - one of the rules is stopped, closed, or restarted
  - the other rule should continue receiving data, but previously stopped receiving until it was restarted