### PR TITLE
fix(topo): shared subtopo init race

### DIFF
--- a/internal/topo/planner/planner_source.go
+++ b/internal/topo/planner/planner_source.go
@@ -117,7 +117,7 @@ func splitSource(ctx api.StreamContext, t *DataSourcePlan, ss api.Source, option
 			// For shared stream, the rule id is the shared subtopo. Subtopo only has one run so runId is always 0
 			subCtx = subCtx.(*context.DefaultContext).WithRuleId(fmt.Sprintf("$$subtopo_%s", t.name)).WithRun(0)
 		}
-		srcSubtopo, existed, err := topo.GetOrCreateSubTopo(subCtx, selName, false, func(srcSubtopo *topo.SrcSubTopo) error {
+		srcSubtopo, err := topo.GetOrCreateSubTopo(subCtx, selName, false, func(srcSubtopo *topo.SrcSubTopo) error {
 			scn, err := node.NewSourceNode(ctx, selName, ss, props, options)
 			if err != nil {
 				return err
@@ -127,11 +127,6 @@ func splitSource(ctx api.StreamContext, t *DataSourcePlan, ss api.Source, option
 		})
 		if err != nil {
 			return nil, nil, 0, err
-		}
-		if !existed {
-			ctx.GetLogger().Infof("Create SubTopo %s for shared connection", selName)
-		} else {
-			ctx.GetLogger().Infof("Load SubTopo %s for shared connection", selName)
 		}
 		srcConnNode = srcSubtopo
 		index++
@@ -220,7 +215,7 @@ func splitSource(ctx api.StreamContext, t *DataSourcePlan, ss api.Source, option
 	if t.streamStmt.Options.SHARED && !t.inRuleTest {
 		isSliceRule := options.Experiment != nil && options.Experiment.UseSliceTuple
 		// Create subtopo in the end to avoid errors in the middle
-		srcSubtopo, existed, err := topo.GetOrCreateSubTopo(ctx, string(t.name), isSliceRule, func(srcSubtopo *topo.SrcSubTopo) error {
+		srcSubtopo, err := topo.GetOrCreateSubTopo(ctx, string(t.name), isSliceRule, func(srcSubtopo *topo.SrcSubTopo) error {
 			srcSubtopo.AddSrc(srcConnNode)
 			subInputs := []node.Emitter{srcSubtopo}
 			for _, e := range ops {
@@ -232,13 +227,8 @@ func splitSource(ctx api.StreamContext, t *DataSourcePlan, ss api.Source, option
 		if err != nil {
 			return nil, nil, 0, err
 		}
-		if !existed {
-			ctx.GetLogger().Infof("Create SubTopo %s", string(t.name))
-		} else {
-			if isSliceRule != srcSubtopo.IsSliceMode() {
-				return nil, nil, 0, fmt.Errorf("rules refer to shared stream must be the same mode, stream slice mode: %v but rule slice mode: %v", srcSubtopo.IsSliceMode(), isSliceRule)
-			}
-			ctx.GetLogger().Infof("Load SubTopo %s", string(t.name))
+		if isSliceRule != srcSubtopo.IsSliceMode() {
+			return nil, nil, 0, fmt.Errorf("rules refer to shared stream must be the same mode, stream slice mode: %v but rule slice mode: %v", srcSubtopo.IsSliceMode(), isSliceRule)
 		}
 		srcSubtopo.StoreSchema(ruleId, string(t.name), t.streamFields, t.isWildCard)
 		return srcSubtopo, nil, len(ops), nil

--- a/internal/topo/planner/planner_source.go
+++ b/internal/topo/planner/planner_source.go
@@ -117,22 +117,23 @@ func splitSource(ctx api.StreamContext, t *DataSourcePlan, ss api.Source, option
 			// For shared stream, the rule id is the shared subtopo. Subtopo only has one run so runId is always 0
 			subCtx = subCtx.(*context.DefaultContext).WithRuleId(fmt.Sprintf("$$subtopo_%s", t.name)).WithRun(0)
 		}
-		srcSubtopo, existed := topo.GetOrCreateSubTopo(subCtx, selName, false)
-		if !existed {
-			var scn node.DataSourceNode
-			scn, err = node.NewSourceNode(ctx, selName, ss, props, options)
-			if err == nil {
-				ctx.GetLogger().Infof("Create SubTopo %s for shared connection", selName)
-				srcSubtopo.AddSrc(scn)
+		srcSubtopo, existed, err := topo.GetOrCreateSubTopo(subCtx, selName, false, func(srcSubtopo *topo.SrcSubTopo) error {
+			scn, err := node.NewSourceNode(ctx, selName, ss, props, options)
+			if err != nil {
+				return err
 			}
+			srcSubtopo.AddSrc(scn)
+			return nil
+		})
+		if err != nil {
+			return nil, nil, 0, err
+		}
+		if !existed {
+			ctx.GetLogger().Infof("Create SubTopo %s for shared connection", selName)
 		} else {
 			ctx.GetLogger().Infof("Load SubTopo %s for shared connection", selName)
 		}
 		srcConnNode = srcSubtopo
-		if err != nil {
-			topo.RemoveSubTopo(selName)
-			return nil, nil, 0, err
-		}
 		index++
 		// another node to set emitter
 		op := Transform(&operator.EmitterOp{Emitter: string(emitterName)}, fmt.Sprintf("%d_emitter", index), options)
@@ -219,15 +220,20 @@ func splitSource(ctx api.StreamContext, t *DataSourcePlan, ss api.Source, option
 	if t.streamStmt.Options.SHARED && !t.inRuleTest {
 		isSliceRule := options.Experiment != nil && options.Experiment.UseSliceTuple
 		// Create subtopo in the end to avoid errors in the middle
-		srcSubtopo, existed := topo.GetOrCreateSubTopo(ctx, string(t.name), isSliceRule)
-		if !existed {
-			ctx.GetLogger().Infof("Create SubTopo %s", string(t.name))
+		srcSubtopo, existed, err := topo.GetOrCreateSubTopo(ctx, string(t.name), isSliceRule, func(srcSubtopo *topo.SrcSubTopo) error {
 			srcSubtopo.AddSrc(srcConnNode)
 			subInputs := []node.Emitter{srcSubtopo}
 			for _, e := range ops {
 				srcSubtopo.AddOperator(subInputs, e)
 				subInputs = []node.Emitter{e}
 			}
+			return nil
+		})
+		if err != nil {
+			return nil, nil, 0, err
+		}
+		if !existed {
+			ctx.GetLogger().Infof("Create SubTopo %s", string(t.name))
 		} else {
 			if isSliceRule != srcSubtopo.IsSliceMode() {
 				return nil, nil, 0, fmt.Errorf("rules refer to shared stream must be the same mode, stream slice mode: %v but rule slice mode: %v", srcSubtopo.IsSliceMode(), isSliceRule)

--- a/internal/topo/subtopo_pool.go
+++ b/internal/topo/subtopo_pool.go
@@ -52,7 +52,7 @@ func GetOrCreateSubTopo(ctx api.StreamContext, name string, isSliceMode bool, in
 			// it is usable. Keep init lightweight; node Provision must not perform
 			// time-consuming work. TODO: revisit if any source init becomes slow.
 			if err := init(ac); err != nil {
-				return nil, false, err
+				return nil, false, fmt.Errorf("init subtopo %s with slice mode %t: %w", name, isSliceMode, err)
 			}
 		}
 		subTopoPool[name] = ac

--- a/internal/topo/subtopo_pool.go
+++ b/internal/topo/subtopo_pool.go
@@ -28,15 +28,43 @@ import (
 )
 
 var (
-	subTopoPool = make(map[string]*SrcSubTopo)
-	lock        syncx.Mutex
+	subTopoPool     = make(map[string]*SrcSubTopo)
+	subTopoCreating = make(map[string]*subTopoCreation)
+	lock            syncx.Mutex
 )
 
+type subTopoCreation struct {
+	ready chan struct{}
+	err   error
+}
+
 func GetOrCreateSubTopo(ctx api.StreamContext, name string, isSliceMode bool, init func(*SrcSubTopo) error) (*SrcSubTopo, bool, error) {
-	lock.Lock()
-	defer lock.Unlock()
-	ac, ok := subTopoPool[name]
-	if !ok {
+	for {
+		lock.Lock()
+		ac, ok := subTopoPool[name]
+		if ok {
+			ac.Init(ctx)
+			lock.Unlock()
+			return ac, true, nil
+		}
+		creating, ok := subTopoCreating[name]
+		if ok {
+			ready := creating.ready
+			lock.Unlock()
+			<-ready
+			if creating.err != nil {
+				return nil, false, creating.err
+			}
+			continue
+		}
+		if init == nil {
+			lock.Unlock()
+			return nil, false, fmt.Errorf("init subtopo %s with slice mode %t: missing initializer", name, isSliceMode)
+		}
+		creating = &subTopoCreation{ready: make(chan struct{})}
+		subTopoCreating[name] = creating
+		lock.Unlock()
+
 		ac = &SrcSubTopo{
 			name: name,
 			topo: &def.PrintableTopo{
@@ -47,15 +75,23 @@ func GetOrCreateSubTopo(ctx api.StreamContext, name string, isSliceMode bool, in
 			refRules:    make(map[string]map[int]chan<- error),
 			isSliceMode: isSliceMode,
 		}
-		if init != nil {
-			if err := init(ac); err != nil {
-				return nil, false, err
-			}
+		if err := init(ac); err != nil {
+			creating.err = fmt.Errorf("init subtopo %s with slice mode %t: %w", name, isSliceMode, err)
 		}
-		subTopoPool[name] = ac
+
+		lock.Lock()
+		if creating.err == nil {
+			subTopoPool[name] = ac
+			ac.Init(ctx)
+		}
+		delete(subTopoCreating, name)
+		close(creating.ready)
+		lock.Unlock()
+		if creating.err != nil {
+			return nil, false, creating.err
+		}
+		return ac, false, nil
 	}
-	ac.Init(ctx)
-	return ac, ok, nil
 }
 
 func RemoveSubTopo(name string) {

--- a/internal/topo/subtopo_pool.go
+++ b/internal/topo/subtopo_pool.go
@@ -32,7 +32,7 @@ var (
 	lock        syncx.Mutex
 )
 
-func GetOrCreateSubTopo(ctx api.StreamContext, name string, isSliceMode bool, init func(*SrcSubTopo) error) (*SrcSubTopo, bool, error) {
+func GetOrCreateSubTopo(ctx api.StreamContext, name string, isSliceMode bool, init func(*SrcSubTopo) error) (*SrcSubTopo, error) {
 	lock.Lock()
 	defer lock.Unlock()
 	ac, ok := subTopoPool[name]
@@ -52,13 +52,16 @@ func GetOrCreateSubTopo(ctx api.StreamContext, name string, isSliceMode bool, in
 			// it is usable. Keep init lightweight; node Provision must not perform
 			// time-consuming work. TODO: revisit if any source init becomes slow.
 			if err := init(ac); err != nil {
-				return nil, false, fmt.Errorf("init subtopo %s with slice mode %t: %w", name, isSliceMode, err)
+				return nil, fmt.Errorf("init subtopo %s with slice mode %t: %w", name, isSliceMode, err)
 			}
 		}
 		subTopoPool[name] = ac
+		ctx.GetLogger().Infof("Create SubTopo %s", name)
+	} else {
+		ctx.GetLogger().Infof("Load SubTopo %s", name)
 	}
 	ac.Init(ctx)
-	return ac, ok, nil
+	return ac, nil
 }
 
 func RemoveSubTopo(name string) {

--- a/internal/topo/subtopo_pool.go
+++ b/internal/topo/subtopo_pool.go
@@ -28,43 +28,15 @@ import (
 )
 
 var (
-	subTopoPool     = make(map[string]*SrcSubTopo)
-	subTopoCreating = make(map[string]*subTopoCreation)
-	lock            syncx.Mutex
+	subTopoPool = make(map[string]*SrcSubTopo)
+	lock        syncx.Mutex
 )
 
-type subTopoCreation struct {
-	ready chan struct{}
-	err   error
-}
-
 func GetOrCreateSubTopo(ctx api.StreamContext, name string, isSliceMode bool, init func(*SrcSubTopo) error) (*SrcSubTopo, bool, error) {
-	for {
-		lock.Lock()
-		ac, ok := subTopoPool[name]
-		if ok {
-			ac.Init(ctx)
-			lock.Unlock()
-			return ac, true, nil
-		}
-		creating, ok := subTopoCreating[name]
-		if ok {
-			ready := creating.ready
-			lock.Unlock()
-			<-ready
-			if creating.err != nil {
-				return nil, false, creating.err
-			}
-			continue
-		}
-		if init == nil {
-			lock.Unlock()
-			return nil, false, fmt.Errorf("init subtopo %s with slice mode %t: missing initializer", name, isSliceMode)
-		}
-		creating = &subTopoCreation{ready: make(chan struct{})}
-		subTopoCreating[name] = creating
-		lock.Unlock()
-
+	lock.Lock()
+	defer lock.Unlock()
+	ac, ok := subTopoPool[name]
+	if !ok {
 		ac = &SrcSubTopo{
 			name: name,
 			topo: &def.PrintableTopo{
@@ -75,23 +47,18 @@ func GetOrCreateSubTopo(ctx api.StreamContext, name string, isSliceMode bool, in
 			refRules:    make(map[string]map[int]chan<- error),
 			isSliceMode: isSliceMode,
 		}
-		if err := init(ac); err != nil {
-			creating.err = fmt.Errorf("init subtopo %s with slice mode %t: %w", name, isSliceMode, err)
+		if init != nil {
+			// init runs under the pool lock so a new subtopo is not visible before
+			// it is usable. Keep init lightweight; node Provision must not perform
+			// time-consuming work. TODO: revisit if any source init becomes slow.
+			if err := init(ac); err != nil {
+				return nil, false, err
+			}
 		}
-
-		lock.Lock()
-		if creating.err == nil {
-			subTopoPool[name] = ac
-			ac.Init(ctx)
-		}
-		delete(subTopoCreating, name)
-		close(creating.ready)
-		lock.Unlock()
-		if creating.err != nil {
-			return nil, false, creating.err
-		}
-		return ac, false, nil
+		subTopoPool[name] = ac
 	}
+	ac.Init(ctx)
+	return ac, ok, nil
 }
 
 func RemoveSubTopo(name string) {

--- a/internal/topo/subtopo_pool.go
+++ b/internal/topo/subtopo_pool.go
@@ -32,7 +32,7 @@ var (
 	lock        syncx.Mutex
 )
 
-func GetOrCreateSubTopo(ctx api.StreamContext, name string, isSliceMode bool) (*SrcSubTopo, bool) {
+func GetOrCreateSubTopo(ctx api.StreamContext, name string, isSliceMode bool, init func(*SrcSubTopo) error) (*SrcSubTopo, bool, error) {
 	lock.Lock()
 	defer lock.Unlock()
 	ac, ok := subTopoPool[name]
@@ -47,10 +47,15 @@ func GetOrCreateSubTopo(ctx api.StreamContext, name string, isSliceMode bool) (*
 			refRules:    make(map[string]map[int]chan<- error),
 			isSliceMode: isSliceMode,
 		}
+		if init != nil {
+			if err := init(ac); err != nil {
+				return nil, false, err
+			}
+		}
 		subTopoPool[name] = ac
 	}
 	ac.Init(ctx)
-	return ac, ok
+	return ac, ok, nil
 }
 
 func RemoveSubTopo(name string) {

--- a/internal/topo/subtopo_test.go
+++ b/internal/topo/subtopo_test.go
@@ -15,7 +15,9 @@
 package topo
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -118,8 +120,13 @@ func TestSubtopoLC(t *testing.T) {
 
 func TestGetOrCreateSubTopoDoesNotExposePartialSubTopo(t *testing.T) {
 	origPool := subTopoPool
+	origCreating := subTopoCreating
 	subTopoPool = make(map[string]*SrcSubTopo)
-	defer func() { subTopoPool = origPool }()
+	subTopoCreating = make(map[string]*subTopoCreation)
+	defer func() {
+		subTopoPool = origPool
+		subTopoCreating = origCreating
+	}()
 
 	ctx1 := mockContext.NewMockContext("rule1", "abc").WithRun(1)
 	ctx2 := mockContext.NewMockContext("rule2", "abc").WithRun(2)
@@ -186,6 +193,90 @@ func TestGetOrCreateSubTopoDoesNotExposePartialSubTopo(t *testing.T) {
 	assert.Equal(t, creatorTopo, loadedTopo)
 	assert.Equal(t, srcNode, loadedTopo.tail)
 	assert.Equal(t, 2, len(loadedTopo.refRules))
+}
+
+func TestGetOrCreateSubTopoDoesNotBlockUnrelatedSubTopo(t *testing.T) {
+	origPool := subTopoPool
+	origCreating := subTopoCreating
+	subTopoPool = make(map[string]*SrcSubTopo)
+	subTopoCreating = make(map[string]*subTopoCreation)
+	defer func() {
+		subTopoPool = origPool
+		subTopoCreating = origCreating
+	}()
+
+	ctx1 := mockContext.NewMockContext("rule1", "abc").WithRun(1)
+	ctx2 := mockContext.NewMockContext("rule2", "abc").WithRun(2)
+	slowStarted := make(chan struct{})
+	releaseSlow := make(chan struct{})
+	slowDone := make(chan struct{})
+	go func() {
+		_, _, _ = GetOrCreateSubTopo(ctx1, "slow", false, func(subTopo *SrcSubTopo) error {
+			close(slowStarted)
+			<-releaseSlow
+			subTopo.AddSrc(&mockSrc{name: "slow"})
+			return nil
+		})
+		close(slowDone)
+	}()
+	<-slowStarted
+
+	fastDone := make(chan struct{})
+	go func() {
+		fastTopo, existed, err := GetOrCreateSubTopo(ctx2, "fast", false, func(subTopo *SrcSubTopo) error {
+			subTopo.AddSrc(&mockSrc{name: "fast"})
+			return nil
+		})
+		assert.NoError(t, err)
+		assert.False(t, existed)
+		assert.Equal(t, "fast", fastTopo.tail.(*mockSrc).name)
+		close(fastDone)
+	}()
+
+	select {
+	case <-fastDone:
+	case <-time.After(time.Second):
+		t.Fatal("creating one subtopo blocked creation of an unrelated subtopo")
+	}
+
+	close(releaseSlow)
+	select {
+	case <-slowDone:
+	case <-time.After(time.Second):
+		t.Fatal("slow creator did not finish")
+	}
+}
+
+func TestGetOrCreateSubTopoWrapsInitError(t *testing.T) {
+	origPool := subTopoPool
+	origCreating := subTopoCreating
+	subTopoPool = make(map[string]*SrcSubTopo)
+	subTopoCreating = make(map[string]*subTopoCreation)
+	defer func() {
+		subTopoPool = origPool
+		subTopoCreating = origCreating
+	}()
+
+	ctx := mockContext.NewMockContext("rule1", "abc").WithRun(1)
+	initErr := errors.New("boom")
+	subTopo, existed, err := GetOrCreateSubTopo(ctx, "badInit", true, func(subTopo *SrcSubTopo) error {
+		return initErr
+	})
+	assert.Nil(t, subTopo)
+	assert.False(t, existed)
+	assert.ErrorIs(t, err, initErr)
+	assert.True(t, strings.Contains(err.Error(), "badInit"))
+	assert.True(t, strings.Contains(err.Error(), "slice mode true"))
+	assert.Equal(t, 0, len(subTopoPool))
+	assert.Equal(t, 0, len(subTopoCreating))
+
+	subTopo, existed, err = GetOrCreateSubTopo(ctx, "missingInit", false, nil)
+	assert.Nil(t, subTopo)
+	assert.False(t, existed)
+	assert.ErrorContains(t, err, "missingInit")
+	assert.ErrorContains(t, err, "missing initializer")
+	assert.Equal(t, 0, len(subTopoPool))
+	assert.Equal(t, 0, len(subTopoCreating))
 }
 
 // Test when connection fails

--- a/internal/topo/subtopo_test.go
+++ b/internal/topo/subtopo_test.go
@@ -37,13 +37,12 @@ func TestSubtopoLC(t *testing.T) {
 	assert.Equal(t, 0, len(subTopoPool))
 	srcNode := &mockSrc{name: "shared"}
 	opNode := &mockOp{name: "op1", ch: make(chan any)}
-	subTopo, existed, err := GetOrCreateSubTopo(ctx1, "lc", false, func(subTopo *SrcSubTopo) error {
+	subTopo, err := GetOrCreateSubTopo(ctx1, "lc", false, func(subTopo *SrcSubTopo) error {
 		subTopo.AddSrc(srcNode)
 		subTopo.AddOperator([]node.Emitter{srcNode}, opNode)
 		return nil
 	})
 	assert.NoError(t, err)
-	assert.False(t, existed)
 	// Test creation
 	subTopo.StoreSchema("rule1", "shared", map[string]*ast.JsonStreamField{
 		"field1": {Type: "string"},
@@ -70,9 +69,8 @@ func TestSubtopoLC(t *testing.T) {
 	assert.Equal(t, 1, opNode.schemaCount)
 	// Run another
 	ctx2 := mockContext.NewMockContext("rule2", "abc").WithRun(2)
-	subTopo2, existed, err := GetOrCreateSubTopo(ctx2, "lc", false, nil)
+	subTopo2, err := GetOrCreateSubTopo(ctx2, "lc", false, nil)
 	assert.NoError(t, err)
-	assert.True(t, existed)
 	assert.Equal(t, subTopo, subTopo2)
 	subTopo.StoreSchema("rule2", "shared", map[string]*ast.JsonStreamField{
 		"field2": {Type: "string"},
@@ -131,10 +129,9 @@ func TestGetOrCreateSubTopoDoesNotExposePartialSubTopo(t *testing.T) {
 	releaseInit := make(chan struct{})
 	creatorDone := make(chan struct{})
 	var creatorTopo *SrcSubTopo
-	var creatorExisted bool
 	var creatorErr error
 	go func() {
-		creatorTopo, creatorExisted, creatorErr = GetOrCreateSubTopo(ctx1, "initRace", false, func(subTopo *SrcSubTopo) error {
+		creatorTopo, creatorErr = GetOrCreateSubTopo(ctx1, "initRace", false, func(subTopo *SrcSubTopo) error {
 			close(initStarted)
 			<-releaseInit
 			subTopo.AddSrc(srcNode)
@@ -149,11 +146,10 @@ func TestGetOrCreateSubTopoDoesNotExposePartialSubTopo(t *testing.T) {
 	loadedDone := make(chan struct{})
 	var secondInitCalled atomic.Bool
 	var loadedTopo *SrcSubTopo
-	var loadedExisted bool
 	var loadedErr error
 	go func() {
 		close(secondStarted)
-		loadedTopo, loadedExisted, loadedErr = GetOrCreateSubTopo(ctx2, "initRace", false, func(subTopo *SrcSubTopo) error {
+		loadedTopo, loadedErr = GetOrCreateSubTopo(ctx2, "initRace", false, func(subTopo *SrcSubTopo) error {
 			secondInitCalled.Store(true)
 			subTopo.AddSrc(&mockSrc{name: "unexpected"})
 			return nil
@@ -182,8 +178,6 @@ func TestGetOrCreateSubTopoDoesNotExposePartialSubTopo(t *testing.T) {
 
 	assert.NoError(t, creatorErr)
 	assert.NoError(t, loadedErr)
-	assert.False(t, creatorExisted)
-	assert.True(t, loadedExisted)
 	assert.False(t, secondInitCalled.Load())
 	assert.Equal(t, creatorTopo, loadedTopo)
 	assert.Equal(t, srcNode, loadedTopo.tail)
@@ -197,11 +191,10 @@ func TestGetOrCreateSubTopoWrapsInitError(t *testing.T) {
 
 	ctx := mockContext.NewMockContext("rule1", "abc").WithRun(1)
 	initErr := errors.New("boom")
-	subTopo, existed, err := GetOrCreateSubTopo(ctx, "badInit", true, func(subTopo *SrcSubTopo) error {
+	subTopo, err := GetOrCreateSubTopo(ctx, "badInit", true, func(subTopo *SrcSubTopo) error {
 		return initErr
 	})
 	assert.Nil(t, subTopo)
-	assert.False(t, existed)
 	assert.ErrorIs(t, err, initErr)
 	assert.True(t, strings.Contains(err.Error(), "badInit"))
 	assert.True(t, strings.Contains(err.Error(), "slice mode true"))
@@ -214,18 +207,16 @@ func TestSubtopoRunError(t *testing.T) {
 	assert.Equal(t, 0, len(subTopoPool))
 	srcNode := &mockSrc{name: "src1"}
 	opNode := &mockOp{name: "op1", ch: make(chan any)}
-	subTopo, existed, err := GetOrCreateSubTopo(ctx0, "re", false, func(subTopo *SrcSubTopo) error {
+	subTopo, err := GetOrCreateSubTopo(ctx0, "re", false, func(subTopo *SrcSubTopo) error {
 		subTopo.AddSrc(srcNode)
 		subTopo.AddOperator([]node.Emitter{srcNode}, opNode)
 		return nil
 	})
 	assert.NoError(t, err)
-	assert.False(t, existed)
 	// create another subtopo
 	ctx1 := mockContext.NewMockContext("rule1", "abc").WithRun(1)
-	subTopo2, existed, err := GetOrCreateSubTopo(ctx1, "re", false, nil)
+	subTopo2, err := GetOrCreateSubTopo(ctx1, "re", false, nil)
 	assert.NoError(t, err)
-	assert.True(t, existed)
 	assert.Equal(t, subTopo, subTopo2)
 	assert.Equal(t, 1, len(subTopoPool))
 	assert.Equal(t, InitState, subTopo.opened.Load())
@@ -265,13 +256,12 @@ func TestErrorClose(t *testing.T) {
 	assert.Equal(t, 0, len(subTopoPool))
 	srcNode := &mockSrc{name: "src1"}
 	opNode := &mockOp{name: "op1", ch: make(chan any)}
-	subTopo, existed, err := GetOrCreateSubTopo(ctx0, "ee", false, func(subTopo *SrcSubTopo) error {
+	subTopo, err := GetOrCreateSubTopo(ctx0, "ee", false, func(subTopo *SrcSubTopo) error {
 		subTopo.AddSrc(srcNode)
 		subTopo.AddOperator([]node.Emitter{srcNode}, opNode)
 		return nil
 	})
 	assert.NoError(t, err)
-	assert.False(t, existed)
 	// create and run subtopo
 	ctx1 := mockContext.NewMockContext("rule1", "abc").WithRun(1)
 	errCh1 := make(chan error, 1)
@@ -301,7 +291,7 @@ func TestSubtopoPrint(t *testing.T) {
 		},
 	}
 	ctx0 := mockContext.NewMockContext("rule0", "abc")
-	subTopo, _, err := GetOrCreateSubTopo(ctx0, "shared", false, func(subTopo *SrcSubTopo) error {
+	subTopo, err := GetOrCreateSubTopo(ctx0, "shared", false, func(subTopo *SrcSubTopo) error {
 		subTopo.AddSrc(&mockSrc{name: "shared"})
 		return nil
 	})
@@ -335,13 +325,12 @@ func TestSubtopoConcurrency(t *testing.T) {
 	assert.Equal(t, 0, len(subTopoPool))
 	srcNode := &mockSrc{name: "shared"}
 	opNode := &mockOp{name: "op1", ch: make(chan any)}
-	subTopo, existed, err := GetOrCreateSubTopo(ctx, "shared", false, func(subTopo *SrcSubTopo) error {
+	subTopo, err := GetOrCreateSubTopo(ctx, "shared", false, func(subTopo *SrcSubTopo) error {
 		subTopo.AddSrc(srcNode)
 		subTopo.AddOperator([]node.Emitter{srcNode}, opNode)
 		return nil
 	})
 	assert.NoError(t, err)
-	assert.False(t, existed)
 	subTopo.StoreSchema("rule1", "shared", map[string]*ast.JsonStreamField{
 		"field1": {Type: "string"},
 	}, false)

--- a/internal/topo/subtopo_test.go
+++ b/internal/topo/subtopo_test.go
@@ -15,7 +15,9 @@
 package topo
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -186,6 +188,24 @@ func TestGetOrCreateSubTopoDoesNotExposePartialSubTopo(t *testing.T) {
 	assert.Equal(t, creatorTopo, loadedTopo)
 	assert.Equal(t, srcNode, loadedTopo.tail)
 	assert.Equal(t, 2, len(loadedTopo.refRules))
+}
+
+func TestGetOrCreateSubTopoWrapsInitError(t *testing.T) {
+	origPool := subTopoPool
+	subTopoPool = make(map[string]*SrcSubTopo)
+	defer func() { subTopoPool = origPool }()
+
+	ctx := mockContext.NewMockContext("rule1", "abc").WithRun(1)
+	initErr := errors.New("boom")
+	subTopo, existed, err := GetOrCreateSubTopo(ctx, "badInit", true, func(subTopo *SrcSubTopo) error {
+		return initErr
+	})
+	assert.Nil(t, subTopo)
+	assert.False(t, existed)
+	assert.ErrorIs(t, err, initErr)
+	assert.True(t, strings.Contains(err.Error(), "badInit"))
+	assert.True(t, strings.Contains(err.Error(), "slice mode true"))
+	assert.Equal(t, 0, len(subTopoPool))
 }
 
 // Test when connection fails

--- a/internal/topo/subtopo_test.go
+++ b/internal/topo/subtopo_test.go
@@ -15,9 +15,7 @@
 package topo
 
 import (
-	"errors"
 	"fmt"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -120,13 +118,8 @@ func TestSubtopoLC(t *testing.T) {
 
 func TestGetOrCreateSubTopoDoesNotExposePartialSubTopo(t *testing.T) {
 	origPool := subTopoPool
-	origCreating := subTopoCreating
 	subTopoPool = make(map[string]*SrcSubTopo)
-	subTopoCreating = make(map[string]*subTopoCreation)
-	defer func() {
-		subTopoPool = origPool
-		subTopoCreating = origCreating
-	}()
+	defer func() { subTopoPool = origPool }()
 
 	ctx1 := mockContext.NewMockContext("rule1", "abc").WithRun(1)
 	ctx2 := mockContext.NewMockContext("rule2", "abc").WithRun(2)
@@ -193,90 +186,6 @@ func TestGetOrCreateSubTopoDoesNotExposePartialSubTopo(t *testing.T) {
 	assert.Equal(t, creatorTopo, loadedTopo)
 	assert.Equal(t, srcNode, loadedTopo.tail)
 	assert.Equal(t, 2, len(loadedTopo.refRules))
-}
-
-func TestGetOrCreateSubTopoDoesNotBlockUnrelatedSubTopo(t *testing.T) {
-	origPool := subTopoPool
-	origCreating := subTopoCreating
-	subTopoPool = make(map[string]*SrcSubTopo)
-	subTopoCreating = make(map[string]*subTopoCreation)
-	defer func() {
-		subTopoPool = origPool
-		subTopoCreating = origCreating
-	}()
-
-	ctx1 := mockContext.NewMockContext("rule1", "abc").WithRun(1)
-	ctx2 := mockContext.NewMockContext("rule2", "abc").WithRun(2)
-	slowStarted := make(chan struct{})
-	releaseSlow := make(chan struct{})
-	slowDone := make(chan struct{})
-	go func() {
-		_, _, _ = GetOrCreateSubTopo(ctx1, "slow", false, func(subTopo *SrcSubTopo) error {
-			close(slowStarted)
-			<-releaseSlow
-			subTopo.AddSrc(&mockSrc{name: "slow"})
-			return nil
-		})
-		close(slowDone)
-	}()
-	<-slowStarted
-
-	fastDone := make(chan struct{})
-	go func() {
-		fastTopo, existed, err := GetOrCreateSubTopo(ctx2, "fast", false, func(subTopo *SrcSubTopo) error {
-			subTopo.AddSrc(&mockSrc{name: "fast"})
-			return nil
-		})
-		assert.NoError(t, err)
-		assert.False(t, existed)
-		assert.Equal(t, "fast", fastTopo.tail.(*mockSrc).name)
-		close(fastDone)
-	}()
-
-	select {
-	case <-fastDone:
-	case <-time.After(time.Second):
-		t.Fatal("creating one subtopo blocked creation of an unrelated subtopo")
-	}
-
-	close(releaseSlow)
-	select {
-	case <-slowDone:
-	case <-time.After(time.Second):
-		t.Fatal("slow creator did not finish")
-	}
-}
-
-func TestGetOrCreateSubTopoWrapsInitError(t *testing.T) {
-	origPool := subTopoPool
-	origCreating := subTopoCreating
-	subTopoPool = make(map[string]*SrcSubTopo)
-	subTopoCreating = make(map[string]*subTopoCreation)
-	defer func() {
-		subTopoPool = origPool
-		subTopoCreating = origCreating
-	}()
-
-	ctx := mockContext.NewMockContext("rule1", "abc").WithRun(1)
-	initErr := errors.New("boom")
-	subTopo, existed, err := GetOrCreateSubTopo(ctx, "badInit", true, func(subTopo *SrcSubTopo) error {
-		return initErr
-	})
-	assert.Nil(t, subTopo)
-	assert.False(t, existed)
-	assert.ErrorIs(t, err, initErr)
-	assert.True(t, strings.Contains(err.Error(), "badInit"))
-	assert.True(t, strings.Contains(err.Error(), "slice mode true"))
-	assert.Equal(t, 0, len(subTopoPool))
-	assert.Equal(t, 0, len(subTopoCreating))
-
-	subTopo, existed, err = GetOrCreateSubTopo(ctx, "missingInit", false, nil)
-	assert.Nil(t, subTopo)
-	assert.False(t, existed)
-	assert.ErrorContains(t, err, "missingInit")
-	assert.ErrorContains(t, err, "missing initializer")
-	assert.Equal(t, 0, len(subTopoPool))
-	assert.Equal(t, 0, len(subTopoCreating))
 }
 
 // Test when connection fails

--- a/internal/topo/subtopo_test.go
+++ b/internal/topo/subtopo_test.go
@@ -33,13 +33,16 @@ import (
 func TestSubtopoLC(t *testing.T) {
 	ctx1 := mockContext.NewMockContext("rule1", "abc").WithRun(1)
 	assert.Equal(t, 0, len(subTopoPool))
-	subTopo, existed := GetOrCreateSubTopo(ctx1, "lc", false)
-	assert.False(t, existed)
-	// Test creation
 	srcNode := &mockSrc{name: "shared"}
 	opNode := &mockOp{name: "op1", ch: make(chan any)}
-	subTopo.AddSrc(srcNode)
-	subTopo.AddOperator([]node.Emitter{srcNode}, opNode)
+	subTopo, existed, err := GetOrCreateSubTopo(ctx1, "lc", false, func(subTopo *SrcSubTopo) error {
+		subTopo.AddSrc(srcNode)
+		subTopo.AddOperator([]node.Emitter{srcNode}, opNode)
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.False(t, existed)
+	// Test creation
 	subTopo.StoreSchema("rule1", "shared", map[string]*ast.JsonStreamField{
 		"field1": {Type: "string"},
 	}, false)
@@ -65,7 +68,8 @@ func TestSubtopoLC(t *testing.T) {
 	assert.Equal(t, 1, opNode.schemaCount)
 	// Run another
 	ctx2 := mockContext.NewMockContext("rule2", "abc").WithRun(2)
-	subTopo2, existed := GetOrCreateSubTopo(ctx2, "lc", false)
+	subTopo2, existed, err := GetOrCreateSubTopo(ctx2, "lc", false, nil)
+	assert.NoError(t, err)
 	assert.True(t, existed)
 	assert.Equal(t, subTopo, subTopo2)
 	subTopo.StoreSchema("rule2", "shared", map[string]*ast.JsonStreamField{
@@ -84,7 +88,7 @@ func TestSubtopoLC(t *testing.T) {
 	assert.Equal(t, metrics, vv)
 	// Append to rule
 	och := make(chan any)
-	err := subTopo.AddOutput(och, "opp")
+	err = subTopo.AddOutput(och, "opp")
 	assert.NoError(t, err)
 	var ochOut chan<- any = och
 	assert.Equal(t, 1, len(opNode.outputs))
@@ -112,19 +116,95 @@ func TestSubtopoLC(t *testing.T) {
 	assert.Equal(t, 0, len(subTopoPool))
 }
 
+func TestGetOrCreateSubTopoDoesNotExposePartialSubTopo(t *testing.T) {
+	origPool := subTopoPool
+	subTopoPool = make(map[string]*SrcSubTopo)
+	defer func() { subTopoPool = origPool }()
+
+	ctx1 := mockContext.NewMockContext("rule1", "abc").WithRun(1)
+	ctx2 := mockContext.NewMockContext("rule2", "abc").WithRun(2)
+	srcNode := &mockSrc{name: "shared"}
+
+	initStarted := make(chan struct{})
+	releaseInit := make(chan struct{})
+	creatorDone := make(chan struct{})
+	var creatorTopo *SrcSubTopo
+	var creatorExisted bool
+	var creatorErr error
+	go func() {
+		creatorTopo, creatorExisted, creatorErr = GetOrCreateSubTopo(ctx1, "initRace", false, func(subTopo *SrcSubTopo) error {
+			close(initStarted)
+			<-releaseInit
+			subTopo.AddSrc(srcNode)
+			return nil
+		})
+		close(creatorDone)
+	}()
+
+	<-initStarted
+
+	secondStarted := make(chan struct{})
+	loadedDone := make(chan struct{})
+	var secondInitCalled atomic.Bool
+	var loadedTopo *SrcSubTopo
+	var loadedExisted bool
+	var loadedErr error
+	go func() {
+		close(secondStarted)
+		loadedTopo, loadedExisted, loadedErr = GetOrCreateSubTopo(ctx2, "initRace", false, func(subTopo *SrcSubTopo) error {
+			secondInitCalled.Store(true)
+			subTopo.AddSrc(&mockSrc{name: "unexpected"})
+			return nil
+		})
+		close(loadedDone)
+	}()
+	<-secondStarted
+
+	select {
+	case <-loadedDone:
+		t.Fatal("second caller observed the subtopo before the creator finished initialization")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(releaseInit)
+	select {
+	case <-creatorDone:
+	case <-time.After(time.Second):
+		t.Fatal("creator did not finish")
+	}
+	select {
+	case <-loadedDone:
+	case <-time.After(time.Second):
+		t.Fatal("second caller did not finish")
+	}
+
+	assert.NoError(t, creatorErr)
+	assert.NoError(t, loadedErr)
+	assert.False(t, creatorExisted)
+	assert.True(t, loadedExisted)
+	assert.False(t, secondInitCalled.Load())
+	assert.Equal(t, creatorTopo, loadedTopo)
+	assert.Equal(t, srcNode, loadedTopo.tail)
+	assert.Equal(t, 2, len(loadedTopo.refRules))
+}
+
 // Test when connection fails
 func TestSubtopoRunError(t *testing.T) {
 	ctx0 := mockContext.NewMockContext("rule0", "abc").WithRun(0)
 	assert.Equal(t, 0, len(subTopoPool))
-	subTopo, existed := GetOrCreateSubTopo(ctx0, "re", false)
-	assert.False(t, existed)
 	srcNode := &mockSrc{name: "src1"}
 	opNode := &mockOp{name: "op1", ch: make(chan any)}
-	subTopo.AddSrc(srcNode)
-	subTopo.AddOperator([]node.Emitter{srcNode}, opNode)
+	subTopo, existed, err := GetOrCreateSubTopo(ctx0, "re", false, func(subTopo *SrcSubTopo) error {
+		subTopo.AddSrc(srcNode)
+		subTopo.AddOperator([]node.Emitter{srcNode}, opNode)
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.False(t, existed)
 	// create another subtopo
 	ctx1 := mockContext.NewMockContext("rule1", "abc").WithRun(1)
-	subTopo2, existed := GetOrCreateSubTopo(ctx1, "re", false)
+	subTopo2, existed, err := GetOrCreateSubTopo(ctx1, "re", false, nil)
+	assert.NoError(t, err)
 	assert.True(t, existed)
 	assert.Equal(t, subTopo, subTopo2)
 	assert.Equal(t, 1, len(subTopoPool))
@@ -163,12 +243,15 @@ func TestSubtopoRunError(t *testing.T) {
 func TestErrorClose(t *testing.T) {
 	ctx0 := mockContext.NewMockContext("rule0", "abc").WithRun(0)
 	assert.Equal(t, 0, len(subTopoPool))
-	subTopo, existed := GetOrCreateSubTopo(ctx0, "ee", false)
-	assert.False(t, existed)
 	srcNode := &mockSrc{name: "src1"}
 	opNode := &mockOp{name: "op1", ch: make(chan any)}
-	subTopo.AddSrc(srcNode)
-	subTopo.AddOperator([]node.Emitter{srcNode}, opNode)
+	subTopo, existed, err := GetOrCreateSubTopo(ctx0, "ee", false, func(subTopo *SrcSubTopo) error {
+		subTopo.AddSrc(srcNode)
+		subTopo.AddOperator([]node.Emitter{srcNode}, opNode)
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.False(t, existed)
 	// create and run subtopo
 	ctx1 := mockContext.NewMockContext("rule1", "abc").WithRun(1)
 	errCh1 := make(chan error, 1)
@@ -198,7 +281,11 @@ func TestSubtopoPrint(t *testing.T) {
 		},
 	}
 	ctx0 := mockContext.NewMockContext("rule0", "abc")
-	subTopo, _ := GetOrCreateSubTopo(ctx0, "shared", false)
+	subTopo, _, err := GetOrCreateSubTopo(ctx0, "shared", false, func(subTopo *SrcSubTopo) error {
+		subTopo.AddSrc(&mockSrc{name: "shared"})
+		return nil
+	})
+	assert.NoError(t, err)
 	subTopo.topo = tt
 	subTopo.tail = &mockOp{name: "op1", ch: make(chan any)}
 	ptopo := &def.PrintableTopo{
@@ -221,19 +308,20 @@ func TestSubtopoPrint(t *testing.T) {
 	RemoveSubTopo("shared")
 }
 
-// because subtopo create and open is not atomic
-// test close in-between, which is supposed to close finally
 func TestSubtopoConcurrency(t *testing.T) {
 	subTopoPool = make(map[string]*SrcSubTopo)
 	// These are happened during planning syncly
 	ctx := mockContext.NewMockContext("rule1", "abc").WithRun(1)
 	assert.Equal(t, 0, len(subTopoPool))
-	subTopo, existed := GetOrCreateSubTopo(ctx, "shared", false)
-	assert.False(t, existed)
 	srcNode := &mockSrc{name: "shared"}
 	opNode := &mockOp{name: "op1", ch: make(chan any)}
-	subTopo.AddSrc(srcNode)
-	subTopo.AddOperator([]node.Emitter{srcNode}, opNode)
+	subTopo, existed, err := GetOrCreateSubTopo(ctx, "shared", false, func(subTopo *SrcSubTopo) error {
+		subTopo.AddSrc(srcNode)
+		subTopo.AddOperator([]node.Emitter{srcNode}, opNode)
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.False(t, existed)
 	subTopo.StoreSchema("rule1", "shared", map[string]*ast.JsonStreamField{
 		"field1": {Type: "string"},
 	}, false)


### PR DESCRIPTION
## Summary
- Initialize newly-created source subtopos before publishing them into the shared subtopo pool.
- Update shared connection and shared stream planning to use the safe initialization callback.
- Add a regression test that verifies concurrent callers cannot observe a partially initialized subtopo.

## Why
- Concurrent rule starts that share the same MQTT `connectionSelector` can race while creating the shared source subtopo.
- The old flow inserted a new subtopo into `subTopoPool` before `AddSrc` set its `tail`, allowing another planner goroutine to call `AddOutput` on a partially initialized subtopo and panic.
- Passing initialization into `GetOrCreateSubTopo` keeps the pool invariant simple: entries are usable when visible.

## Changes In This PR
- Changes `topo.GetOrCreateSubTopo` to accept an initialization callback and only insert new subtopos after successful initialization.
- Updates `planner_source.go` so shared connection and shared stream subtopos are initialized atomically at creation time.
- Updates subtopo tests and adds `TestGetOrCreateSubTopoDoesNotExposePartialSubTopo` to cover the concurrent creation window.

## Notes
- Existing subtopos do not run the initialization callback, so source nodes are not recreated for already-pooled subtopos.
- Verified with `go test ./internal/topo ./internal/topo/planner`.

Closes #1160
