### PR TITLE
fix(planner): cancel partial topo on plan failure

### DIFF
--- a/internal/topo/planner/planner.go
+++ b/internal/topo/planner/planner.go
@@ -290,6 +290,17 @@ func createTopo(rule *def.Rule, lp LogicalPlan, mockSourcesProp map[string]map[s
 	tp.SetStreams(streamsFromStmt)
 	tp.SetSinkSchema(schema)
 
+	// Cancel the partial topo on any planning error so that shared connection/stream
+	// subtopo refs and output channels registered during buildOps are cleaned up.
+	// Without this, a failed buildActions would leave the rule permanently registered
+	// in the shared subtopo's refRules with an unread output channel, causing
+	// "buffer full, drop message" errors for other rules.
+	defer func() {
+		if err != nil {
+			tp.Cancel()
+		}
+	}()
+
 	input, _, err := buildOps(lp, tp, rule.Options, mockSourcesProp, streamsFromStmt, 0)
 	if err != nil {
 		return nil, err

--- a/internal/topo/planner/planner_source.go
+++ b/internal/topo/planner/planner_source.go
@@ -72,7 +72,7 @@ func transformSourceNode(ctx api.StreamContext, t *DataSourcePlan, mockSourcesPr
 	return splitSource(ctx, t, si, options, mockProps, index, ruleId, pp, emitterName)
 }
 
-func splitSource(ctx api.StreamContext, t *DataSourcePlan, ss api.Source, options *def.RuleOption, mockProps map[string]any, index int, ruleId string, pp node.UnOperation, emitterName ast.StreamName) (node.DataSourceNode, []node.OperatorNode, int, error) {
+func splitSource(ctx api.StreamContext, t *DataSourcePlan, ss api.Source, options *def.RuleOption, mockProps map[string]any, index int, ruleId string, pp node.UnOperation, emitterName ast.StreamName) (_ node.DataSourceNode, _ []node.OperatorNode, _ int, err error) {
 	// Get all props
 	props := nodeConf.GetSourceConf(t.streamStmt.Options.TYPE, t.streamStmt.Options)
 	sp := &SourcePropsForSplit{}
@@ -83,10 +83,7 @@ func splitSource(ctx api.StreamContext, t *DataSourcePlan, ss api.Source, option
 	}
 	_ = cast.MapToStruct(props, sp)
 	// Create the connector node as source node
-	var (
-		err         error
-		srcConnNode node.DataSourceNode
-	)
+	var srcConnNode node.DataSourceNode
 	// Some connection only allow one subscription. The source should implement UniqueSub to provide a subId to avoid multiple connection.
 	us, hasSubId := ss.(model.UniqueSub)
 	conId := sp.SelId
@@ -112,23 +109,33 @@ func splitSource(ctx api.StreamContext, t *DataSourcePlan, ss api.Source, option
 			subId = us.SubId(props)
 		}
 		selName := fmt.Sprintf("%s/%s", conId, subId)
+
 		subCtx := ctx
 		if t.streamStmt.Options.SHARED && !t.inRuleTest {
 			// For shared stream, the rule id is the shared subtopo. Subtopo only has one run so runId is always 0
 			subCtx = subCtx.(*context.DefaultContext).WithRuleId(fmt.Sprintf("$$subtopo_%s", t.name)).WithRun(0)
 		}
-		srcSubtopo, err := topo.GetOrCreateSubTopo(subCtx, selName, false, func(srcSubtopo *topo.SrcSubTopo) error {
-			scn, err := node.NewSourceNode(ctx, selName, ss, props, options)
-			if err != nil {
-				return err
+		var connSubtopo *topo.SrcSubTopo
+		connSubtopo, err = topo.GetOrCreateSubTopo(subCtx, selName, false, func(st *topo.SrcSubTopo) error {
+			scn, initErr := node.NewSourceNode(ctx, selName, ss, props, options)
+			if initErr != nil {
+				return initErr
 			}
-			srcSubtopo.AddSrc(scn)
+			st.AddSrc(scn)
 			return nil
 		})
 		if err != nil {
 			return nil, nil, 0, err
 		}
-		srcConnNode = srcSubtopo
+		srcConnNode = connSubtopo
+
+		defer func() {
+			// If splitSource fails before returning, clean up the ref early,
+			// as it has not been attached to the topo yet.
+			if err != nil {
+				connSubtopo.Close(subCtx)
+			}
+		}()
 		index++
 		// another node to set emitter
 		op := Transform(&operator.EmitterOp{Emitter: string(emitterName)}, fmt.Sprintf("%d_emitter", index), options)
@@ -228,6 +235,7 @@ func splitSource(ctx api.StreamContext, t *DataSourcePlan, ss api.Source, option
 			return nil, nil, 0, err
 		}
 		if isSliceRule != srcSubtopo.IsSliceMode() {
+			srcSubtopo.Close(ctx)
 			return nil, nil, 0, fmt.Errorf("rules refer to shared stream must be the same mode, stream slice mode: %v but rule slice mode: %v", srcSubtopo.IsSliceMode(), isSliceRule)
 		}
 		srcSubtopo.StoreSchema(ruleId, string(t.name), t.streamFields, t.isWildCard)

--- a/internal/topo/planner/planner_source_test.go
+++ b/internal/topo/planner/planner_source_test.go
@@ -16,6 +16,7 @@ package planner
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,6 +31,7 @@ import (
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/store"
 	"github.com/lf-edge/ekuiper/v2/internal/schema"
+	"github.com/lf-edge/ekuiper/v2/internal/topo"
 	"github.com/lf-edge/ekuiper/v2/internal/xsql"
 	"github.com/lf-edge/ekuiper/v2/pkg/ast"
 	"github.com/lf-edge/ekuiper/v2/pkg/message"
@@ -577,4 +579,117 @@ func (m *MockLookupBytes) Connect(ctx api.StreamContext, _ api.StatusChangeHandl
 
 func (m *MockLookupBytes) Lookup(ctx api.StreamContext, fields []string, keys []string, values []any) ([][]byte, error) {
 	return nil, nil
+}
+
+// TestSharedConnSubtopoCleanedUpAfterPlanFailure is a regression test for the
+// "buffer full, drop message" bug that occurs when a rule sharing an MQTT connection
+// fails to plan (e.g. missing converter: message type not found in proto schema).
+//
+// Without the fix: createTopo returns nil without calling tp.Cancel(), so the shared
+// connection subtopo retains the failed rule's ref and output channel. The subtopo then
+// keeps broadcasting to an unread channel, filling the buffer and dropping messages
+// for all other rules that share the same connection.
+//
+// With the fix: createTopo's deferred cancel calls tp.Cancel() on error, which calls
+// SrcSubTopo.Close() and removes the stale ref and output channel.
+func TestSharedConnSubtopoCleanedUpAfterPlanFailure(t *testing.T) {
+	conf.IsTesting = true
+	schema.InitRegistry()
+
+	// Register a converter that always fails, simulating "UP_XX_YY not found in proto".
+	modules.RegisterConverter("errfmt", func(_ api.StreamContext, _ string, _ map[string]*ast.JsonStreamField, _ map[string]any) (message.Converter, error) {
+		return nil, errors.New("message type UP_Test_T1 not found in schema path fake.proto")
+	})
+	t.Cleanup(func() { delete(modules.Converters, "errfmt") })
+
+	kv, err := store.GetKV("stream")
+	require.NoError(t, err)
+
+	// A stream with a shared MQTT connection (connectionSelector).
+	streamSQL := `CREATE STREAM planFailSrc () WITH (DATASOURCE="t/planfail", FORMAT="json", TYPE="mqtt", CONF_KEY="planFailConn");`
+	s, _ := json.Marshal(&xsql.StreamInfo{StreamType: ast.TypeStream, Statement: streamSQL})
+	require.NoError(t, kv.Set("planFailSrc", string(s)))
+	t.Cleanup(func() { _ = kv.Delete("planFailSrc") })
+
+	meta.InitYamlConfigManager()
+	dataDir, _ := conf.GetDataLoc()
+	require.NoError(t, os.MkdirAll(filepath.Join(dataDir, "sources"), 0o755))
+	connConf := map[string]any{
+		"connectionSelector": "mqtt.localConnection",
+		"interval":           "1s",
+	}
+	bs, _ := json.Marshal(connConf)
+	require.NoError(t, meta.AddSourceConfKey("mqtt", "planFailConn", "", bs))
+	t.Cleanup(func() { _ = meta.DelSourceConfKey("mqtt", "planFailConn", "") })
+
+	// Record pool size before planning to detect leaks.
+	sizeBefore := topo.GetSubTopoPoolSize()
+
+	// Plan a rule with a bad sink format — buildActions fails after buildOps succeeds.
+	// buildOps registered the shared connection subtopo; buildActions then fails.
+	rule := def.GetDefaultRule("planFailRule", "SELECT * FROM planFailSrc")
+	rule.Actions = []map[string]any{
+		{"logToMemory": map[string]any{"format": "errfmt"}},
+	}
+	tp, _, err := PlanSQLWithSourcesAndSinks(rule, nil)
+	assert.Error(t, err, "planning with invalid sink format must fail")
+	assert.Nil(t, tp, "failed plan must return nil topo")
+
+	// KEY ASSERTION: the shared connection subtopo must be cleaned up.
+	// Without the fix, sizeAfter > sizeBefore (pool has a stale entry).
+	// With the fix, the subtopo is destroyed because all refs were removed.
+	sizeAfter := topo.GetSubTopoPoolSize()
+	assert.Equal(t, sizeBefore, sizeAfter,
+		"shared connection subtopo must be removed from pool after failed plan; "+
+			"leaked subtopo would cause 'buffer full, drop message' for other rules")
+}
+
+// TestSharedConnSubtopoCleanedUpAfterSplitSourceFailure is a regression test for the
+// "planner failure after shared-connection ref registration" leak bug.
+// It triggers an error in checkFeatures inside splitSource, which happens AFTER GetOrCreateSubTopo
+// registers the ref, but BEFORE tp.AddSrc() is ever called.
+func TestSharedConnSubtopoCleanedUpAfterSplitSourceFailure(t *testing.T) {
+	conf.IsTesting = true
+	schema.InitRegistry()
+
+	kv, err := store.GetKV("stream")
+	require.NoError(t, err)
+
+	// A stream with a shared MQTT connection AND conflicting merger configurations
+	// (merger and mergeField set together causes checkFeatures to fail).
+	streamSQL := `CREATE STREAM planSplitFailSrc () WITH (DATASOURCE="t/plansplitfail", FORMAT="json", TYPE="mqtt", CONF_KEY="planSplitFailConn", MERGER="m1", MERGEFIELD="m2");`
+	s, _ := json.Marshal(&xsql.StreamInfo{StreamType: ast.TypeStream, Statement: streamSQL})
+	require.NoError(t, kv.Set("planSplitFailSrc", string(s)))
+	t.Cleanup(func() { _ = kv.Delete("planSplitFailSrc") })
+
+	meta.InitYamlConfigManager()
+	dataDir, _ := conf.GetDataLoc()
+	require.NoError(t, os.MkdirAll(filepath.Join(dataDir, "sources"), 0o755))
+	connConf := map[string]any{
+		"connectionSelector": "mqtt.localConnection",
+	}
+	bs, _ := json.Marshal(connConf)
+	require.NoError(t, meta.AddSourceConfKey("mqtt", "planSplitFailConn", "", bs))
+	t.Cleanup(func() { _ = meta.DelSourceConfKey("mqtt", "planSplitFailConn", "") })
+
+	// Record pool size before planning to detect leaks.
+	sizeBefore := topo.GetSubTopoPoolSize()
+
+	// Plan a rule. buildOps -> planSource -> splitSource
+	// splitSource calls GetOrCreateSubTopo for the shared connection, registers ref,
+	// then fails at checkFeatures because both MERGER and MERGEFIELD are set.
+	// Since the error happens before tp.AddSrc, tp.Cancel() won't clean this up.
+	// The new defer in splitSource itself must clean it up.
+	rule := def.GetDefaultRule("planSplitFailRule", "SELECT * FROM planSplitFailSrc")
+	rule.Actions = []map[string]any{
+		{"logToMemory": map[string]any{}},
+	}
+	tp, _, err := PlanSQLWithSourcesAndSinks(rule, nil)
+	assert.Error(t, err, "planning with invalid merger source config must fail")
+	assert.Nil(t, tp, "failed plan must return nil topo")
+
+	// KEY ASSERTION: the shared connection subtopo must be cleaned up by splitSource's defer.
+	sizeAfter := topo.GetSubTopoPoolSize()
+	assert.Equal(t, sizeBefore, sizeAfter,
+		"shared connection subtopo must be cleaned up if splitSource fails internally before tp.AddSrc")
 }

--- a/internal/topo/subtopo.go
+++ b/internal/topo/subtopo.go
@@ -273,6 +273,14 @@ func (s *SrcSubTopo) OpsCount() int {
 	return len(s.ops)
 }
 
+// RefCount returns the number of rules currently referencing this sub-topology.
+// It is intended for use in tests to verify cleanup after planning errors.
+func (s *SrcSubTopo) RefCount() int {
+	s.RLock()
+	defer s.RUnlock()
+	return len(s.refRules)
+}
+
 func (s *SrcSubTopo) StoreSchema(ruleID, dataSource string, schema map[string]*ast.JsonStreamField, isWildCard bool) {
 	s.schemaLayer.RegSchema(ruleID, dataSource, schema, isWildCard)
 }

--- a/internal/topo/subtopo_pool.go
+++ b/internal/topo/subtopo_pool.go
@@ -71,6 +71,14 @@ func RemoveSubTopo(name string) {
 	conf.Log.Infof("Delete SubTopo %s", name)
 }
 
+// GetSubTopoPoolSize returns the number of entries in the subtopo pool.
+// It is intended for use in tests to verify cleanup after planning errors.
+func GetSubTopoPoolSize() int {
+	lock.Lock()
+	defer lock.Unlock()
+	return len(subTopoPool)
+}
+
 // CloseSubTopo closes the subtopo safely. It locks the pool first to avoid deadlock.
 func CloseSubTopo(ctx api.StreamContext, s *SrcSubTopo, runId int) {
 	lock.Lock()

--- a/internal/topo/subtopo_test.go
+++ b/internal/topo/subtopo_test.go
@@ -477,3 +477,59 @@ func (m *mockOp) RemoveMetrics(name string) {
 func (m *mockOp) ResetSchema(ctx api.StreamContext, schema map[string]*ast.JsonStreamField) {
 	m.schemaCount = len(schema)
 }
+
+// TestCancelReleasesSubtopoRef verifies that cancelling a partial (never-opened) topo
+// correctly removes its ref from the shared connection subtopo.
+//
+// This is the core plumbing test for the bug fix: when a rule's topo.Cancel() is called
+// after a planning failure, Topo.doClose() must call SrcSubTopo.Close() which removes
+// the rule's ref and output channel from the subtopo.
+func TestCancelReleasesSubtopoRef(t *testing.T) {
+	// Reset pool for test isolation.
+	origPool := subTopoPool
+	subTopoPool = make(map[string]*SrcSubTopo)
+	defer func() { subTopoPool = origPool }()
+
+	// Build a shared connection subtopo with a mock source (like the real MQTT case).
+	ctx1 := mockContext.NewMockContext("rule1", "abc").WithRun(1)
+	subTopo, err := GetOrCreateSubTopo(ctx1, "connSubTopo", false, nil)
+	assert.NoError(t, err)
+
+	srcNode := &mockSrc{name: "shared"}
+	opNode := &mockOp{name: "op1", ch: make(chan any)}
+	subTopo.AddSrc(srcNode)
+	subTopo.AddOperator([]node.Emitter{srcNode}, opNode)
+	assert.Equal(t, 1, subTopo.RefCount(), "setup: rule1 should have 1 ref after GetOrCreateSubTopo")
+
+	// Allocate a topo for rule2 that shares the same connection subtopo.
+	// This simulates plantopo.buildOps succeeding (subtopo registered for rule2).
+	tp, err := NewWithNameAndOptions("rule2", &def.RuleOption{})
+	assert.NoError(t, err)
+
+	// Manually wire rule2 into the subtopo, as the planner would do.
+	ctx2 := tp.GetContext() // ruleId="rule2", runId=tp.runId
+	subTopo2, _ := GetOrCreateSubTopo(ctx2, "connSubTopo", false, nil)
+	assert.Equal(t, subTopo, subTopo2)
+	assert.Equal(t, 2, subTopo.RefCount(), "rule1 + rule2 should each hold a ref")
+
+	// Add rule2's output channel to the subtopo's tail (as topo.AddOperator does).
+	ch := make(chan any, 1)
+	err = subTopo.AddOutput(ch, "rule2.0_emitter")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(opNode.outputs), "subtopo tail should have rule2's output channel")
+
+	// Add the subtopo as a source to rule2's topo (needed for Cancel to call Close).
+	tp.AddSrc(subTopo)
+
+	// Simulate buildActions failure → tp.Cancel() is called.
+	tp.Cancel()
+
+	// KEY ASSERTIONS: rule2's ref and output channel must be removed.
+	assert.Equal(t, 1, subTopo.RefCount(), "after Cancel, rule2 ref must be removed")
+	assert.Equal(t, 0, len(opNode.outputs), "after Cancel, rule2 output channel must be removed from subtopo tail")
+	assert.Equal(t, 1, len(subTopoPool), "subtopo pool must still have the entry (rule1 still holds a ref)")
+
+	// Cleanup rule1.
+	subTopo.Close(ctx1)
+	assert.Equal(t, 0, len(subTopoPool), "subtopo pool must be empty after all refs removed")
+}


### PR DESCRIPTION
This PR fixes a critical resource leak where shared sub-topologies (e.g., MQTT shared connections) would leak references and output channels if a rule failed during the building phase (e.g., invalid actions or converters).

### Changes:
- **Topology Cancellation**: Added a deferred \	p.Cancel()\ in \planner.createTopo\ to ensure that any partially built topology is cleaned up if buildOps or buildActions fails.
- **Sub-topology Cleanup**: Added a deferred \srcSubtopo.Close()\ in \splitSource\ to release shared sub-topology references if subsequent operator creation fails.
- **Variable Shadowing Fix**: Fixed a bug in \splitSource\ where the deferred cleanup missed errors due to block-scoped variable shadowing.
- **Regression Tests**: Added tests in \planner_source_test.go\ and \subtopo_test.go\ to verify that shared sub-topology references are correctly released and pool entries are removed when planning fails at various stages.