### PR TITLE
Fix bug and improve test

### DIFF
--- a/internal/pkg/store/sql/sqlKv.go
+++ b/internal/pkg/store/sql/sqlKv.go
@@ -77,7 +77,7 @@ func (kv *sqlKvStore) initPreparedStmt() error {
 		if err != nil {
 			return err
 		}
-		kv.preparedGetByPrefixStmt, err = db.Prepare(fmt.Sprintf("SELECT key, val FROM %s WHERE key LIKE ?", kv.table))
+		kv.preparedGetByPrefixStmt, err = db.Prepare(fmt.Sprintf("SELECT key, val FROM '%s' WHERE key LIKE ?", kv.table))
 		if err != nil {
 			return err
 		}

--- a/internal/topo/node/cache_op_test.go
+++ b/internal/topo/node/cache_op_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/lf-edge/ekuiper/v2/internal/conf"
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
@@ -119,6 +120,11 @@ func TestCacheRun(t *testing.T) {
 	index := 0
 	errCh := make(chan error)
 	cacheOp.Exec(ctx, errCh)
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(100 * time.Millisecond):
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var r any


### PR DESCRIPTION
This PR consists of two commits:
1. Add an error check in cache_op_test.TestCacheRun. Previously, any error sent by cacheOp.Exec(ctx, errCh) to errCh was ignored; this change explicitly checks the error and handles it gracefully.
2. Quote the table name in the last SQL statement of sqlKvStore.initPreparedStmt. Unlike the other SQL statements, the table name was not quoted, which could lead to errors.