### PR TITLE
fix(planner): cancel partial topo on plan failure

### DIFF
--- a/internal/topo/planner/planner.go
+++ b/internal/topo/planner/planner.go
@@ -249,6 +249,17 @@ func createTopo(rule *def.Rule, lp LogicalPlan, mockSourcesProp map[string]map[s
 	tp.SetStreams(streamsFromStmt)
 	tp.SetSinkSchema(schema)
 
+	// Cancel the partial topo on any planning error so that shared connection/stream
+	// subtopo refs and output channels registered during buildOps are cleaned up.
+	// Without this, a failed buildActions (e.g. mande converter missing proto message)
+	// would leave the rule permanently registered in the shared subtopo's refRules with
+	// an unread output channel, causing "buffer full, drop message" errors for other rules.
+	defer func() {
+		if err != nil {
+			tp.Cancel()
+		}
+	}()
+
 	input, _, err := buildOps(lp, tp, rule.Options, mockSourcesProp, streamsFromStmt, 0)
 	if err != nil {
 		return nil, err

--- a/internal/topo/planner/planner_source.go
+++ b/internal/topo/planner/planner_source.go
@@ -110,6 +110,12 @@ func splitSource(ctx api.StreamContext, t *DataSourcePlan, ss api.Source, option
 			subId = us.SubId(props)
 		}
 		selName := fmt.Sprintf("%s/%s", conId, subId)
+		var scn node.DataSourceNode
+		scn, err = node.NewSourceNode(ctx, selName, ss, props, options)
+		if err != nil {
+			return nil, nil, 0, err
+		}
+
 		subCtx := ctx
 		if t.streamStmt.Options.SHARED && !t.inRuleTest {
 			// For shared stream, the rule id is the shared subtopo. Subtopo only has one run so runId is always 0
@@ -117,20 +123,21 @@ func splitSource(ctx api.StreamContext, t *DataSourcePlan, ss api.Source, option
 		}
 		srcSubtopo, existed := topo.GetOrCreateSubTopo(subCtx, selName, false)
 		if !existed {
-			var scn node.DataSourceNode
-			scn, err = node.NewSourceNode(ctx, selName, ss, props, options)
-			if err == nil {
-				ctx.GetLogger().Infof("Create SubTopo %s for shared connection", selName)
-				srcSubtopo.AddSrc(scn)
-			}
+			ctx.GetLogger().Infof("Create SubTopo %s for shared connection", selName)
+			srcSubtopo.AddSrc(scn)
 		} else {
 			ctx.GetLogger().Infof("Load SubTopo %s for shared connection", selName)
 		}
 		srcConnNode = srcSubtopo
-		if err != nil {
-			topo.RemoveSubTopo(selName)
-			return nil, nil, 0, err
-		}
+
+		defer func() {
+			// If splitSource fails before returning, clean up the ref early,
+			// as it has not been attached to the topo yet.
+			if err != nil {
+				srcSubtopo.Close(subCtx)
+			}
+		}()
+
 		index++
 		// another node to set emitter
 		op := Transform(&operator.EmitterOp{Emitter: string(t.name)}, fmt.Sprintf("%d_emitter", index), options)

--- a/internal/topo/planner/planner_source_test.go
+++ b/internal/topo/planner/planner_source_test.go
@@ -16,6 +16,7 @@ package planner
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,6 +31,7 @@ import (
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/store"
 	"github.com/lf-edge/ekuiper/v2/internal/schema"
+	"github.com/lf-edge/ekuiper/v2/internal/topo"
 	"github.com/lf-edge/ekuiper/v2/internal/xsql"
 	"github.com/lf-edge/ekuiper/v2/pkg/ast"
 	"github.com/lf-edge/ekuiper/v2/pkg/message"
@@ -577,4 +579,117 @@ func (m *MockLookupBytes) Connect(ctx api.StreamContext, _ api.StatusChangeHandl
 
 func (m *MockLookupBytes) Lookup(ctx api.StreamContext, fields []string, keys []string, values []any) ([][]byte, error) {
 	return nil, nil
+}
+
+// TestSharedConnSubtopoCleanedUpAfterPlanFailure is a regression test for the
+// "buffer full, drop message" bug that occurs when a rule sharing an MQTT connection
+// fails to plan (e.g. mande converter: message type not found in proto schema).
+//
+// Without the fix: createTopo returns nil without calling tp.Cancel(), so the shared
+// connection subtopo retains the failed rule's ref and output channel. The subtopo then
+// keeps broadcasting to an unread channel, filling the buffer and dropping messages
+// for all other rules that share the same connection.
+//
+// With the fix: createTopo's deferred cancel calls tp.Cancel() on error, which calls
+// SrcSubTopo.Close() and removes the stale ref and output channel.
+func TestSharedConnSubtopoCleanedUpAfterPlanFailure(t *testing.T) {
+	conf.IsTesting = true
+	schema.InitRegistry()
+
+	// Register a converter that always fails, simulating "UP_XX_YY not found in proto".
+	modules.RegisterConverter("errfmt", func(_ api.StreamContext, _ string, _ map[string]*ast.JsonStreamField, _ map[string]any) (message.Converter, error) {
+		return nil, errors.New("message type UP_Test_T1 not found in schema path fake.proto")
+	})
+	t.Cleanup(func() { delete(modules.Converters, "errfmt") })
+
+	kv, err := store.GetKV("stream")
+	require.NoError(t, err)
+
+	// A stream with a shared MQTT connection (connectionSelector).
+	streamSQL := `CREATE STREAM planFailSrc () WITH (DATASOURCE="t/planfail", FORMAT="json", TYPE="mqtt", CONF_KEY="planFailConn");`
+	s, _ := json.Marshal(&xsql.StreamInfo{StreamType: ast.TypeStream, Statement: streamSQL})
+	require.NoError(t, kv.Set("planFailSrc", string(s)))
+	t.Cleanup(func() { _ = kv.Delete("planFailSrc") })
+
+	meta.InitYamlConfigManager()
+	dataDir, _ := conf.GetDataLoc()
+	require.NoError(t, os.MkdirAll(filepath.Join(dataDir, "sources"), 0o755))
+	connConf := map[string]any{
+		"connectionSelector": "mqtt.localConnection",
+		"interval":           "1s",
+	}
+	bs, _ := json.Marshal(connConf)
+	require.NoError(t, meta.AddSourceConfKey("mqtt", "planFailConn", "", bs))
+	t.Cleanup(func() { _ = meta.DelSourceConfKey("mqtt", "planFailConn", "") })
+
+	// Record pool size before planning to detect leaks.
+	sizeBefore := topo.GetSubTopoPoolSize()
+
+	// Plan a rule with a bad sink format — buildActions fails after buildOps succeeds.
+	// buildOps registered the shared connection subtopo; buildActions then fails.
+	rule := def.GetDefaultRule("planFailRule", "SELECT * FROM planFailSrc")
+	rule.Actions = []map[string]any{
+		{"logToMemory": map[string]any{"format": "errfmt"}},
+	}
+	tp, _, err := PlanSQLWithSourcesAndSinks(rule, nil)
+	assert.Error(t, err, "planning with invalid sink format must fail")
+	assert.Nil(t, tp, "failed plan must return nil topo")
+
+	// KEY ASSERTION: the shared connection subtopo must be cleaned up.
+	// Without the fix, sizeAfter > sizeBefore (pool has a stale entry).
+	// With the fix, the subtopo is destroyed because all refs were removed.
+	sizeAfter := topo.GetSubTopoPoolSize()
+	assert.Equal(t, sizeBefore, sizeAfter,
+		"shared connection subtopo must be removed from pool after failed plan; "+
+			"leaked subtopo would cause 'buffer full, drop message' for other rules")
+}
+
+// TestSharedConnSubtopoCleanedUpAfterSplitSourceFailure is a regression test for the
+// "planner failure after shared-connection ref registration" leak bug.
+// It triggers an error in checkFeatures inside splitSource, which happens AFTER GetOrCreateSubTopo
+// registers the ref, but BEFORE tp.AddSrc() is ever called.
+func TestSharedConnSubtopoCleanedUpAfterSplitSourceFailure(t *testing.T) {
+	conf.IsTesting = true
+	schema.InitRegistry()
+
+	kv, err := store.GetKV("stream")
+	require.NoError(t, err)
+
+	// A stream with a shared MQTT connection AND conflicting merger configurations
+	// (merger and mergeField set together causes checkFeatures to fail).
+	streamSQL := `CREATE STREAM planSplitFailSrc () WITH (DATASOURCE="t/plansplitfail", FORMAT="json", TYPE="mqtt", CONF_KEY="planSplitFailConn", MERGER="m1", MERGEFIELD="m2");`
+	s, _ := json.Marshal(&xsql.StreamInfo{StreamType: ast.TypeStream, Statement: streamSQL})
+	require.NoError(t, kv.Set("planSplitFailSrc", string(s)))
+	t.Cleanup(func() { _ = kv.Delete("planSplitFailSrc") })
+
+	meta.InitYamlConfigManager()
+	dataDir, _ := conf.GetDataLoc()
+	require.NoError(t, os.MkdirAll(filepath.Join(dataDir, "sources"), 0o755))
+	connConf := map[string]any{
+		"connectionSelector": "mqtt.localConnection",
+	}
+	bs, _ := json.Marshal(connConf)
+	require.NoError(t, meta.AddSourceConfKey("mqtt", "planSplitFailConn", "", bs))
+	t.Cleanup(func() { _ = meta.DelSourceConfKey("mqtt", "planSplitFailConn", "") })
+
+	// Record pool size before planning to detect leaks.
+	sizeBefore := topo.GetSubTopoPoolSize()
+
+	// Plan a rule. buildOps -> planSource -> splitSource
+	// splitSource calls GetOrCreateSubTopo for the shared connection, registers ref,
+	// then fails at checkFeatures because both MERGER and MERGEFIELD are set.
+	// Since the error happens before tp.AddSrc, tp.Cancel() won't clean this up.
+	// The new defer in splitSource itself must clean it up.
+	rule := def.GetDefaultRule("planSplitFailRule", "SELECT * FROM planSplitFailSrc")
+	rule.Actions = []map[string]any{
+		{"logToMemory": map[string]any{}},
+	}
+	tp, _, err := PlanSQLWithSourcesAndSinks(rule, nil)
+	assert.Error(t, err, "planning with invalid merger source config must fail")
+	assert.Nil(t, tp, "failed plan must return nil topo")
+
+	// KEY ASSERTION: the shared connection subtopo must be cleaned up by splitSource's defer.
+	sizeAfter := topo.GetSubTopoPoolSize()
+	assert.Equal(t, sizeBefore, sizeAfter,
+		"shared connection subtopo must be cleaned up if splitSource fails internally before tp.AddSrc")
 }

--- a/internal/topo/subtopo.go
+++ b/internal/topo/subtopo.go
@@ -275,6 +275,14 @@ func (s *SrcSubTopo) OpsCount() int {
 	return len(s.ops)
 }
 
+// RefCount returns the number of rules currently referencing this sub-topology.
+// It is intended for use in tests to verify cleanup after planning errors.
+func (s *SrcSubTopo) RefCount() int {
+	s.RLock()
+	defer s.RUnlock()
+	return len(s.refRules)
+}
+
 func (s *SrcSubTopo) StoreSchema(ruleID, dataSource string, schema map[string]*ast.JsonStreamField, isWildCard bool) {
 	s.schemaLayer.RegSchema(ruleID, dataSource, schema, isWildCard)
 }

--- a/internal/topo/subtopo_pool.go
+++ b/internal/topo/subtopo_pool.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/lf-edge/ekuiper/v2/internal/conf"
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
+	kctx "github.com/lf-edge/ekuiper/v2/internal/topo/context"
 	"github.com/lf-edge/ekuiper/v2/internal/topo/node"
 	"github.com/lf-edge/ekuiper/v2/internal/topo/schema"
 )
@@ -57,6 +58,45 @@ func RemoveSubTopo(name string) {
 	defer lock.Unlock()
 	delete(subTopoPool, name)
 	conf.Log.Infof("Delete SubTopo %s", name)
+}
+
+// GetSubTopoPoolSize returns the number of entries in the subtopo pool.
+// It is intended for use in tests to verify cleanup after planning errors.
+func GetSubTopoPoolSize() int {
+	lock.Lock()
+	defer lock.Unlock()
+	return len(subTopoPool)
+}
+
+// CloseSubTopo closes the subtopo safely. It locks the pool first to avoid deadlock.
+func CloseSubTopo(ctx api.StreamContext, s *SrcSubTopo, runId int) {
+	lock.Lock()
+
+	s.Lock()
+	// Check again if it is empty because it may be added again during unlock
+	if len(s.refRules) == 0 {
+		if s.cancel != nil {
+			s.cancel()
+		}
+		var ss *SrcSubTopo
+		if sourceSub, ok := s.source.(*SrcSubTopo); ok {
+			ss = sourceSub
+		}
+		delete(subTopoPool, s.name)
+		conf.Log.Infof("Delete SubTopo %s", s.name)
+		// Unlock before recursive call to avoid deadlock
+		s.Unlock()
+		lock.Unlock()
+
+		if ss != nil {
+			subCtx := ctx.(*kctx.DefaultContext).WithRuleId(fmt.Sprintf("$$subtopo_%s", s.name)).WithRun(0)
+			ss.Close(subCtx)
+		}
+	} else {
+		// Unlock if no deletion
+		s.Unlock()
+		lock.Unlock()
+	}
 }
 
 func (s *SrcSubTopo) AddSrc(src node.DataSourceNode) *SrcSubTopo {

--- a/internal/topo/subtopo_test.go
+++ b/internal/topo/subtopo_test.go
@@ -380,3 +380,59 @@ func (m *mockOp) RemoveMetrics(name string) {
 func (m *mockOp) ResetSchema(ctx api.StreamContext, schema map[string]*ast.JsonStreamField) {
 	m.schemaCount = len(schema)
 }
+
+// TestCancelReleasesSubtopoRef verifies that cancelling a partial (never-opened) topo
+// correctly removes its ref from the shared connection subtopo.
+//
+// This is the core plumbing test for the bug fix: when a rule's topo.Cancel() is called
+// after a planning failure, Topo.doClose() must call SrcSubTopo.Close() which removes
+// the rule's ref and output channel from the subtopo.
+func TestCancelReleasesSubtopoRef(t *testing.T) {
+	// Reset pool for test isolation.
+	origPool := subTopoPool
+	subTopoPool = make(map[string]*SrcSubTopo)
+	defer func() { subTopoPool = origPool }()
+
+	// Build a shared connection subtopo with a mock source (like the real MQTT case).
+	ctx1 := mockContext.NewMockContext("rule1", "abc").WithRun(1)
+	subTopo, existed := GetOrCreateSubTopo(ctx1, "connSubTopo", false)
+	assert.False(t, existed)
+
+	srcNode := &mockSrc{name: "shared"}
+	opNode := &mockOp{name: "op1", ch: make(chan any)}
+	subTopo.AddSrc(srcNode)
+	subTopo.AddOperator([]node.Emitter{srcNode}, opNode)
+	assert.Equal(t, 1, subTopo.RefCount(), "setup: rule1 should have 1 ref after GetOrCreateSubTopo")
+
+	// Allocate a topo for rule2 that shares the same connection subtopo.
+	// This simulates plantopo.buildOps succeeding (subtopo registered for rule2).
+	tp, err := NewWithNameAndOptions("rule2", &def.RuleOption{})
+	assert.NoError(t, err)
+
+	// Manually wire rule2 into the subtopo, as the planner would do.
+	ctx2 := tp.GetContext() // ruleId="rule2", runId=tp.runId
+	subTopo2, _ := GetOrCreateSubTopo(ctx2, "connSubTopo", false)
+	assert.Equal(t, subTopo, subTopo2)
+	assert.Equal(t, 2, subTopo.RefCount(), "rule1 + rule2 should each hold a ref")
+
+	// Add rule2's output channel to the subtopo's tail (as topo.AddOperator does).
+	ch := make(chan any, 1)
+	err = subTopo.AddOutput(ch, "rule2.0_emitter")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(opNode.outputs), "subtopo tail should have rule2's output channel")
+
+	// Add the subtopo as a source to rule2's topo (needed for Cancel to call Close).
+	tp.AddSrc(subTopo)
+
+	// Simulate buildActions failure → tp.Cancel() is called.
+	tp.Cancel()
+
+	// KEY ASSERTIONS: rule2's ref and output channel must be removed.
+	assert.Equal(t, 1, subTopo.RefCount(), "after Cancel, rule2 ref must be removed")
+	assert.Equal(t, 0, len(opNode.outputs), "after Cancel, rule2 output channel must be removed from subtopo tail")
+	assert.Equal(t, 1, len(subTopoPool), "subtopo pool must still have the entry (rule1 still holds a ref)")
+
+	// Cleanup rule1.
+	subTopo.Close(ctx1)
+	assert.Equal(t, 0, len(subTopoPool), "subtopo pool must be empty after all refs removed")
+}


### PR DESCRIPTION
## Summary
- Ensure fully failed `planner.Plan()` operations don't leak subtopologies.
- Clean up the shared connection subtopo ref registered during a failed partial topology correctly.

## Why

When a rule's `PUT /rules` planning fails (e.g. protobuf schema mismatch — "message type not found in schema"), `planner.Plan()` may have already called `GetOrCreateSubTopo` → `Init`, which registers the rule as a ref in the shared subtopo and adds an output channel to the subtopo's tail node. Because the plan fails and `tp.Cancel()` is never called, these refs and output channels leak as zombies with no consumer goroutine.

As the shared subtopo keeps broadcasting (e.g. at ~1 msg/s), the unread channel fills to `BufferLength:1024` (~17 min) and begins logging "buffer full, drop message" errors, dropping messages for **all other rules** sharing the same connection/stream.

## Changes

- **`internal/topo/planner/planner.go`** — `createTopo`: add `defer tp.Cancel()` on error. Covers the case where `buildActions` fails after `buildOps` has already registered the subtopo ref. `tp.Cancel()` → `doClose()` → `SrcSubTopo.Close()` removes the ref and output channel.

- **`internal/topo/planner/planner_source.go`** — `splitSource`: add `defer srcSubtopo.Close(subCtx)` on error. Covers failures (e.g. `checkFeatures`) that happen **after** `GetOrCreateSubTopo` but **before** `tp.AddSrc` — a window where `tp.Cancel()` cannot reach.

- **`internal/topo/subtopo.go`** — Add `RefCount()` helper for test assertions.
- **`internal/topo/subtopo_pool.go`** — Add `GetSubTopoPoolSize()` helper for test assertions; add `CloseSubTopo()` safe pool-locked close helper.
- **Tests** — `subtopo_test.go` and `planner_source_test.go`: two regression tests verifying subtopo pool is clean after failed plans.

Cherry-pick of emqx/ekuiper@1998082017dabfa473fad40ff7abaa1da76df023.