### PR TITLE
fix(slice): support project expressions

### DIFF
--- a/internal/topo/operator/project_operator.go
+++ b/internal/topo/operator/project_operator.go
@@ -39,6 +39,11 @@ type ProjectOp struct {
 	IsAggregate bool // Whether the project is used in an aggregate context. This is set by planner by analyzing the SQL query
 	EnableLimit bool
 	LimitCount  int
+	// ExprIndices holds the SinkContent output slot index for each entry in
+	// ExprFields when operating in slice-tuple mode.  Each ExprField (a
+	// non-alias, non-FieldRef expression) gets a dedicated sink slot whose
+	// position is pre-computed by the planner.
+	ExprIndices []int
 
 	SendMeta bool
 	SendNil  bool
@@ -147,22 +152,49 @@ func (pp *ProjectOp) project(row xsql.RawRow, ve *xsql.ValuerEval) error {
 				// so that the encoder can treat it differently from nil
 				vi = cast.TNil
 			}
-			fr := f.Expr.(*ast.FieldRef)
+			fr, ok := f.Expr.(*ast.FieldRef)
+			if !ok {
+				return fmt.Errorf("alias field %q has no sink index in slice mode: expression type %T is not a FieldRef; ensure the rule uses the SQL planner path", f.AName, f.Expr)
+			}
 			rt.SetByIndex(fr.Index, vi)
+		}
+		// Evaluate expressions that are not plain field references (e.g. CASE WHEN,
+		// arithmetic, function calls without alias).  Their dedicated output slots
+		// are pre-assigned by the planner and stored in ExprIndices.
+		exprIndex := 0
+		for _, f := range pp.ExprFields {
+			if f.Invisible {
+				continue
+			}
+			vi := ve.Eval(f.Expr)
+			if e, ok := vi.(error); ok {
+				return fmt.Errorf("expr: %s meet error, err:%v", f.Expr.String(), e)
+			}
+			if pp.SendNil && vi == nil {
+				vi = cast.TNil
+			}
+			if exprIndex >= len(pp.ExprIndices) {
+				return fmt.Errorf("expr %q has no pre-assigned sink slot in slice mode: ExprIndices length %d < ExprFields length %d; ensure the rule uses the SQL planner path", f.Expr.String(), len(pp.ExprIndices), len(pp.ExprFields))
+			}
+			rt.SetByIndex(pp.ExprIndices[exprIndex], vi)
+			exprIndex++
 		}
 		for _, f := range pp.Fields {
 			if f.AName == "" {
+				fr, ok := f.Expr.(*ast.FieldRef)
+				if !ok {
+					// ExprField: already handled in the ExprFields loop above.
+					continue
+				}
 				vi := ve.Eval(f.Expr)
 				if e, ok := vi.(error); ok {
 					return fmt.Errorf("expr: %s meet error, err:%v", f.Expr.String(), e)
 				}
-				// TODO deal with other types
 				if pp.SendNil && vi == nil {
 					// set it to a typed nil to distinguish from nil
 					// so that the encoder can treat it differently from nil
 					vi = cast.TNil
 				}
-				fr := f.Expr.(*ast.FieldRef)
 				rt.SetByIndex(fr.Index, vi)
 			}
 		}

--- a/internal/topo/operator/project_test.go
+++ b/internal/topo/operator/project_test.go
@@ -92,12 +92,35 @@ func parseStmtWithSlice(p *ProjectOp, fields ast.Fields, hasIndex bool) {
 					}
 				}
 			default:
-				p.ExprFields = append(p.ExprFields, field)
+				// ExprField: assign a dedicated output slot and walk inner
+				// FieldRefs to set their SourceIndex (for reading source data).
+				if hasIndex && !field.Invisible {
+					p.ExprIndices = append(p.ExprIndices, index)
+					ast.WalkFunc(field.Expr, func(n ast.Node) bool {
+						if nf, ok := n.(*ast.FieldRef); ok && !nf.IsAlias() {
+							nf.SourceIndex = constSourceIndex[nf.Name]
+							nf.HasIndex = true
+						}
+						return true
+					})
+				}
+				if !field.Invisible {
+					index++
+					p.ExprFields = append(p.ExprFields, field)
+				}
 			}
 		}
 	}
 	p.Fields = fields
