### PR TITLE
fix(kafka): close transport on sink close (#4034)

### DIFF
--- a/extensions/impl/kafka/sink.go
+++ b/extensions/impl/kafka/sink.go
@@ -52,6 +52,7 @@ const (
 type KafkaSink struct {
 	props          map[string]any
 	writer         *kafkago.Writer
+	transport      *kafkago.Transport
 	kc             *kafkaConf
 	tlsConfig      *tls.Config
 	headersMap     map[string]string
@@ -209,6 +210,11 @@ func (k *KafkaSink) ping(address string) error {
 
 func (k *KafkaSink) buildKafkaWriter(ctx api.StreamContext) {
 	brokers := strings.Split(k.kc.Brokers, ",")
+	transport := &kafkago.Transport{
+		SASL: k.mechanism,
+		TLS:  k.tlsConfig,
+	}
+	k.transport = transport
 	w := &kafkago.Writer{
 		Addr:  kafkago.TCP(brokers...),
 		Topic: k.kc.Topic,
@@ -221,20 +227,22 @@ func (k *KafkaSink) buildKafkaWriter(ctx api.StreamContext) {
 		BatchSize:              k.kc.BatchSize,
 		BatchBytes:             k.kc.BatchBytes,
 		BatchTimeout:           k.kc.BatchTimeout,
-		Transport: &kafkago.Transport{
-			SASL: k.mechanism,
-			TLS:  k.tlsConfig,
-		},
-		Compression: toCompression(k.kc.Compression),
-		RuleID:      ctx.GetRuleId(),
-		OpID:        ctx.GetOpId(),
+		Transport:              transport,
+		Compression:            toCompression(k.kc.Compression),
+		RuleID:                 ctx.GetRuleId(),
+		OpID:                   ctx.GetOpId(),
 	}
 	k.writer = w
 	return
 }
 
 func (k *KafkaSink) Close(ctx api.StreamContext) error {
-	return k.writer.Close()
+	err := k.writer.Close()
+	if k.transport != nil {
+		k.transport.CloseIdleConnections()
+		k.transport = nil
+	}
+	return err
 }
 
 func (k *KafkaSink) Connect(ctx api.StreamContext, sch api.StatusChangeHandler) error {


### PR DESCRIPTION
## Problem

When a Kafka sink is configured with SASL authentication and a rule is stopped, NeuronEx / eKuiper continues to make authentication attempts against the Kafka broker. This can cause the Kafka account to be locked out if the credentials are wrong.

## Root Cause

`buildKafkaWriter` creates an external `kafkago.Transport` and assigns it to `Writer.Transport` (the uppercase, user-provided field):

```go
Transport: &kafkago.Transport{
    SASL: k.mechanism,
    TLS:  k.tlsConfig,
},
```

The first time this transport is used, `kafka-go` creates a `connPool` and starts a background goroutine (`connPool.discover`) that periodically refreshes cluster metadata — including SASL authentication — every ~6 seconds. This goroutine's context is derived from `context.Background()` (because `Transport.Context` is not set), so cancelling the rule context does not stop it.

`Writer.Close()` only calls `CloseIdleConnections()` on the **internal** lowercase `w.transport` field (created via the old Dialer API). It does **not** touch the **external** `w.Transport` field. So after `KafkaSink.Close()` → `k.writer.Close()`, the transport's `discover` goroutine keeps running indefinitely and keeps retrying SASL auth even after all rules are stopped.

The only way to stop the goroutine is via
`Transport.CloseIdleConnections()`, which cancels the pool's context.

## Fix

Store the transport reference in `KafkaSink` and call `CloseIdleConnections()` explicitly in `Close()`.

```go
func (k *KafkaSink) Close(ctx api.StreamContext) error {
    err := k.writer.Close()
    if k.transport != nil {
        k.transport.CloseIdleConnections()
        k.transport = nil
    }
    return err
}
```