### PR TITLE
fix(schema): fix wildcard rules schema detaches

### DIFF
--- a/internal/topo/schema/source.go
+++ b/internal/topo/schema/source.go
@@ -118,14 +118,21 @@ func (s *SharedLayer) Detach(ctx api.StreamContext, isClose bool) error {
 			delete(s.streamMap, ruleID)
 			delete(s.wildcardMap, ruleID)
 			delete(s.reg, ruleID)
-			newSchema := make(map[string]*ast.JsonStreamField)
-			for _, si := range s.reg {
-				newSchema, err = s.merge(newSchema, si.schema)
-				if err != nil {
-					return err
+			// If any remaining rule is still wildcard, keep schema as nil (schemaless).
+			// Merging nil wildcard schemas would produce {} which causes the decoder to
+			// reject every field and emit empty tuples.
+			if len(s.wildcardMap) > 0 {
+				s.schema = nil
+			} else {
+				newSchema := make(map[string]*ast.JsonStreamField)
+				for _, si := range s.reg {
+					newSchema, err = s.merge(newSchema, si.schema)
+					if err != nil {
+						return err
+					}
 				}
+				s.schema = newSchema
 			}
-			s.schema = newSchema
 			s.updateReg()
 		}
 	}

--- a/internal/topo/schema/source_test.go
+++ b/internal/topo/schema/source_test.go
@@ -266,3 +266,29 @@ func TestAttachDetachSchema(t *testing.T) {
 	}
 	require.Equal(t, r, er)
 }
+
+// TestDetachWildcardKeepsWildcard verifies that when one wildcard rule closes while another
+// wildcard rule is still running, the shared schema remains nil (schemaless). Previously
+// the Detach logic would merge nil schemas and produce {} (empty non-nil map), causing the
+// JSON decoder to reject every field and output empty tuples {}.
+func TestDetachWildcardKeepsWildcard(t *testing.T) {
+	f := newSharedLayer()
+	ctx1 := mockContext.NewMockContext("rule1", "t1")
+	ctx2 := mockContext.NewMockContext("rule2", "t2")
+
+	// Both rules are wildcard (SELECT *)
+	f.RegSchema("rule1", "demo", nil, true)
+	f.RegSchema("rule2", "demo", nil, true)
+	require.NoError(t, f.Attach(ctx1))
+	require.NoError(t, f.Attach(ctx2))
+	require.Nil(t, f.GetSchema(), "both wildcard: schema should be nil")
+
+	// Stop rule1 — rule2 (also wildcard) is still running
+	require.NoError(t, f.Detach(ctx1, true))
+	require.Nil(t, f.GetSchema(), "after wildcard rule1 closes, remaining wildcard rule2 must keep schema nil")
+
+	// Stop rule2 as well — no rules left, schema collapses to empty
+	require.NoError(t, f.Detach(ctx2, true))
+	require.NotNil(t, f.GetSchema(), "after all rules close the schema map should be non-nil empty")
+	require.Empty(t, f.GetSchema(), "after all rules close the schema map should be empty")
+}


### PR DESCRIPTION
## Problem

When two or more rules share a `SHARED=true` source (e.g. a neuron stream) and both use wildcard queries (`SELECT *`), stopping one rule causes the remaining rule(s) to start emitting empty tuples `{}`. Starting the stopped rule again restores normal output.

## Root Cause

`SharedLayer.Detach` recalculates the merged schema from remaining rules after removing the closing rule. Wildcard rules store `nil` as their schema in `s.reg`. Merging `nil` schemas into a fresh empty map produces `{}` — a **non-nil empty map** — not `nil`.

`FastJsonConverter` treats the two differently:
- `nil` schema → schemaless mode, all fields pass through  
- `{}` schema → strict mode with zero allowed fields → every field is skipped → output is `{}`

`Attach` already has the correct guard:
```go
isWildCard := len(s.wildcardMap) > 0
    ...
}
```
`Detach` was missing the equivalent check.

## Fix

After removing the closing rule's entries, if `len(s.wildcardMap) > 0` (at least one remaining rule is still wildcard), set `s.schema = nil` instead of running the merge loop.

Adds `TestDetachWildcardKeepsWildcard` to cover this scenario directly.