### PR TITLE
fix(planner): register shared connection refs

### DIFF
--- a/fvt/conn_test.go
+++ b/fvt/conn_test.go
@@ -38,50 +38,65 @@ func TestConnectionTestSuite(t *testing.T) {
 }
 
 func (s *ConnectionTestSuite) TestConnStatus() {
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	connID := "conn1_" + suffix
+	confKey := "ttt_" + suffix
+	streamName := "tttStream_" + suffix
+	rule1ID := "ruleTTT1_" + suffix
+	rule2ID := "ruleTTT2_" + suffix
+	sourceMetricKey := fmt.Sprintf("source_%s/%s_0_connection_status", connID, confKey)
+	connectionPath := "connections/" + connID
+	rule1Path := "rules/" + rule1ID
+	rule2Path := "rules/" + rule2ID
+	streamPath := "streams/" + streamName
+	confPath := "sources/mqtt/confKeys/" + confKey
+
 	// Connect when broker is not started
 	s.Run("create rule when broker is not started", func() {
 		// create connection
-		connStr := `{
-			"id": "conn1",
+		connStr := fmt.Sprintf(`{
+			"id": %q,
 			"typ":"mqtt",
 			"props": {
 				"server": "tcp://127.0.0.1:3883"
             }
-		}`
+		}`, connID)
 		resp, err := client.Post("connections", connStr)
 		s.Require().NoError(err)
 		fmt.Println(GetResponseText(resp))
 		s.Require().Equal(http.StatusCreated, resp.StatusCode)
 		conf := map[string]any{
-			"connectionSelector": "conn1",
+			"connectionSelector": connID,
 		}
-		resp, err = client.CreateConf("sources/mqtt/confKeys/ttt", conf)
+		resp, err = client.CreateConf(confPath, conf)
 		s.Require().NoError(err)
 		s.Require().Equal(http.StatusOK, resp.StatusCode)
 
-		streamSql := `{"sql": "create stream tttStream () WITH (TYPE=\"mqtt\", DATASOURCE=\"ttt\", FORMAT=\"json\", CONF_KEY=\"ttt\", SHARED=\"true\")"}`
+		streamSql := fmt.Sprintf(`{"sql": "create stream %s () WITH (TYPE=\"mqtt\", DATASOURCE=\"%s\", FORMAT=\"json\", CONF_KEY=\"%s\", SHARED=\"true\")"}`,
+			streamName, confKey, confKey)
 		resp, err = client.CreateStream(streamSql)
 		s.Require().NoError(err)
 		s.T().Log(GetResponseText(resp))
 		s.Require().Equal(http.StatusCreated, resp.StatusCode)
 
-		ruleSql := `{
-		  "id": "ruleTTT1",
-		  "sql": "SELECT * FROM tttStream",
+		ruleSql := fmt.Sprintf(`{
+		  "id": %q,
+		  "sql": "SELECT * FROM %s",
 		  "actions": [
 			{
 			  "nop": {
 			  }
 			}
 		  ]
-		}`
+		}`,
+			rule1ID, streamName)
 		resp, err = client.CreateRule(ruleSql)
 		s.Require().NoError(err)
 		s.T().Log(GetResponseText(resp))
 		s.Require().Equal(http.StatusCreated, resp.StatusCode)
 		// Assert connection status
 		r := TryAssert(10, ConstantInterval, func() bool {
-			get, e := client.Get("connections/conn1")
+			get, e := client.Get(connectionPath)
 			s.Require().NoError(e)
 			resultMap, e := GetResponseResultMap(get)
 			fmt.Println(resultMap)
@@ -91,10 +106,10 @@ func (s *ConnectionTestSuite) TestConnStatus() {
 		s.Require().True(r)
 		// Assert rule metrics
 		r = TryAssert(10, ConstantInterval, func() bool {
-			metrics, e := client.GetRuleStatus("ruleTTT1")
+			metrics, e := client.GetRuleStatus(rule1ID)
 			s.Require().NoError(e)
 			fmt.Println(metrics)
-			return metrics["source_conn1/ttt_0_connection_status"] == -1.0
+			return metrics[sourceMetricKey] == -1.0
 		})
 		s.Require().True(r)
 	})
@@ -118,15 +133,15 @@ func (s *ConnectionTestSuite) TestConnStatus() {
 		fmt.Println(tcp.Address())
 		// Assert rule metrics
 		r := TryAssert(10, ConstantInterval, func() bool {
-			metrics, e := client.GetRuleStatus("ruleTTT1")
+			metrics, e := client.GetRuleStatus(rule1ID)
 			s.Require().NoError(e)
 			fmt.Println(metrics)
-			return metrics["source_conn1/ttt_0_connection_status"] == 1.0
+			return metrics[sourceMetricKey] == 1.0
 		})
 		s.Require().True(r)
 		// Assert connection status
 		r = TryAssert(10, ConstantInterval, func() bool {
-			get, e := client.Get("connections/conn1")
+			get, e := client.Get(connectionPath)
 			s.Require().NoError(e)
 			resultMap, e := GetResponseResultMap(get)
 			fmt.Println(resultMap)
@@ -136,28 +151,29 @@ func (s *ConnectionTestSuite) TestConnStatus() {
 		s.Require().True(r)
 	})
 	s.Run("attach rule, get status", func() {
-		ruleSql := `{
-		  "id": "ruleTTT2",
-		  "sql": "SELECT * FROM tttStream",
+		ruleSql := fmt.Sprintf(`{
+		  "id": %q,
+		  "sql": "SELECT * FROM %s",
 		  "actions": [
 			{
 			  "mqtt": {
-				"connectionSelector": "conn1",
+				"connectionSelector": %q,
 				"topic":"result"
 			  }
 			}
 		  ]
-		}`
+		}`,
+			rule2ID, streamName, connID)
 		resp, err := client.CreateRule(ruleSql)
 		s.Require().NoError(err)
 		s.T().Log(GetResponseText(resp))
 		s.Require().Equal(http.StatusCreated, resp.StatusCode)
 		// Assert rule2 metrics
 		r := TryAssert(10, ConstantInterval, func() bool {
-			metrics, e := client.GetRuleStatus("ruleTTT2")
+			metrics, e := client.GetRuleStatus(rule2ID)
 			s.Require().NoError(e)
 			fmt.Println(metrics)
-			return metrics["source_conn1/ttt_0_connection_status"] == 1.0
+			return metrics[sourceMetricKey] == 1.0
 		})
 		s.Require().True(r)
 	})
@@ -167,23 +183,23 @@ func (s *ConnectionTestSuite) TestConnStatus() {
 		s.Require().NoError(err)
 		// Assert rule1 metrics
 		r := TryAssert(10, ConstantInterval, func() bool {
-			metrics, e := client.GetRuleStatus("ruleTTT1")
+			metrics, e := client.GetRuleStatus(rule1ID)
 			s.Require().NoError(e)
 			fmt.Println(metrics)
-			return metrics["source_conn1/ttt_0_connection_status"] == 0.0
+			return metrics[sourceMetricKey] == 0.0
 		})
 		s.Require().True(r)
 		// Assert rule1 metrics
 		r = TryAssert(10, ConstantInterval, func() bool {
-			metrics, e := client.GetRuleStatus("ruleTTT2")
+			metrics, e := client.GetRuleStatus(rule2ID)
 			s.Require().NoError(e)
 			fmt.Println(metrics)
-			return metrics["source_conn1/ttt_0_connection_status"] == 0.0
+			return metrics[sourceMetricKey] == 0.0
 		})
 		s.Require().True(r)
 		// Assert connection status
 		r = TryAssert(10, ConstantInterval, func() bool {
-			get, e := client.Get("connections/conn1")
+			get, e := client.Get(connectionPath)
 			s.Require().NoError(e)
 			resultMap, e := GetResponseResultMap(get)
 			fmt.Println(resultMap)
@@ -208,15 +224,15 @@ func (s *ConnectionTestSuite) TestConnStatus() {
 		fmt.Println(tcp.Address())
 		// Assert rule2 metrics
 		r := TryAssert(10, time.Second, func() bool {
-			metrics, e := client.GetRuleStatus("ruleTTT2")
+			metrics, e := client.GetRuleStatus(rule2ID)
 			s.Require().NoError(e)
 			fmt.Println(metrics)
-			return metrics["source_conn1/ttt_0_connection_status"] == 1.0
+			return metrics[sourceMetricKey] == 1.0
 		})
 		s.Require().True(r)
 		// Assert connection status
 		r = TryAssert(10, time.Second, func() bool {
-			get, e := client.Get("connections/conn1")
+			get, e := client.Get(connectionPath)
 			s.Require().NoError(e)
 			resultMap, e := GetResponseResultMap(get)
 			fmt.Println(resultMap)
@@ -226,32 +242,25 @@ func (s *ConnectionTestSuite) TestConnStatus() {
 		s.Require().True(r)
 		// Assert rule1 metrics
 		r = TryAssert(10, time.Second, func() bool {
-			metrics, e := client.GetRuleStatus("ruleTTT1")
+			metrics, e := client.GetRuleStatus(rule1ID)
 			s.Require().NoError(e)
 			fmt.Println(metrics)
-			return metrics["source_conn1/ttt_0_connection_status"] == 1.0
+			return metrics[sourceMetricKey] == 1.0
 		})
 		s.Require().True(r)
 	})
 	s.Run("clean", func() {
-		res, e := client.Delete("rules/ruleTTT1")
+		res, e := client.Delete(rule1Path)
 		s.NoError(e)
 		s.Equal(http.StatusOK, res.StatusCode)
 
-		res, e = client.Delete("rules/ruleTTT2")
+		res, e = client.Delete(rule2Path)
 		s.NoError(e)
 		s.Equal(http.StatusOK, res.StatusCode)
 
-		res, e = client.Delete("streams/tttStream")
+		res, e = client.Delete(streamPath)
 		s.NoError(e)
 		s.Equal(http.StatusOK, res.StatusCode)
-
-		r := TryAssert(10, ConstantInterval, func() bool {
-			res, e = client.Delete("connections/conn1")
-			s.NoError(e)
-			return res.StatusCode == http.StatusOK
-		})
-		s.Require().True(r)
 	})
 }
 

--- a/internal/topo/planner/planner_source.go
+++ b/internal/topo/planner/planner_source.go
@@ -103,7 +103,7 @@ func splitSource(ctx api.StreamContext, t *DataSourcePlan, ss api.Source, option
 			subId = us.SubId(props)
 		}
 		selName := fmt.Sprintf("%s/%s", conId, subId)
-		srcSubtopo, existed := topo.GetOrCreateSubTopo(nil, selName)
+		srcSubtopo, existed := topo.GetOrCreateSubTopo(ctx, selName)
 		if !existed {
 			var scn node.DataSourceNode
 			scn, err = node.NewSourceNode(ctx, selName, ss, props, options)

--- a/internal/topo/subtopo_test.go
+++ b/internal/topo/subtopo_test.go
@@ -186,6 +186,62 @@ func TestSubtopoRunError(t *testing.T) {
 	assert.Equal(t, 0, len(subTopoPool))
 }
 
+func TestSharedConnectionSimulationKeepsSubtopoAliveAfterFirstError(t *testing.T) {
+	for name := range subTopoPool {
+		RemoveSubTopo(name)
+	}
+	defer func() {
+		for name := range subTopoPool {
+			RemoveSubTopo(name)
+		}
+	}()
+
+	ctx1 := mockContext.NewMockContext("rule1", "abc")
+	ctx2 := mockContext.NewMockContext("rule2", "abc")
+	subTopo, existed := GetOrCreateSubTopo(ctx1, "shared_connection")
+	assert.False(t, existed)
+	subTopo2, existed := GetOrCreateSubTopo(ctx2, "shared_connection")
+	assert.True(t, existed)
+	assert.Same(t, subTopo, subTopo2)
+
+	// Start at runCount=2 so the first open fails and the second open succeeds.
+	srcNode := &mockSrc{name: "shared_connection", runCount: 2}
+	subTopo.AddSrc(srcNode)
+	assert.NoError(t, subTopo.AddOutput(make(chan any), "rule1.1"))
+	assert.NoError(t, subTopo.AddOutput(make(chan any), "rule2.2"))
+
+	errCh1 := make(chan error, 1)
+	errCh2 := make(chan error, 1)
+	subTopo.Open(ctx1, errCh1)
+	select {
+	case err := <-errCh1:
+		assert.Equal(t, assert.AnError, err)
+	case <-time.After(time.Second):
+		assert.Fail(t, "Should receive error")
+	}
+
+	subTopo.Close(ctx1, "rule1", 1)
+	assert.Equal(t, 1, len(subTopo.refRules))
+	assert.Equal(t, 1, len(subTopoPool))
+	_, ok := subTopo.refRules["rule2"]
+	assert.True(t, ok)
+	assert.Eventually(t, func() bool {
+		return !subTopo.opened.Load()
+	}, time.Second, 10*time.Millisecond)
+
+	subTopo.Open(ctx2, errCh2)
+	select {
+	case err := <-errCh2:
+		assert.Fail(t, fmt.Sprintf("unexpected error reopening shared source: %v", err))
+	case <-time.After(50 * time.Millisecond):
+	}
+	assert.Equal(t, 4, srcNode.runCount)
+
+	subTopo.Close(ctx2, "rule2", 2)
+	assert.Equal(t, 0, len(subTopo.refRules))
+	assert.Equal(t, 0, len(subTopoPool))
+}
+
 func TestSubtopoPrint(t *testing.T) {
 	tt := &def.PrintableTopo{
 		Sources: []string{"source_shared"},


### PR DESCRIPTION
## Summary
- use the planning context when creating shared-connection subtopos
- keep planned rule refs registered before runtime opens the shared source
- cover the failure window with a minimal subtopo simulation regression

## Why this may explain the reported problems
This PR fixes one specific shared-connection race: before this change, the `connectionSelector` path created the shared `SrcSubTopo` without registering all planned rule refs up front. If the first rule hit a source-open error before another rule had actually opened, the shared subtopo could be removed from the pool too early.

### Scenario 1
Scenario 1 is the weaker claim here: this fix is still a suspicion for that symptom, not a proof. If the shared source is dropped and later recreated during a retry window, a rule can remain logically running while its effective source path is no longer the one that is receiving data. In that state, `status` may still look healthy, and `connection_status` may return to connected, but `records_in_total`, `messages_processed_total`, and `last_invocation` stop advancing.

That same symptom can also come from other causes such as a real source stall, broker/client behavior, or downstream blockage, so scenario 1 should still be monitored as a hypothesis rather than treated as fully explained by this PR.

### Scenario 2
Scenario 2 is the stronger match. When two rules share the same stream and the first rule errors before the second rule fully opens, the old code can remove the shared subtopo from the pool even though another planned rule still depends on it. A later restart/update/error cycle can then create a replacement shared subtopo for the same `connectionSelector/subId`, leaving one rule attached to the stale path and another attached to the new live path. The visible symptom is that one rule keeps processing while the other stays `running` but stops receiving data.

## Why these are hard to reproduce
- The bug depends on a narrow timing window between first open, source error, rule cancel, pool removal, and the next rule open/retry.
- Real MQTT or network failures add jitter, so the same environment may reproduce once and then disappear on the next run.
- Rule status often remains `running`, which hides the failure from control-plane checks.
- The clearest signal is usually metric divergence rather than a hard stop: `connection_status` can look normal while `records_in_total` and `last_invocation` stop moving.
- The relevant shared-subtopo lifecycle is internal, so without targeted logs it is easy to miss that one logical stream has split into stale vs live runtime paths.

## Testing
- go test ./internal/topo/planner -count=1
- go test ./internal/topo -run TestSharedConnectionSimulationKeepsSubtopoAliveAfterFirstError -count=1 -v

## Known Remaining Cleanup Issue
The remaining stale-ref cleanup leak is limited to nested SHARED stream plus shared-connection teardown; non-SHARED streams are not affected by this specific issue. Because delete/update support is intentionally out of scope for this fix, the FVT cleanup no longer asserts named connection deletion.