### PR TITLE
fix: quote table name in initPreparedStmt

### DIFF
--- a/internal/pkg/store/sql/sqlKv.go
+++ b/internal/pkg/store/sql/sqlKv.go
@@ -77,7 +77,7 @@ func (kv *sqlKvStore) initPreparedStmt() error {
 		if err != nil {
 			return err
 		}
-		kv.preparedGetByPrefixStmt, err = db.Prepare(fmt.Sprintf("SELECT key, val FROM %s WHERE key LIKE ?", kv.table))
+		kv.preparedGetByPrefixStmt, err = db.Prepare(fmt.Sprintf("SELECT key, val FROM '%s' WHERE key LIKE ?", kv.table))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Quote the table name in the last sql statement of sqlKvStore.initPreparedStmt similar to the other sql statements made in the method. Unqoted table name could lead to errors