### PR TITLE
fix(kv): prepare keyed state stmt once

### DIFF
--- a/internal/pkg/store/sql/sqlKv.go
+++ b/internal/pkg/store/sql/sqlKv.go
@@ -142,32 +142,17 @@ func (kv *sqlKvStore) Get(key string, value interface{}) (bool, error) {
 func (kv *sqlKvStore) GetKeyedState(key string) (interface{}, error) {
 	var value interface{}
 	err := kv.database.Apply(func(db *sql.DB) error {
-		query := fmt.Sprintf("SELECT val FROM '%s' WHERE key=?;", kv.table)
-		stmt, err := db.Prepare(query)
-		if err != nil {
-			return err
-		}
-		row := stmt.QueryRow(key)
-		err = row.Scan(&value)
-		if err != nil {
-			return err
-		}
-		return nil
+		row := kv.preparedGetStmt.QueryRow(key)
+		return row.Scan(&value)
 	})
 	return value, err
 }
 
 func (kv *sqlKvStore) SetKeyedState(key string, value interface{}) error {
-	err := kv.database.Apply(func(db *sql.DB) error {
-		query := fmt.Sprintf("REPLACE INTO '%s'(key,val) values(?,?);", kv.table)
-		stmt, err := db.Prepare(query)
-		if err != nil {
-			return err
-		}
-		_, err = stmt.Exec(key, value)
+	return kv.database.Apply(func(db *sql.DB) error {
+		_, err := kv.preparedSetStmt.Exec(key, value)
 		return err
 	})
-	return err
 }
 
 func (kv *sqlKvStore) Delete(key string) error {


### PR DESCRIPTION
GetKeyedState and SetKeyedState are calling db.Prepare on every request without ever calling stmt.Close(), which is causing a memory leak. This is the exact same issue we fixed in #3672. 