### PR TITLE
fix(topo): avoid maps.Clear

### DIFF
--- a/internal/topo/node/cache_op_test.go
+++ b/internal/topo/node/cache_op_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/exp/maps"
 
 	"github.com/lf-edge/ekuiper/v2/internal/conf"
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
@@ -174,7 +173,10 @@ func TestRunError(t *testing.T) {
 	assert.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), "cache op should have only 1 output but got"), err.Error())
 	// Test done
-	maps.Clear(op.outputs)
+	for k := range op.outputs {
+		delete(op.outputs, k)
+	}
+
 	err = op.AddOutput(make(chan any, 2), "output1")
 	assert.NoError(t, err)
 	op.Exec(ctx, errCh)

--- a/internal/topo/node/rate_limit.go
+++ b/internal/topo/node/rate_limit.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/lf-edge/ekuiper/contract/v2/api"
-	"golang.org/x/exp/maps"
 
 	"github.com/lf-edge/ekuiper/v2/internal/conf"
 	"github.com/lf-edge/ekuiper/v2/internal/converter"
@@ -221,7 +220,9 @@ func (o *RateLimitOp) Exec(ctx api.StreamContext, errCh chan<- error) {
 						o.Broadcast(val)
 						o.onSend(ctx, val)
 						o.latest = nil
-						maps.Clear(o.frameSet)
+						for k := range o.frameSet {
+							delete(o.frameSet, k)
+						}
 					} else {
 						ctx.GetLogger().Debugf("ratelimit had nothing to sent at %d", t.UnixMilli())
 					}


### PR DESCRIPTION
This PR fixes a linting error reported in the CI pipeline of PR (#4025 - default clause implementation). The pipeline failed due to the usage of maps.Clear. 
The changes made replace the usage of maps.Clear with a manual map-clearing implementation using a for loop and delete.


