### PR TITLE
feat(docs): document scan table queries

### DIFF
--- a/docs/en_US/api/restapi/tables.md
+++ b/docs/en_US/api/restapi/tables.md
@@ -129,3 +129,13 @@ The API is used for drop the table definition.
 ```shell
 DELETE http://localhost:9081/tables/{id}
 ```
+
+## query a scan table
+
+This API allows users to directly query the content of scan tables related to a specific rule.
+
+```shell
+GET http://localhost:9081/rules/{rule}/scantables
+```
+
+This GET call returns the actual content of each scan table associated with the given rule.


### PR DESCRIPTION
This PR adds the missing documentation for querying scan tables, following up on the recently merged PR that introduced this feature. 
It includes the API endpoint details, description, and expected response behavior.
