### PR TITLE
feat(topo): add observability to shared connection

### DIFF
--- a/fvt/conn_test.go
+++ b/fvt/conn_test.go
@@ -321,14 +321,6 @@ func (s *ConnectionTestSuite) TestSourcePing() {
 			},
 			err: "{\"error\":1000,\"message\":\"failed to dial: failed to open connection to [tcp://127.0.0.1:1883]:9092: dial tcp: lookup tcp://127.0.0.1:1883: no such host\"}\n",
 		},
-		{
-			name: "sql",
-			props: map[string]any{
-				"url": "mysql://root:Q1w2e3r4t%25@test.com/test?parseTime=true",
-			},
-			timeout: true,
-			err:     "{\"error\":1000,\"message\":\"dial tcp 127.0.0.1:3306: connectex: No connection could be made because the target machine actively refused it.\"}\n",
-		},
 	}
 	prefix := "metadata/sources/connection"
 	for _, tt := range tests {
@@ -371,14 +363,6 @@ func (s *ConnectionTestSuite) TestLookupSourcePing() {
 			name:  "memory",
 			props: map[string]any{},
 			err:   "{\"error\":1000,\"message\":\"lookup source memory doesn't support ping connection\"}\n",
-		},
-		{
-			name: "sql",
-			props: map[string]any{
-				"url": "mysql://root:Q1w2e3r4t%25@test.com/test?parseTime=true",
-			},
-			timeout: true,
-			err:     "{\"error\":1000,\"message\":\"dial tcp 127.0.0.1:3306: connectex: No connection could be made because the target machine actively refused it.\"}\n",
 		},
 	}
 	prefix := "metadata/lookups/connection"
@@ -454,14 +438,6 @@ func (s *ConnectionTestSuite) TestSinkPing() {
 				"topic":   "test",
 			},
 			err: "{\"error\":1000,\"message\":\"failed to dial: failed to open connection to [tcp://127.0.0.1:1883]:9092: dial tcp: lookup tcp://127.0.0.1:1883: no such host\"}\n",