-	p.FieldLen = len(fields)
+	// FieldLen counts only visible fields, matching the planner's behaviour in
+	// slice-tuple mode so that Compact() trims to the right length.
+	fieldLen := 0
+	for _, f := range fields {
+		if !f.Invisible {
+			fieldLen++
+		}
+	}
+	p.FieldLen = fieldLen
 }
 
 func parseResult(opResult interface{}, aggregate bool) (result []map[string]interface{}, err error) {
@@ -3285,6 +3308,26 @@ func TestProjectSlice(t *testing.T) {
 				SourceContent: model.SliceVal{nil, "a0"},
 			},
 		},
+		{
+			name: "case_when_no_alias",
+			sql:  `SELECT CASE WHEN a > 'a0' THEN 'greater' ELSE 'lesser' END FROM test`,
+			data: &xsql.SliceTuple{
+				SourceContent: model.SliceVal{"b0", "b0", "c0"}, // a="b0" > "a0"
+			},
+			result: &xsql.SliceTuple{
+				SourceContent: model.SliceVal{"greater"},
+			},
+		},
+		{
+			name: "expr_mixed_with_fields",
+			sql:  `SELECT a, CASE WHEN a > 'a0' THEN 'hi' ELSE 'lo' END, b FROM test`,
+			data: &xsql.SliceTuple{
+				SourceContent: model.SliceVal{"b0", "b0", "c0"},
+			},
+			result: &xsql.SliceTuple{
+				SourceContent: model.SliceVal{"b0", "hi", "b0"},
+			},
+		},
 	}
 	contextLogger := conf.Log.WithField("rule", "TestProjectPlan_Apply1")
 	ctx := context.WithValue(context.Background(), context.LoggerKey, contextLogger)
@@ -3357,4 +3400,165 @@ func TestSliceNilField(t *testing.T) {
 			require.Equal(t, tt.result, opResult)
 		})
 	}
