### PR TITLE
refactor: use strconv.FormatFloat

### DIFF
--- a/internal/topo/planner/analyzer_test.go
+++ b/internal/topo/planner/analyzer_test.go
@@ -81,7 +81,7 @@ var tests = []struct {
 	},
 	{ // 5
 		sql: `SELECT count(*) as c FROM src1 WHERE name = "dname" HAVING sum(c) > 0.3 OR sin(temp) > 3`,
-		r:   newErrorStruct("Not allowed to call non-aggregate functions in HAVING clause: binaryExpr:{ binaryExpr:{ Call:{ name:sum, args:[$$alias.c,aliasRef:Call:{ name:count, args:[*] }] } > 0.300000 } OR binaryExpr:{ Call:{ name:sin, args:[src1.temp] } > 3 } }."),
+		r:   newErrorStruct("Not allowed to call non-aggregate functions in HAVING clause: binaryExpr:{ binaryExpr:{ Call:{ name:sum, args:[$$alias.c,aliasRef:Call:{ name:count, args:[*] }] } > 0.3 } OR binaryExpr:{ Call:{ name:sin, args:[src1.temp] } > 3 } }."),
 	},
 	{ // 6
 		sql: `SELECT collect(*) as c FROM src1 WHERE name = "dname" HAVING c[2]->temp > 20 AND sin(c[0]->temp) > 0`,

--- a/internal/topo/planner/analyzer_test.go
+++ b/internal/topo/planner/analyzer_test.go
@@ -61,7 +61,7 @@ var tests = []struct {
 }{
 	{ // 0
 		sql: `SELECT count(*) FROM src1 HAVING sin(temp) > 0.3`,
-		r:   newErrorStruct("Not allowed to call non-aggregate functions in HAVING clause: binaryExpr:{ Call:{ name:sin, args:[src1.temp] } > 0.300000 }."),
+		r:   newErrorStruct("Not allowed to call non-aggregate functions in HAVING clause: binaryExpr:{ Call:{ name:sin, args:[src1.temp] } > 0.3 }."),
 	},
 	{ // 1
 		sql: `SELECT count(*) FROM src1 WHERE name = "dname" HAVING sin(count(*)) > 0.3`,

--- a/pkg/ast/expr.go
+++ b/pkg/ast/expr.go
@@ -16,7 +16,6 @@ package ast
 
 import (
 	"errors"
-	"fmt"
 	"strconv"
 )
 
@@ -191,7 +190,7 @@ func (nl *NumberLiteral) expr()    {}
 func (nl *NumberLiteral) literal() {}
 func (nl *NumberLiteral) node()    {}
 func (nl *NumberLiteral) String() string {
-	return fmt.Sprintf("%f", nl.Val)
+	return strconv.FormatFloat(nl.Val, 'g', -1, 64)
 }
 
 func (sl *StringLiteral) expr()    {}

--- a/pkg/ast/expr_test.go
+++ b/pkg/ast/expr_test.go
@@ -182,7 +182,7 @@ func Test_exprStringPlan(t *testing.T) {
 		},
 		{
 			e:   &NumberLiteral{Val: 1.23},
-			res: "1.230000",
+			res: "1.23",
 		},
 		{
 			e:   &StringLiteral{Val: "v1"},

--- a/pkg/ast/sourceStmt_test.go
+++ b/pkg/ast/sourceStmt_test.go
@@ -85,9 +85,9 @@ func TestMarshalJSON(t *testing.T) {
 			input: StreamField{
 				Name:      "foo",
 				FieldType: &BasicType{Type: FLOAT},
-				Default:   &NumberLiteral{Val: -55.340},
+				Default:   &NumberLiteral{Val: -55.34},
 			},
-			output: `{"FieldType":"float","Name":"foo","DefaultClause":"-55.340000"}`,
+			output: `{"FieldType":"float","Name":"foo","DefaultClause":"-55.34"}`,
 			err:    nil,
 		},
 		{


### PR DESCRIPTION
### Summary
This PR fixes an issue identified by Copilot in the recently merged PR (#4025).
The ```NumberLiteral``` struct implemented the ```String()``` method using ```fmt.Sprintf("%f")```. As a result, calling ```String()``` produced a float representation with trailing zeros.

For example, a number such as 55.340 would be printed as 55.340000.

### Changes
This change replaces fmt.Sprintf with strconv.FormatFloat, ensuring a more accurate representation of float literals.