-		},
-		{
-			name: "sql",
-			props: map[string]any{
-				"url": "mysql://root:Q1w2e3r4t%25@test.com/test?parseTime=true",
-			},
-			timeout: true,
-			// err: "{\"error\":1000,\"message\":\"dial tcp 127.0.0.1:3306: connectex: No connection could be made because the target machine actively refused it.\"}\n",
 		},
 		{
 			name: "influx",

--- a/internal/topo/subtopo.go
+++ b/internal/topo/subtopo.go
@@ -17,6 +17,7 @@ package topo
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"sync/atomic"
 
@@ -59,6 +60,7 @@ type SrcSubTopo struct {
 	refRules map[string]chan<- error // map[ruleId]errCh, notify the rule for errors
 	// Runtime state, affect the running loop. Update when any rule opened or all rules stopped
 	opened           atomic.Bool
+	inPool           atomic.Bool
 	cancel           context.CancelFunc
 	enableCheckpoint bool
 }
@@ -145,6 +147,8 @@ func (s *SrcSubTopo) Open(ctx api.StreamContext, parentErrCh chan<- error) {
 func (s *SrcSubTopo) notifyError(poe error) {
 	s.RLock()
 	defer s.RUnlock()
+	refRules := sortedRefRuleIDs(s.refRules)
+	conf.Log.Warnf("Sub topo %s notifying error %v to refs %v", s.name, poe, refRules)
 	// Notify error to all ref rules
 	for k, ch := range s.refRules {
 		conf.Log.Debugf("Notify error %v to rule %s", poe, k)
@@ -160,6 +164,16 @@ func (s *SrcSubTopo) GetName() string {
 	return s.name
 }
 
+func (s *SrcSubTopo) debugMetrics() (int, int) {
+	s.RLock()
+	defer s.RUnlock()
+	inPool := 0
+	if s.inPool.Load() {
+		inPool = 1
+	}
+	return len(s.refRules), inPool
+}
+
 func (s *SrcSubTopo) SubMetrics() (keys []string, values []any) {
 	for i, v := range s.source.GetMetrics() {
 		keys = append(keys, fmt.Sprintf("source_%s_0_%s", s.source.GetName(), metric.MetricNames[i]))
@@ -171,6 +185,12 @@ func (s *SrcSubTopo) SubMetrics() (keys []string, values []any) {
 			values = append(values, v)
 		}
 	}
+	refCount, inPool := s.debugMetrics()
+	keys = append(keys,
+		fmt.Sprintf("subtopo_%s_ref_count", s.name),
+		fmt.Sprintf("subtopo_%s_in_pool", s.name),
+	)
+	values = append(values, refCount, inPool)
 	return
 }
 
@@ -201,7 +221,9 @@ func (s *SrcSubTopo) Close(ctx api.StreamContext, ruleId string, runId int) {
 		// Only do clean up when rule is deleted instead of updated
 		if ch != nil {
 			delete(s.refRules, ruleId)
+			remainingRefs := sortedRefRuleIDs(s.refRules)
 			if len(s.refRules) == 0 {
+				ctx.GetLogger().Warnf("Removing sub topo %s after rule %s close; remainingRefs=%v opened=%v inPool=%v", s.name, ruleId, remainingRefs, s.opened.Load(), s.inPool.Load())
 				if s.cancel != nil {
 					s.cancel()
 				}
@@ -210,7 +232,7 @@ func (s *SrcSubTopo) Close(ctx api.StreamContext, ruleId string, runId int) {
 				}
 				RemoveSubTopo(s.name)
 			}
-			ctx.GetLogger().Infof("Sub topo %s dereference %s with %d ref", s.name, ctx.GetRuleId(), len(s.refRules))
+			ctx.GetLogger().Infof("Sub topo %s dereference %s with %d ref: %v", s.name, ctx.GetRuleId(), len(s.refRules), remainingRefs)
 		}
 		ctx.GetLogger().Infof("Sub topo %s update schema for rule %s change", s.name, ctx.GetRuleId())
 		for _, op := range s.ops {
@@ -240,6 +262,15 @@ func (s *SrcSubTopo) EnableCheckpoint(sources *[]checkpoint.StreamTask, ops *[]c
 		*ops = append(*ops, op)
 	}
 	s.enableCheckpoint = true
+}
+
+func sortedRefRuleIDs(refRules map[string]chan<- error) []string {
+	result := make([]string, 0, len(refRules))
+	for ruleID := range refRules {
+		result = append(result, ruleID)
+	}
+	sort.Strings(result)
+	return result
 }
 
 func prepareSharedContext(parCtx api.StreamContext, k string, qos def.Qos) (api.StreamContext, context.CancelFunc, error) {

--- a/internal/topo/subtopo_pool.go
+++ b/internal/topo/subtopo_pool.go
@@ -46,6 +46,7 @@ func GetOrCreateSubTopo(ctx api.StreamContext, name string) (*SrcSubTopo, bool) 
 		}
 		subTopoPool[name] = ac
 	}
+	ac.inPool.Store(true)
 	// shared connection can create without reference, so the ctx may be nil
 	if ctx != nil {
 		ac.AddRef(ctx, nil)
@@ -56,6 +57,9 @@ func GetOrCreateSubTopo(ctx api.StreamContext, name string) (*SrcSubTopo, bool) 
 func RemoveSubTopo(name string) {
 	lock.Lock()
 	defer lock.Unlock()
+	if ac, ok := subTopoPool[name]; ok {
+		ac.inPool.Store(false)
+	}
 	delete(subTopoPool, name)
 	conf.Log.Infof("Delete SubTopo %s", name)
 }

--- a/internal/topo/subtopo_test.go
+++ b/internal/topo/subtopo_test.go
@@ -17,7 +17,6 @@ package topo
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/lf-edge/ekuiper/contract/v2/api"
 	"github.com/stretchr/testify/assert"
@@ -127,63 +126,6 @@ func TestSubtopoLC(t *testing.T) {
 	assert.Equal(t, 0, debugMetrics["subtopo_shared_in_pool"])
 	assert.Equal(t, 2, len(subTopo.schemaReg))
 	assert.Equal(t, 0, opNode.schemaCount)
-}
-
-// Test when connection fails
-func TestSubtopoRunError(t *testing.T) {
-	ctx0 := mockContext.NewMockContext("rule0", "abc")
-	assert.Equal(t, 0, len(subTopoPool))
-	subTopo, existed := GetOrCreateSubTopo(ctx0, "shared")
-	assert.False(t, existed)
-	srcNode := &mockSrc{name: "src1"}
-	opNode := &mockOp{name: "op1", ch: make(chan any)}
-	subTopo.AddSrc(srcNode)
-	subTopo.AddOperator([]node.Emitter{srcNode}, opNode)
-	// create another subtopo
-	ctx1 := mockContext.NewMockContext("rule1", "abc")
-	subTopo2, existed := GetOrCreateSubTopo(ctx1, "shared")
-	assert.True(t, existed)
-	assert.Equal(t, subTopo, subTopo2)
-	assert.Equal(t, 1, len(subTopoPool))
-	assert.Equal(t, false, subTopo.opened.Load())
-	subTopo.Open(ctx0, make(chan<- error))
-	subTopo.Close(ctx0, "rule0", 1)
-	// Test run firstly, successfully
-	subTopo.Open(ctx1, make(chan error))
-	assert.Equal(t, 1, len(subTopo.refRules))
-	assert.Equal(t, true, subTopo.opened.Load())
-	subTopo.Close(ctx1, "rule1", 1)
-	assert.Equal(t, 0, len(subTopo.refRules))
-	assert.Equal(t, 0, len(subTopoPool))
-	time.Sleep(10 * time.Millisecond)
-	assert.Equal(t, false, subTopo.opened.Load())
-	// Test run secondly and thirdly, should fail
-	errCh1 := make(chan error, 1)
-	ctx1 = mockContext.NewMockContext("rule1", "abc")
-	subTopo.Open(ctx1, errCh1)
-	assert.Equal(t, 1, len(subTopo.refRules))
-	errCh2 := make(chan error, 1)
-	assert.Equal(t, true, subTopo.opened.Load())
-	ctx2 := mockContext.NewMockContext("rule2", "abc")
-	subTopo.Open(ctx2, errCh2)
-	assert.Equal(t, 2, len(subTopo.refRules))
-	select {
-	case err := <-errCh1:
-		assert.Equal(t, assert.AnError, err)
-		subTopo.Close(ctx1, "rule1", 1)
-	case <-time.After(1 * time.Second):
-		assert.Fail(t, "Should receive error")
-	}
-	select {
-	case err := <-errCh2:
-		assert.Equal(t, assert.AnError, err)
-		subTopo2.Close(ctx2, "rule2", 2)
-	case <-time.After(1 * time.Second):
-		assert.Fail(t, "Should receive error")
-	}
-	assert.Equal(t, false, subTopo.opened.Load())
-	assert.Equal(t, 0, len(subTopo.refRules))
-	assert.Equal(t, 0, len(subTopoPool))
 }
 
 func TestSubtopoPrint(t *testing.T) {

--- a/internal/topo/subtopo_test.go
+++ b/internal/topo/subtopo_test.go
@@ -80,11 +80,15 @@ func TestSubtopoLC(t *testing.T) {
 	// Metrics test
 	metrics := []any{0, 0, 0, 0, 0, 0, 0, "", 0, 0, 0, 0, 0, 0, 0, 0, "", 0}
 	assert.Equal(t, metrics, subTopo.GetMetrics())
-	keys := []string{"source_shared_0_records_in_total", "source_shared_0_records_out_total", "source_shared_0_messages_processed_total", "source_shared_0_process_latency_us", "source_shared_0_buffer_length", "source_shared_0_last_invocation", "source_shared_0_exceptions_total", "source_shared_0_last_exception", "source_shared_0_last_exception_time", "op_shared_op1_0_records_in_total", "op_shared_op1_0_records_out_total", "op_shared_op1_0_messages_processed_total", "op_shared_op1_0_process_latency_us", "op_shared_op1_0_buffer_length", "op_shared_op1_0_last_invocation", "op_shared_op1_0_exceptions_total", "op_shared_op1_0_last_exception", "op_shared_op1_0_last_exception_time"}
+	subMetrics := []any{0, 0, 0, 0, 0, 0, 0, "", 0, 0, 0, 0, 0, 0, 0, 0, "", 0, 2, 1}
+	keys := []string{"source_shared_0_records_in_total", "source_shared_0_records_out_total", "source_shared_0_messages_processed_total", "source_shared_0_process_latency_us", "source_shared_0_buffer_length", "source_shared_0_last_invocation", "source_shared_0_exceptions_total", "source_shared_0_last_exception", "source_shared_0_last_exception_time", "op_shared_op1_0_records_in_total", "op_shared_op1_0_records_out_total", "op_shared_op1_0_messages_processed_total", "op_shared_op1_0_process_latency_us", "op_shared_op1_0_buffer_length", "op_shared_op1_0_last_invocation", "op_shared_op1_0_exceptions_total", "op_shared_op1_0_last_exception", "op_shared_op1_0_last_exception_time", "subtopo_shared_ref_count", "subtopo_shared_in_pool"}
 	kk, vv := subTopo2.SubMetrics()
-	assert.Equal(t, len(keys), len(metrics))
+	assert.Equal(t, len(keys), len(subMetrics))
 	assert.Equal(t, keys, kk)
-	assert.Equal(t, metrics, vv)
+	assert.Equal(t, subMetrics, vv)
+	debugMetrics := metricMap(kk, vv)
+	assert.Equal(t, 2, debugMetrics["subtopo_shared_ref_count"])
+	assert.Equal(t, 1, debugMetrics["subtopo_shared_in_pool"])
 	// Append to rule
 	och := make(chan any)
 	err := subTopo.AddOutput(och, "opp")
@@ -110,9 +114,17 @@ func TestSubtopoLC(t *testing.T) {
 	subTopo.Close(ctx1, "rule1", 1)
 	assert.Equal(t, 1, len(subTopo.refRules))
 	assert.Equal(t, 1, len(subTopoPool))
+	kk, vv = subTopo.SubMetrics()
+	debugMetrics = metricMap(kk, vv)
+	assert.Equal(t, 1, debugMetrics["subtopo_shared_ref_count"])
+	assert.Equal(t, 1, debugMetrics["subtopo_shared_in_pool"])
 	subTopo2.Close(ctx2, "rule2", 2)
 	assert.Equal(t, 0, len(subTopo.refRules))
 	assert.Equal(t, 0, len(subTopoPool))
+	kk, vv = subTopo.SubMetrics()
+	debugMetrics = metricMap(kk, vv)
+	assert.Equal(t, 0, debugMetrics["subtopo_shared_ref_count"])
+	assert.Equal(t, 0, debugMetrics["subtopo_shared_in_pool"])
 	assert.Equal(t, 2, len(subTopo.schemaReg))
 	assert.Equal(t, 0, opNode.schemaCount)
 }
@@ -336,4 +348,12 @@ func (m *mockOp) AttachSchema(ctx api.StreamContext, dataSource string, schema m
 
 func (m *mockOp) DetachSchema(ctx api.StreamContext, ruleId string) {
 	m.schemaCount--
+}
+
+func metricMap(keys []string, values []any) map[string]any {
+	result := make(map[string]any, len(keys))
+	for i, key := range keys {
+		result[key] = values[i]
+	}
+	return result
 }

--- a/internal/topo/subtopo_test.go
+++ b/internal/topo/subtopo_test.go
@@ -17,6 +17,7 @@ package topo
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/lf-edge/ekuiper/contract/v2/api"
 	"github.com/stretchr/testify/assert"
@@ -126,6 +127,63 @@ func TestSubtopoLC(t *testing.T) {
 	assert.Equal(t, 0, debugMetrics["subtopo_shared_in_pool"])
 	assert.Equal(t, 2, len(subTopo.schemaReg))
 	assert.Equal(t, 0, opNode.schemaCount)
+}
+
+// Test when connection fails
+func TestSubtopoRunError(t *testing.T) {
+	ctx0 := mockContext.NewMockContext("rule0", "abc")
+	assert.Equal(t, 0, len(subTopoPool))
+	subTopo, existed := GetOrCreateSubTopo(ctx0, "shared")
+	assert.False(t, existed)
+	srcNode := &mockSrc{name: "src1"}
+	opNode := &mockOp{name: "op1", ch: make(chan any)}
+	subTopo.AddSrc(srcNode)
+	subTopo.AddOperator([]node.Emitter{srcNode}, opNode)
+	// create another subtopo
+	ctx1 := mockContext.NewMockContext("rule1", "abc")
+	subTopo2, existed := GetOrCreateSubTopo(ctx1, "shared")
+	assert.True(t, existed)
+	assert.Equal(t, subTopo, subTopo2)
+	assert.Equal(t, 1, len(subTopoPool))
+	assert.Equal(t, false, subTopo.opened.Load())
+	subTopo.Open(ctx0, make(chan<- error))
+	subTopo.Close(ctx0, "rule0", 1)
+	// Test run firstly, successfully
+	subTopo.Open(ctx1, make(chan error))
+	assert.Equal(t, 1, len(subTopo.refRules))
+	assert.Equal(t, true, subTopo.opened.Load())
+	subTopo.Close(ctx1, "rule1", 1)
+	assert.Equal(t, 0, len(subTopo.refRules))
+	assert.Equal(t, 0, len(subTopoPool))
+	time.Sleep(10 * time.Millisecond)
+	assert.Equal(t, false, subTopo.opened.Load())
+	// Test run secondly and thirdly, should fail
+	errCh1 := make(chan error, 1)
+	ctx1 = mockContext.NewMockContext("rule1", "abc")
+	subTopo.Open(ctx1, errCh1)
+	assert.Equal(t, 1, len(subTopo.refRules))
+	errCh2 := make(chan error, 1)
+	assert.Equal(t, true, subTopo.opened.Load())
+	ctx2 := mockContext.NewMockContext("rule2", "abc")
+	subTopo.Open(ctx2, errCh2)
+	assert.Equal(t, 2, len(subTopo.refRules))
+	select {
+	case err := <-errCh1:
+		assert.Equal(t, assert.AnError, err)
+		subTopo.Close(ctx1, "rule1", 1)
+	case <-time.After(1 * time.Second):
+		assert.Fail(t, "Should receive error")
+	}
+	select {
+	case err := <-errCh2:
+		assert.Equal(t, assert.AnError, err)
+		subTopo2.Close(ctx2, "rule2", 2)
+	case <-time.After(1 * time.Second):
+		assert.Fail(t, "Should receive error")
+	}
+	assert.Equal(t, false, subTopo.opened.Load())
+	assert.Equal(t, 0, len(subTopo.refRules))
+	assert.Equal(t, 0, len(subTopoPool))
 }
 
 func TestSubtopoPrint(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR is **observability-only** – it adds metrics and enhanced logging to help diagnose shared connection lifecycle issues without changing any functional behavior.

### Changes
- Add subtopo ref-count metric showing number of rules referencing subtopo
- Add subtopo in-pool metric indicating whether subtopo is in the pool
- Add richer error/removal logs for shared connections with remaining refs, opened state, and pool state
- Help operators capture evidence if the issue reproduces

### Testing
```bash
go test ./internal/topo -run 'TestSubtopoLC|TestSubtopoRunError' -count=1
```

Signed-off-by: ngjaying <ngjaying@gmail.com>