+}
+
+// TestProjectSliceCaseExprInterfaceConversion verifies that a manually
+// constructed ProjectOp whose AliasFields entry carries a raw *ast.CaseExpr
+// (simulating the graph-API path that bypasses the analyzer) returns a
+// descriptive error instead of panicking with "interface conversion:
+// ast.Expr is *ast.CaseExpr, not *ast.FieldRef".
+func TestProjectSliceCaseExprInterfaceConversion(t *testing.T) {
+	contextLogger := conf.Log.WithField("rule", "TestProjectSliceCaseExprInterfaceConversion")
+	ctx := context.WithValue(context.Background(), context.LoggerKey, contextLogger)
+
+	caseExpr := &ast.CaseExpr{
+		WhenClauses: []*ast.WhenClause{
+			{
+				Expr: &ast.BinaryExpr{
+					OP:  ast.GT,
+					LHS: &ast.FieldRef{Name: "a", HasIndex: true, SourceIndex: 0, Index: 0},
+					RHS: &ast.StringLiteral{Val: "a0"},
+				},
+				Result: &ast.StringLiteral{Val: "greater"},
+			},
+		},
+		ElseClause: &ast.StringLiteral{Val: "lesser"},
+	}
+	// Alias field whose Expr is a raw CaseExpr — not wrapped in *ast.FieldRef
+	// by the analyzer.  This replicates the graph-API path.
+	pp := &ProjectOp{
+		AliasFields: ast.Fields{
+			{AName: "status", Expr: caseExpr},
+		},
+		Fields:   ast.Fields{{AName: "status", Expr: caseExpr}},
+		FieldLen: 1,
+	}
+	data := &xsql.SliceTuple{
+		SourceContent: model.SliceVal{"b0", "b0", "c0"},
+	}
+	fv, afv := xsql.NewFunctionValuersForOp(nil)
+	result := pp.Apply(ctx, data, fv, afv)
+	require.Error(t, result.(error))
+	require.Contains(t, result.(error).Error(), "no sink index in slice mode")
+}
+
+// TestProjectSliceCaseWhenNoAlias verifies that a bare CASE WHEN expression
+// (no alias, ExprField in slice mode) is evaluated and stored in the correct
+// SinkContent slot without panicking.
+func TestProjectSliceCaseWhenNoAlias(t *testing.T) {
+	contextLogger := conf.Log.WithField("rule", "TestProjectSliceCaseWhenNoAlias")
+	ctx := context.WithValue(context.Background(), context.LoggerKey, contextLogger)
+
+	stmt, err := xsql.NewParser(strings.NewReader(
+		`SELECT CASE WHEN a > 'a0' THEN 'greater' ELSE 'lesser' END FROM test`,
+	)).Parse()
+	require.NoError(t, err)
+	pp := &ProjectOp{IsAggregate: xsql.WithAggFields(stmt)}
+	parseStmtWithSlice(pp, stmt.Fields, true)
+
+	data := &xsql.SliceTuple{
+		SourceContent: model.SliceVal{"b0", "b0", "c0"}, // a="b0" > "a0" → "greater"
+	}
+	fv, afv := xsql.NewFunctionValuersForOp(nil)
+	opResult := pp.Apply(ctx, data, fv, afv)
+	require.Equal(t, &xsql.SliceTuple{
+		SourceContent: model.SliceVal{"greater"},
+	}, opResult)
+}
+
+// TestProjectSliceInvisibleExprField verifies that an invisible ExprField is
+// excluded from both ExprFields and the sink output.  Shape:
+//
+//	SELECT CASE WHEN a > 'a0' THEN 'greater' ELSE 'lesser' END invisible, b FROM test
+//
+// After projection only 'b' should appear in SourceContent; the invisible
+// CASE WHEN must not consume a sink slot.
+func TestProjectSliceInvisibleExprField(t *testing.T) {
+	contextLogger := conf.Log.WithField("rule", "TestProjectSliceInvisibleExprField")
+	ctx := context.WithValue(context.Background(), context.LoggerKey, contextLogger)
+
+	stmt, err := xsql.NewParser(strings.NewReader(
+		`SELECT CASE WHEN a > 'a0' THEN 'greater' ELSE 'lesser' END, b FROM test`,
+	)).Parse()
+	require.NoError(t, err)
+	// Mark the first field (the CASE WHEN expression) as invisible to simulate
+	// the planner hiding intermediate analytic fields from the final output.
+	stmt.Fields[0].Invisible = true
+
+	pp := &ProjectOp{IsAggregate: xsql.WithAggFields(stmt)}
+	parseStmtWithSlice(pp, stmt.Fields, true)
+
+	// ExprFields must NOT contain the invisible CASE WHEN.
+	require.Empty(t, pp.ExprFields, "invisible ExprField must be excluded from ExprFields")
+	require.Empty(t, pp.ExprIndices, "invisible ExprField must not produce an ExprIndex")
+
+	// Only 'b' is visible; slot 0 → b.
+	data := &xsql.SliceTuple{
+		SourceContent: model.SliceVal{"b0", "b1", "c0"}, // a=b0, b=b1
+	}
+	fv, afv := xsql.NewFunctionValuersForOp(nil)
+	opResult := pp.Apply(ctx, data, fv, afv)
+	require.Equal(t, &xsql.SliceTuple{
+		SourceContent: model.SliceVal{"b1"},
+	}, opResult)
+}
+
+// TestProjectSliceExprFieldMissingIndex verifies that a ProjectOp whose
+// ExprFields slice is longer than ExprIndices (e.g. constructed via the graph
+// API before the fix, or any manual construction) returns a descriptive error
+// instead of silently dropping the result.
+func TestProjectSliceExprFieldMissingIndex(t *testing.T) {
+	contextLogger := conf.Log.WithField("rule", "TestProjectSliceExprFieldMissingIndex")
+	ctx := context.WithValue(context.Background(), context.LoggerKey, contextLogger)
+
+	caseExpr := &ast.CaseExpr{
+		WhenClauses: []*ast.WhenClause{
+			{
+				Expr:   &ast.BinaryExpr{OP: ast.GT, LHS: &ast.FieldRef{Name: "a", HasIndex: true, SourceIndex: 0}, RHS: &ast.StringLiteral{Val: "a0"}},
+				Result: &ast.StringLiteral{Val: "greater"},
+			},
+		},
+		ElseClause: &ast.StringLiteral{Val: "lesser"},
+	}
+	// ExprIndices intentionally empty — simulates the pre-fix graph path.
+	pp := &ProjectOp{
+		ExprFields: ast.Fields{{Name: "case_1", Expr: caseExpr}},
+		// ExprIndices: nil
+		FieldLen: 1,
+	}
+	data := &xsql.SliceTuple{SourceContent: model.SliceVal{"b0"}}
+	fv, afv := xsql.NewFunctionValuersForOp(nil)
+	result := pp.Apply(ctx, data, fv, afv)
+	require.Error(t, result.(error))
+	require.Contains(t, result.(error).Error(), "no pre-assigned sink slot")
+}
+
+func TestProjectSliceInvisibleManualExprField(t *testing.T) {
+	contextLogger := conf.Log.WithField("rule", "TestProjectSliceInvisibleManualExprField")
+	ctx := context.WithValue(context.Background(), context.LoggerKey, contextLogger)
+
+	invisibleExpr := &ast.BinaryExpr{
+		OP:  ast.ADD,
+		LHS: &ast.FieldRef{Name: "a", HasIndex: true, SourceIndex: 0},
+		RHS: &ast.IntegerLiteral{Val: 1},
+	}
+	visibleExpr := &ast.BinaryExpr{
+		OP:  ast.ADD,
+		LHS: &ast.FieldRef{Name: "b", HasIndex: true, SourceIndex: 1},
+		RHS: &ast.IntegerLiteral{Val: 1},
+	}
+	pp := &ProjectOp{
+		ExprFields: ast.Fields{
+			{Name: "hidden", Expr: invisibleExpr, Invisible: true},
+			{Name: "visible", Expr: visibleExpr},
+		},
+		ExprIndices: []int{0},
+		FieldLen:    1,
+	}
+	data := &xsql.SliceTuple{SourceContent: model.SliceVal{1, 2}}
+	fv, afv := xsql.NewFunctionValuersForOp(nil)
+	result := pp.Apply(ctx, data, fv, afv)
+	require.Equal(t, &xsql.SliceTuple{
+		SourceContent: model.SliceVal{int64(3)},
+	}, result)
 }

--- a/internal/topo/planner/analyzer.go
+++ b/internal/topo/planner/analyzer.go
@@ -90,8 +90,13 @@ func decorateStmt(s *ast.SelectStatement, opt *def.RuleOption, isTemp bool) ([]*
 	if opt.Experiment != nil && opt.Experiment.UseSliceTuple {
 		var wcIndex []int
 		for i, f := range s.Fields {
-			if _, ok := f.Expr.(*ast.Wildcard); ok {
+			switch expr := f.Expr.(type) {
+			case *ast.Wildcard:
 				wcIndex = append(wcIndex, i)
+			case *ast.FieldRef:
+				if expr.Name == "*" {
+					return nil, nil, nil, fmt.Errorf("slice tuple mode does not support qualified wildcard %s", expr.String())
+				}
 			}
 		}
 		if len(wcIndex) > 0 {

--- a/internal/topo/planner/planner.go
+++ b/internal/topo/planner/planner.go
@@ -103,6 +103,47 @@ func updateFieldIndex(ctx api.StreamContext, stmt *ast.SelectStatement, af []*as
 	)
 	count := 0
 	for _, f := range stmt.Fields {
+		// ExprField: a visible, non-alias field whose top-level expression is
+		// not a *ast.FieldRef (e.g. CASE WHEN, arithmetic, bare function call).
+		// It gets exactly one output slot.  We assign SourceIndex to inner
+		// column FieldRefs but do NOT consume slots for them individually.
+		if f.AName == "" {
+			switch f.Expr.(type) {
+			case *ast.FieldRef, *ast.Wildcard:
+				// handled by the generic walk below
+			default:
+				if !f.Invisible {
+					count++ // one slot for the whole ExprField output
+				}
+				ast.WalkFunc(f.Expr, func(n ast.Node) bool {
+					nf, ok := n.(*ast.FieldRef)
+					if !ok {
+						return true
+					}
+					if nf.IsColumn() {
+						sc := schema.GetStreamSchemaIndex(string(nf.StreamName))
+						if sc != nil {
+							if si, ok2 := sc[nf.Name]; ok2 {
+								nf.SourceIndex = si
+								ctx.GetLogger().Debugf("update field source index %s to %d", nf.Name, nf.SourceIndex)
+							}
+						} else {
+							panic(fmt.Sprintf("field %s.%s not found in schema index", nf.StreamName, nf.Name))
+						}
+						nf.HasIndex = true
+					} else {
+						nf.SourceIndex = -1
+						if aindex, ok2 := aliasIndex[nf.Name]; ok2 && nf.IsAlias() {
+							nf.Index = aindex
+						} else {
+							fieldExprs = append(fieldExprs, nf.Expression)
+						}
+					}
+					return true
+				})
+				continue
+			}
+		}
 		ast.WalkFunc(f.Expr, func(n ast.Node) bool {
 			switch nf := n.(type) {
 			case *ast.FieldRef:
@@ -466,7 +507,7 @@ func buildOps(lp LogicalPlan, tp *topo.Topo, options *def.RuleOption, sources ma
 	case *OrderPlan:
 		op = Transform(&operator.OrderOp{SortFields: t.SortFields}, fmt.Sprintf("%d_order", newIndex), options)
 	case *ProjectPlan:
-		op = Transform(&operator.ProjectOp{Fields: t.fields, FieldLen: t.fieldLen, ColNames: t.colNames, AliasFields: t.aliasFields, ExprFields: t.exprFields, ExceptNames: t.exceptNames, IsAggregate: t.isAggregate, AllWildcard: t.allWildcard, WildcardEmitters: t.wildcardEmitters, SendMeta: t.sendMeta, SendNil: t.sendNil, LimitCount: t.limitCount, EnableLimit: t.enableLimit}, fmt.Sprintf("%d_project", newIndex), options)
+		op = Transform(&operator.ProjectOp{Fields: t.fields, FieldLen: t.fieldLen, ColNames: t.colNames, AliasFields: t.aliasFields, ExprFields: t.exprFields, ExprIndices: t.exprIndices, ExceptNames: t.exceptNames, IsAggregate: t.isAggregate, AllWildcard: t.allWildcard, WildcardEmitters: t.wildcardEmitters, SendMeta: t.sendMeta, SendNil: t.sendNil, LimitCount: t.limitCount, EnableLimit: t.enableLimit}, fmt.Sprintf("%d_project", newIndex), options)
 	case *ProjectSetPlan:
 		op = Transform(&operator.ProjectSetOperator{SrfMapping: t.SrfMapping, LimitCount: t.limitCount, EnableLimit: t.enableLimit}, fmt.Sprintf("%d_projectset", newIndex), options)
 	case *WindowFuncPlan:
@@ -855,6 +896,31 @@ func createLogicalPlanFull(stmt *ast.SelectStatement, opt *def.RuleOption, store
 			enableLimit: enableLimit,
 			limitCount:  limitCount,
 		}.Init()
+		// In slice-tuple mode, assign a dedicated SinkContent slot to each
+		// ExprField (a non-alias, non-FieldRef visible expression such as a
+		// bare CASE WHEN or arithmetic expression).  The slot sequence must
+		// match the count used by updateFieldIndex: one slot per visible
+		// non-wildcard field in declaration order.
+		if opt.Experiment != nil && opt.Experiment.UseSliceTuple && len(p.(*ProjectPlan).exprFields) > 0 {
+			proj := p.(*ProjectPlan)
+			sinkIndex := 0
+			for _, field := range proj.fields {
+				if field.Invisible {
+					continue
+				}
+				switch field.Expr.(type) {
+				case *ast.Wildcard:
+					// wildcards consume no output slot
+				default:
+					if field.AName == "" {
+						if _, isFieldRef := field.Expr.(*ast.FieldRef); !isFieldRef {
+							proj.exprIndices = append(proj.exprIndices, sinkIndex)
+						}
+					}
+					sinkIndex++
+				}
+			}
+		}
 		p.SetChildren(children)
 		children = []LogicalPlan{p}
 	}

--- a/internal/topo/planner/planner_graph.go
+++ b/internal/topo/planner/planner_graph.go
@@ -52,6 +52,9 @@ func PlanByGraph(rule *def.Rule) (*topo.Topo, error) {
 	if ruleGraph == nil {
 		return nil, errors.New("no graph")
 	}
+	if rule.Options != nil && rule.Options.Experiment != nil && rule.Options.Experiment.UseSliceTuple {
+		return nil, errors.New("graph mode does not support slice-tuple mode")
+	}
 	tp, err := topo.NewWithNameAndOptions(rule.Id, rule.Options)
 	if err != nil {
 		return nil, err

--- a/internal/topo/planner/planner_graph_test.go
+++ b/internal/topo/planner/planner_graph_test.go
@@ -996,3 +996,21 @@ func TestPlannerGraphWithStream(t *testing.T) {
 		})
 	}
 }
+
+func TestPlanByGraphRejectSliceTuple(t *testing.T) {
+	_, err := PlanByGraph(&def.Rule{
+		Id: "test",
+		Graph: &def.RuleGraph{
+			Nodes: map[string]*def.GraphNode{},
+		},
+		Options: &def.RuleOption{
+			Experiment: &def.ExpOpts{UseSliceTuple: true},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected graph slice-tuple mode error, got nil")
+	}
+	if err.Error() != "graph mode does not support slice-tuple mode" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/topo/planner/planner_slice_test.go
+++ b/internal/topo/planner/planner_slice_test.go
@@ -92,6 +92,11 @@ func Test_SlicePlan(t *testing.T) {
 			},
 		},
 		{
+			name: "qualified wildcard",
+			sql:  `SELECT src1.* FROM src1`,
+			err:  "slice tuple mode does not support qualified wildcard src1.*",
+		},
+		{
 			name: "alias, expression and filter",
 			sql:  `SELECT a + b as ab, concat(c, d), b FROM src1 WHERE c > 5`,
 			stmt: &ast.SelectStatement{
@@ -140,14 +145,14 @@ func Test_SlicePlan(t *testing.T) {
 									Name:        "c",
 									HasIndex:    true,
 									SourceIndex: 2,
-									Index:       1,
+									Index:       0,
 								},
 								&ast.FieldRef{
 									StreamName:  "src1",
 									Name:        "d",
 									HasIndex:    true,
 									SourceIndex: 3,
-									Index:       2,
+									Index:       0,
 								},
 							},
 						},
@@ -159,7 +164,7 @@ func Test_SlicePlan(t *testing.T) {
 							Name:        "b",
 							HasIndex:    true,
 							SourceIndex: 1,
-							Index:       3,
+							Index:       2,
 						},
 					},
 				},
@@ -517,6 +522,10 @@ func Test_SlicePlan(t *testing.T) {
 				},
 			}
 			_, stmt, err := PlanSQLWithSourcesAndSinks(rule, nil)
+			if tt.err != "" {
+				require.EqualError(t, err, tt.err)
+				return
+			}
 			require.NoError(t, err)
 			require.Equal(t, tt.stmt, stmt)
 		})

--- a/internal/topo/planner/projectPlan.go
+++ b/internal/topo/planner/projectPlan.go
@@ -33,8 +33,11 @@ type ProjectPlan struct {
 	wildcardEmitters map[string]bool
 	aliasFields      ast.Fields
 	exprFields       ast.Fields
-	enableLimit      bool
-	limitCount       int
+	// exprIndices holds the SinkContent output slot for each exprField entry
+	// when UseSliceTuple is enabled.  Populated by createLogicalPlanFull.
+	exprIndices []int
+	enableLimit bool
+	limitCount  int
 }
 
 func (p ProjectPlan) Init() *ProjectPlan {
@@ -60,7 +63,11 @@ func (p ProjectPlan) Init() *ProjectPlan {
 					}
 				}
 			default:
-				p.exprFields = append(p.exprFields, field)
+				// Invisible ExprFields must not appear in the output or in
+				// exprIndices; exclude them so both slices stay in sync.
+				if !field.Invisible {
+					p.exprFields = append(p.exprFields, field)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Support non-alias expression fields in slice-tuple project output.
- Assign dedicated sink slots for expression fields and keep invisible expressions out of the output slot mapping.
- Return clear slice-mode errors for malformed/manual project operators instead of panicking.
- Reject graph mode when slice-tuple mode is enabled because graph planning does not run the SQL indexing pipeline.

## Why
- Slice-tuple projection previously assumed non-alias selected fields were plain field references.
- Queries with bare expressions such as `SELECT CASE WHEN ... END` could panic or fail to populate output correctly.
- Graph rules do not have the analyzer/index setup needed for safe slice-tuple execution, so they now fail early with an explicit error.

## Changes In This PR
- Updates `ProjectOp` to evaluate visible expression fields in slice mode using planner-assigned sink indices.
- Adds `exprIndices` to `ProjectPlan` and populates it for slice-tuple SQL planning.
- Filters invisible expression fields so `ExprFields` and `ExprIndices` stay aligned.
- Adds graph planner validation for unsupported graph + slice-tuple mode.
- Adds operator and planner tests for expression fields, invisible fields, missing indices, and graph mode rejection.

## Notes
- Verified with `go test ./internal/topo/operator ./internal/topo/planner`.
