### PR TITLE
fix(test):  fix flaky fvt test

### DIFF
--- a/docs/en_US/api/restapi/schemas.md
+++ b/docs/en_US/api/restapi/schemas.md
@@ -56,6 +56,28 @@ Schema with static plugin：
      - content: the text content of the schema.
 3. soFile：The so file of the static plugin. Detail about the plugin creation, please check [customize format](../../guide/serialization/serialization.md#format-extension).
 
+## Upload a schema file
+
+Use multipart form data to create or update a schema from a local file. The uploaded file has the same semantics as the `file` property of the JSON API: its type and content are handled by the schema implementation. For example, protobuf accepts a single schema file or a zip archive with supporting files.
+
+```shell
+PUT http://localhost:9081/schemas/{type}/{name}/upload
+```
+
+```shell
+curl -X PUT http://localhost:9081/schemas/protobuf/schema1/upload \
+  -F "file=@/path/to/schema1.proto"
+```
+
+The multipart request contains one required `file` field and an optional `version` field. If the schema does not exist, the API creates it and returns `201 Created`. If it already exists, the API replaces it and returns `200 OK`. The temporary uploaded file is removed after the request completes.
+
+```json
+{
+  "type": "protobuf",
+  "name": "schema1"
+}
+```
+
 ## Show schemas
 
 The API is used for displaying all schemas defined in the server.

--- a/docs/en_US/api/restapi/schemas.md
+++ b/docs/en_US/api/restapi/schemas.md
@@ -69,7 +69,11 @@ curl -X PUT http://localhost:9081/schemas/protobuf/schema1/upload \
   -F "file=@/path/to/schema1.proto"
 ```
 
-The multipart request contains one required `file` field and an optional `version` field. If the schema does not exist, the API creates it and returns `201 Created`. If it already exists, the API replaces it and returns `200 OK`. The temporary uploaded file is removed after the request completes.
+The request has no JSON body. The schema type and name come from the URL. The multipart body contains one required `file` field and an optional `version` field.
+
+If the schema does not exist, the API creates it and returns `201 Created`. If it already exists, the API replaces it and returns `200 OK`. The temporary uploaded file is removed after the request completes.
+
+Response example:
 
 ```json
 {

--- a/docs/zh_CN/api/restapi/schemas.md
+++ b/docs/zh_CN/api/restapi/schemas.md
@@ -57,6 +57,28 @@ POST http://localhost:9081/schemas/protobuf
    - content：模式文件的内容。
 3. soFile：静态插件 so。插件创建请看[自定义格式](../../guide/serialization/serialization.md#格式扩展)。
 
+## 上传模式文件
+
+使用 multipart form data 从本地文件创建或更新模式。上传文件与 JSON API 的 `file` 属性语义相同，文件类型和内容由对应的模式实现处理。例如，protobuf 可以处理单个模式文件或包含支持文件的 ZIP 压缩文件。
+
+```shell
+PUT http://localhost:9081/schemas/{type}/{name}/upload
+```
+
+```shell
+curl -X PUT http://localhost:9081/schemas/protobuf/schema1/upload \
+  -F "file=@/path/to/schema1.proto"
+```
+
+multipart 请求包含一个必填的 `file` 字段和一个可选的 `version` 字段。模式不存在时创建并返回 `201 Created`；模式已存在时替换并返回 `200 OK`。请求完成后，服务端会删除上传产生的临时文件。
+
+```json
+{
+  "type": "protobuf",
+  "name": "schema1"
+}
+```
+
 ## 显示模式
 
 该 API 用于显示服务器中为模式类型定义的所有模式。

--- a/docs/zh_CN/api/restapi/schemas.md
+++ b/docs/zh_CN/api/restapi/schemas.md
@@ -70,7 +70,11 @@ curl -X PUT http://localhost:9081/schemas/protobuf/schema1/upload \
   -F "file=@/path/to/schema1.proto"
 ```
 
-multipart 请求包含一个必填的 `file` 字段和一个可选的 `version` 字段。模式不存在时创建并返回 `201 Created`；模式已存在时替换并返回 `200 OK`。请求完成后，服务端会删除上传产生的临时文件。
+请求不包含 JSON body，模式类型和名称来自 URL。multipart body 只包含一个必填的 `file` 字段和一个可选的 `version` 字段。
+
+模式不存在时创建并返回 `201 Created`；模式已存在时替换并返回 `200 OK`。请求完成后，服务端会删除上传产生的临时文件。
+
+响应示例：
 
 ```json
 {

--- a/fvt/rule_test.go
+++ b/fvt/rule_test.go
@@ -886,7 +886,7 @@ func (s *RuleTestSuite) TestShowScanTableContent() {
 	s.T().Log(GetResponseText(resp))
 	s.Require().Equal(http.StatusCreated, resp.StatusCode)
 
-	var res *http.Response
+	var result []server.ShowScanTablesResponse
 	require.Eventually(s.T(), func() bool {
 		resp, err = client.GetRuleScanTablesSnapshot("joinTestRule")
 		if err != nil {
@@ -894,18 +894,28 @@ func (s *RuleTestSuite) TestShowScanTableContent() {
 		}
 
 		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
 			return false
 		}
 
-		res = resp
-		return true
-	}, 3*time.Second, 200*time.Millisecond)
+		body, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			return false
+		}
 
-	body, err := io.ReadAll(res.Body)
-	defer res.Body.Close()
-	var result []server.ShowScanTablesResponse
-	err = json.Unmarshal(body, &result)
-	s.Require().NoError(err)
+		var r []server.ShowScanTablesResponse
+		if unmarshalErr := json.Unmarshal(body, &r); unmarshalErr != nil {
+			return false
+		}
+
+		if len(r) < 3 {
+			return false
+		}
+
+		result = r
+		return true
+	}, 5*time.Second, 200*time.Millisecond)
 
 	expectedDevices := []map[string]interface{}{
 		{"id": float64(1), "name": "Device1", "location": "Room1"},

--- a/internal/schema/registry.go
+++ b/internal/schema/registry.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -147,30 +148,39 @@ func GetAllForType(schemaType string) ([]string, error) {
 }
 
 func Register(info *Info) error {
-	err := func() error {
-		registry.RLock()
-		defer registry.RUnlock()
-		if _, ok := registry.schemas[info.Type]; !ok {
-			return fmt.Errorf("schema type %s not found", info.Type)
-		}
-		if _, ok := registry.schemas[info.Type][info.Name]; ok {
-			return fmt.Errorf("schema %s.%s already registered", info.Type, info.Name)
-		}
-		return nil
-	}()
-	if err != nil {
-		return err
+	registry.Lock()
+	defer registry.Unlock()
+	if _, ok := registry.schemas[info.Type]; !ok {
+		return fmt.Errorf("schema type %s not found", info.Type)
 	}
-	err = CreateOrUpdateSchema(info)
-	if err != nil {
-		return err
+	if _, ok := registry.schemas[info.Type][info.Name]; ok {
+		return fmt.Errorf("schema %s.%s already registered", info.Type, info.Name)
 	}
-	return nil
+	return createOrUpdateSchemaLocked(info, false)
 }
 
 func CreateOrUpdateSchema(info *Info) error {
 	registry.Lock()
 	defer registry.Unlock()
+	return createOrUpdateSchemaLocked(info, false)
+}
+
+// Upsert creates or updates a schema and reports whether a new schema was created.
+// Uploaded files use this entry point so their temporary source path is not persisted.
+func Upsert(info *Info) (bool, error) {
+	registry.Lock()
+	defer registry.Unlock()
+	if _, ok := registry.schemas[info.Type]; !ok {
+		return false, fmt.Errorf("schema type %s not found", info.Type)
+	}
+	_, existed := registry.schemas[info.Type][info.Name]
+	if err := createOrUpdateSchemaLocked(info, true); err != nil {
+		return false, err
+	}
+	return !existed, nil
+}
+
+func createOrUpdateSchemaLocked(info *Info, persistInstalledPath bool) error {
 	if strings.Contains(info.Type, "/") || strings.Contains(info.Type, "\\") || strings.Contains(info.Type, "..") {
 		return fmt.Errorf("schema type %s is invalid", info.Type)
 	}
@@ -264,7 +274,7 @@ func CreateOrUpdateSchema(info *Info) error {
 				if err != nil {
 					return err
 				}
-			} else {
+			} else if !sameLocalFile(info.FilePath, schemaFile) {
 				_, err := httpx.DownloadFile(etcDir, targetName, info.FilePath)
 				if err != nil {
 					return err
@@ -276,18 +286,36 @@ func CreateOrUpdateSchema(info *Info) error {
 
 	if info.SoPath != "" {
 		soFile := filepath.Join(etcDir, info.Name+".so")
-		_, err := httpx.DownloadFile(etcDir, info.Name+".so", info.SoPath)
-		if err != nil {
-			return err
+		if !sameLocalFile(info.SoPath, soFile) {
+			_, err := httpx.DownloadFile(etcDir, info.Name+".so", info.SoPath)
+			if err != nil {
+				return err
+			}
 		}
 		ffs.SoFile = soFile
 	}
 	ffs.Version = info.Version
+	installInfo := info
+	if persistInstalledPath {
+		installInfo = &Info{
+			Type:    info.Type,
+			Name:    info.Name,
+			Version: info.Version,
+		}
+		if ffs.SchemaFile != "" {
+			installInfo.FilePath = localFileURL(ffs.SchemaFile)
+		}
+		if ffs.SoFile != "" {
+			installInfo.SoPath = localFileURL(ffs.SoFile)
+		}
+	}
+	if err := storeSchemaInstallScript(installInfo); err != nil {
+		return err
+	}
 	registry.schemas[info.Type][info.Name] = ffs
-	storeSchemaInstallScript(info)
 	// clean up old ffs
 	if offs != nil && info.Version != "" {
-		if offs.SchemaFile != "" {
+		if offs.SchemaFile != "" && offs.SchemaFile != ffs.SchemaFile {
 			err := os.Remove(offs.SchemaFile)
 			if err != nil {
 				conf.Log.Errorf("cannot delete old schema file %s: %s", offs.SchemaFile, err)
@@ -295,6 +323,30 @@ func CreateOrUpdateSchema(info *Info) error {
 		}
 	}
 	return nil
+}
+
+func localFileURL(path string) string {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		absPath = path
+	}
+	return (&url.URL{Scheme: "file", Path: absPath}).String()
+}
+
+func sameLocalFile(uri string, target string) bool {
+	u, err := url.ParseRequestURI(uri)
+	if err != nil || u.Scheme != "file" || u.Host != "" || u.Path == "" {
+		return false
+	}
+	sourceInfo, err := os.Stat(u.Path)
+	if err != nil {
+		return false
+	}
+	targetInfo, err := os.Stat(target)
+	if err != nil {
+		return false
+	}
+	return os.SameFile(sourceInfo, targetInfo)
 }
 
 func GetSchema(schemaType string, name string) (*Info, error) {
@@ -506,10 +558,10 @@ func schemaInstallWhenReboot() {
 	}
 }
 
-func storeSchemaInstallScript(info *Info) {
+func storeSchemaInstallScript(info *Info) error {
 	key := info.Type + "_" + info.Name
 	val := info.InstallScript()
-	_ = schemaDb.Set(key, val)
+	return schemaDb.Set(key, val)
 }
 
 func removeSchemaInstallScript(schemaType string, name string) {

--- a/internal/schema/registry.go
+++ b/internal/schema/registry.go
@@ -18,13 +18,12 @@ import (
 	"archive/zip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/google/uuid"
 
 	"github.com/lf-edge/ekuiper/v2/internal/conf"
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/filex"
@@ -50,6 +49,14 @@ type Registry struct {
 	syncx.RWMutex
 	// The map of schema files for all types
 	schemas map[string]map[string]*modules.Files
+}
+
+type fileReplacement struct {
+	source    string
+	target    string
+	backup    string
+	installed bool
+	hadTarget bool
 }
 
 // Registry provide the method to add, update, get and parse and delete schemas
@@ -208,32 +215,42 @@ func createOrUpdateSchemaLocked(info *Info, persistInstalledPath bool) error {
 	etcDir := filepath.Join(dataDir, "schemas", info.Type)
 	// make sure info.Type does not escape from root
 	if err := os.MkdirAll(etcDir, os.ModePerm); err != nil {
-		conf.Log.Warnf("failed to create directory %s: %v", info.Type, err)
+		return fmt.Errorf("failed to create schema directory %s: %w", etcDir, err)
 	}
+	stageDir, err := os.MkdirTemp(etcDir, ".schema-install-")
+	if err != nil {
+		return fmt.Errorf("failed to create schema staging directory: %w", err)
+	}
+	removeStageDir := true
+	defer func() {
+		if removeStageDir {
+			_ = os.RemoveAll(stageDir)
+		}
+	}()
+	payloadDir := filepath.Join(stageDir, "payload")
+	if err := os.Mkdir(payloadDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create schema payload directory: %w", err)
+	}
+
 	ffs := &modules.Files{}
+	replacements := make([]fileReplacement, 0, 3)
 	// If file path is a .zip, it must have the name.type file and a folder of the same name to hold the supporting files. Other files will all be ignored.
 	// Otherwise, save the file in the upper folder
 	if info.Content != "" || info.FilePath != "" {
 		supportingDir := filepath.Join(etcDir, info.Name)
-		err := os.RemoveAll(filepath.Join(etcDir, info.Name))
-		if err != nil {
-			conf.Log.Errorf("cannot delete schema supporting files %s: %s", supportingDir, err)
-		}
-
 		schemaFileName := info.Name + st.Ext
 		targetName := schemaFileName
 		if info.Version != "" {
 			targetName = fmt.Sprintf("%s@%s%s", info.Name, info.Version, st.Ext)
 		}
 		schemaFile := filepath.Join(etcDir, targetName)
+		stagedSchemaFile := filepath.Join(payloadDir, targetName)
 		if filepath.Ext(info.FilePath) == ".zip" {
 			conf.Log.Infof("unzipping schema file %s", info.FilePath)
-			tmpFileName := uuid.New().String() + ".zip"
-			tmpFile, err := httpx.DownloadFile(etcDir, tmpFileName, info.FilePath)
+			tmpFile, err := httpx.DownloadFile(stageDir, "archive.zip", info.FilePath)
 			if err != nil {
 				return err
 			}
-			defer os.Remove(tmpFile)
 			reader, err := zip.OpenReader(tmpFile)
 			if err != nil {
 				return err
@@ -244,12 +261,12 @@ func createOrUpdateSchemaLocked(info *Info, persistInstalledPath bool) error {
 				fileName := file.Name
 				// Check if it's the exact file we want
 				if fileName == schemaFileName {
-					err = filex.UnzipTo(file, etcDir, targetName)
+					err = filex.UnzipTo(file, payloadDir, targetName)
 					found = true
 				} else if fileName == info.Name && file.FileInfo().IsDir() {
-					err = filex.UnzipTo(file, etcDir, info.Name)
+					err = filex.UnzipTo(file, payloadDir, info.Name)
 				} else if strings.HasPrefix(fileName, info.Name+"/") {
-					err = filex.UnzipTo(file, etcDir, fileName)
+					err = filex.UnzipTo(file, payloadDir, fileName)
 				} else {
 					// Skip files that don't match our criteria
 					continue
@@ -262,37 +279,38 @@ func createOrUpdateSchemaLocked(info *Info, persistInstalledPath bool) error {
 				return fmt.Errorf("schema file %s not found inside the zip", schemaFileName)
 			}
 		} else {
-			if _, err := os.Stat(schemaFile); os.IsNotExist(err) {
-				file, err := os.Create(schemaFile)
-				if err != nil {
-					return err
-				}
-				defer file.Close()
-			}
 			if info.Content != "" {
-				err := os.WriteFile(schemaFile, cast.StringToBytes(info.Content), 0o666)
+				err := os.WriteFile(stagedSchemaFile, cast.StringToBytes(info.Content), 0o666)
 				if err != nil {
 					return err
 				}
-			} else if !sameLocalFile(info.FilePath, schemaFile) {
-				_, err := httpx.DownloadFile(etcDir, targetName, info.FilePath)
+			} else {
+				_, err := httpx.DownloadFile(payloadDir, targetName, info.FilePath)
 				if err != nil {
 					return err
 				}
 			}
 		}
 		ffs.SchemaFile = schemaFile
+		replacements = append(replacements, fileReplacement{source: stagedSchemaFile, target: schemaFile})
+		stagedSupportingDir := filepath.Join(payloadDir, info.Name)
+		if _, err := os.Stat(stagedSupportingDir); err != nil {
+			if !os.IsNotExist(err) {
+				return err
+			}
+			stagedSupportingDir = ""
+		}
+		replacements = append(replacements, fileReplacement{source: stagedSupportingDir, target: supportingDir})
 	}
 
 	if info.SoPath != "" {
 		soFile := filepath.Join(etcDir, info.Name+".so")
-		if !sameLocalFile(info.SoPath, soFile) {
-			_, err := httpx.DownloadFile(etcDir, info.Name+".so", info.SoPath)
-			if err != nil {
-				return err
-			}
+		stagedSoFile, err := httpx.DownloadFile(payloadDir, info.Name+".so", info.SoPath)
+		if err != nil {
+			return err
 		}
 		ffs.SoFile = soFile
+		replacements = append(replacements, fileReplacement{source: stagedSoFile, target: soFile})
 	}
 	ffs.Version = info.Version
 	installInfo := info
@@ -309,7 +327,16 @@ func createOrUpdateSchemaLocked(info *Info, persistInstalledPath bool) error {
 			installInfo.SoPath = localFileURL(ffs.SoFile)
 		}
 	}
+	backupDir := filepath.Join(stageDir, ".backup")
+	if err := commitFileReplacements(replacements, backupDir); err != nil {
+		removeStageDir = false
+		return fmt.Errorf("failed to install schema files; staging directory retained at %s: %w", stageDir, err)
+	}
 	if err := storeSchemaInstallScript(installInfo); err != nil {
+		if rollbackErr := rollbackFileReplacements(replacements); rollbackErr != nil {
+			removeStageDir = false
+			return errors.Join(err, fmt.Errorf("failed to roll back schema files: %w", rollbackErr))
+		}
 		return err
 	}
 	registry.schemas[info.Type][info.Name] = ffs
@@ -325,28 +352,70 @@ func createOrUpdateSchemaLocked(info *Info, persistInstalledPath bool) error {
 	return nil
 }
 
+func commitFileReplacements(replacements []fileReplacement, backupDir string) error {
+	if len(replacements) == 0 {
+		return nil
+	}
+	if err := os.MkdirAll(backupDir, 0o755); err != nil {
+		return err
+	}
+	for i := range replacements {
+		replacement := &replacements[i]
+		if _, err := os.Lstat(replacement.target); err == nil {
+			replacement.backup = filepath.Join(backupDir, fmt.Sprintf("%d", i))
+			if err := os.Rename(replacement.target, replacement.backup); err != nil {
+				return rollbackAfterCommitError(replacements[:i], err)
+			}
+			replacement.hadTarget = true
+		} else if !os.IsNotExist(err) {
+			return rollbackAfterCommitError(replacements[:i], err)
+		}
+		if replacement.source == "" {
+			continue
+		}
+		if err := os.Rename(replacement.source, replacement.target); err != nil {
+			return rollbackAfterCommitError(replacements[:i+1], err)
+		}
+		replacement.installed = true
+	}
+	return nil
+}
+
+func rollbackAfterCommitError(replacements []fileReplacement, commitErr error) error {
+	if rollbackErr := rollbackFileReplacements(replacements); rollbackErr != nil {
+		return errors.Join(commitErr, fmt.Errorf("failed to roll back partial file installation: %w", rollbackErr))
+	}
+	return commitErr
+}
+
+func rollbackFileReplacements(replacements []fileReplacement) error {
+	var errs []error
+	for i := len(replacements) - 1; i >= 0; i-- {
+		replacement := &replacements[i]
+		if replacement.installed {
+			if err := os.RemoveAll(replacement.target); err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			replacement.installed = false
+		}
+		if replacement.hadTarget {
+			if err := os.Rename(replacement.backup, replacement.target); err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			replacement.hadTarget = false
+		}
+	}
+	return errors.Join(errs...)
+}
+
 func localFileURL(path string) string {
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		absPath = path
 	}
 	return (&url.URL{Scheme: "file", Path: absPath}).String()
-}
-
-func sameLocalFile(uri string, target string) bool {
-	u, err := url.ParseRequestURI(uri)
-	if err != nil || u.Scheme != "file" || u.Host != "" || u.Path == "" {
-		return false
-	}
-	sourceInfo, err := os.Stat(u.Path)
-	if err != nil {
-		return false
-	}
-	targetInfo, err := os.Stat(target)
-	if err != nil {
-		return false
-	}
-	return os.SameFile(sourceInfo, targetInfo)
 }
 
 func GetSchema(schemaType string, name string) (*Info, error) {

--- a/internal/schema/registry_test.go
+++ b/internal/schema/registry_test.go
@@ -32,8 +32,17 @@ import (
 
 	"github.com/lf-edge/ekuiper/v2/internal/conf"
 	"github.com/lf-edge/ekuiper/v2/internal/testx"
+	"github.com/lf-edge/ekuiper/v2/pkg/kv"
 	"github.com/lf-edge/ekuiper/v2/pkg/modules"
 )
+
+type failingSetKV struct {
+	kv.KeyValue
+}
+
+func (failingSetKV) Set(string, interface{}) error {
+	return fmt.Errorf("injected schema DB write failure")
+}
 
 func init() {
 	testx.InitEnv("schema")
@@ -486,4 +495,67 @@ func TestUpsert(t *testing.T) {
 	_, script := GetSchemaInstallScript(modules.PROTOBUF + "_" + name)
 	require.NotContains(t, script, ".upsert-test-")
 	require.True(t, strings.Contains(script, "/schemas/protobuf/") || strings.Contains(script, "\\schemas\\protobuf\\"))
+}
+
+func TestUpsertRollsBackFilesWhenPersistenceFails(t *testing.T) {
+	modules.RegisterSchemaType(modules.PROTOBUF, &PbType{}, ".proto")
+	require.NoError(t, InitRegistry())
+
+	dataDir, err := conf.GetDataLoc()
+	require.NoError(t, err)
+	schemaDir := filepath.Join(dataDir, "schemas", modules.PROTOBUF)
+
+	t.Run("create", func(t *testing.T) {
+		const name = "upsert_db_failure_create"
+		_ = DeleteSchema(modules.PROTOBUF, name)
+		defer func() { _ = DeleteSchema(modules.PROTOBUF, name) }()
+
+		originalDB := schemaDb
+		schemaDb = failingSetKV{KeyValue: originalDB}
+		defer func() { schemaDb = originalDB }()
+
+		created, upsertErr := Upsert(&Info{
+			Type:    modules.PROTOBUF,
+			Name:    name,
+			Content: "message Created { required string value = 1; }",
+		})
+		require.False(t, created)
+		require.EqualError(t, upsertErr, "injected schema DB write failure")
+		_, getErr := GetSchema(modules.PROTOBUF, name)
+		require.Error(t, getErr)
+		require.NoFileExists(t, filepath.Join(schemaDir, name+".proto"))
+	})
+
+	t.Run("update", func(t *testing.T) {
+		const name = "upsert_db_failure_update"
+		_ = DeleteSchema(modules.PROTOBUF, name)
+		defer func() { _ = DeleteSchema(modules.PROTOBUF, name) }()
+
+		const originalContent = "message Original { required string value = 1; }"
+		created, upsertErr := Upsert(&Info{
+			Type:    modules.PROTOBUF,
+			Name:    name,
+			Content: originalContent,
+		})
+		require.NoError(t, upsertErr)
+		require.True(t, created)
+		_, originalScript := GetSchemaInstallScript(modules.PROTOBUF + "_" + name)
+
+		originalDB := schemaDb
+		schemaDb = failingSetKV{KeyValue: originalDB}
+		defer func() { schemaDb = originalDB }()
+
+		created, upsertErr = Upsert(&Info{
+			Type:    modules.PROTOBUF,
+			Name:    name,
+			Content: "message Updated { required int32 value = 1; }",
+		})
+		require.False(t, created)
+		require.EqualError(t, upsertErr, "injected schema DB write failure")
+		gotten, getErr := GetSchema(modules.PROTOBUF, name)
+		require.NoError(t, getErr)
+		require.Equal(t, originalContent, gotten.Content)
+		_, currentScript := GetSchemaInstallScript(modules.PROTOBUF + "_" + name)
+		require.Equal(t, originalScript, currentScript)
+	})
 }

--- a/internal/schema/registry_test.go
+++ b/internal/schema/registry_test.go
@@ -559,3 +559,54 @@ func TestUpsertRollsBackFilesWhenPersistenceFails(t *testing.T) {
 		require.Equal(t, originalScript, currentScript)
 	})
 }
+
+func TestFileReplacementTransaction(t *testing.T) {
+	t.Run("rolls back a partial installation", func(t *testing.T) {
+		dir := t.TempDir()
+		targetFile := filepath.Join(dir, "schema.proto")
+		require.NoError(t, os.WriteFile(targetFile, []byte("old schema"), 0o600))
+		sourceFile := filepath.Join(dir, "new.proto")
+		require.NoError(t, os.WriteFile(sourceFile, []byte("new schema"), 0o600))
+
+		targetDir := filepath.Join(dir, "supporting")
+		require.NoError(t, os.Mkdir(targetDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(targetDir, "old.txt"), []byte("old support"), 0o600))
+
+		replacements := []fileReplacement{
+			{source: sourceFile, target: targetFile},
+			{target: targetDir},
+			{source: filepath.Join(dir, "missing.proto"), target: filepath.Join(dir, "third.proto")},
+		}
+		err := commitFileReplacements(replacements, filepath.Join(dir, "backup"))
+		require.Error(t, err)
+		content, err := os.ReadFile(targetFile)
+		require.NoError(t, err)
+		require.Equal(t, "old schema", string(content))
+		support, err := os.ReadFile(filepath.Join(targetDir, "old.txt"))
+		require.NoError(t, err)
+		require.Equal(t, "old support", string(support))
+		require.NoFileExists(t, replacements[2].target)
+	})
+
+	t.Run("handles empty replacement list", func(t *testing.T) {
+		require.NoError(t, commitFileReplacements(nil, filepath.Join(t.TempDir(), "backup")))
+	})
+
+	t.Run("reports backup directory error", func(t *testing.T) {
+		dir := t.TempDir()
+		backupPath := filepath.Join(dir, "backup")
+		require.NoError(t, os.WriteFile(backupPath, []byte("not a directory"), 0o600))
+		err := commitFileReplacements([]fileReplacement{{target: filepath.Join(dir, "target")}}, backupPath)
+		require.Error(t, err)
+	})
+
+	t.Run("reports rollback error", func(t *testing.T) {
+		dir := t.TempDir()
+		err := rollbackFileReplacements([]fileReplacement{{
+			target:    filepath.Join(dir, "target"),
+			backup:    filepath.Join(dir, "missing-backup"),
+			hadTarget: true,
+		}})
+		require.Error(t, err)
+	})
+}

--- a/internal/schema/registry_test.go
+++ b/internal/schema/registry_test.go
@@ -23,6 +23,8 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -418,4 +420,70 @@ func TestInvalidInfo(t *testing.T) {
 		err := CreateOrUpdateSchema(tt.info)
 		assert.EqualError(t, err, tt.err)
 	}
+}
+
+func TestUpsert(t *testing.T) {
+	modules.RegisterSchemaType(modules.PROTOBUF, &PbType{}, ".proto")
+	require.NoError(t, InitRegistry())
+	const name = "upsert_concurrent_test"
+	_ = DeleteSchema(modules.PROTOBUF, name)
+	defer func() {
+		_ = DeleteSchema(modules.PROTOBUF, name)
+	}()
+
+	dataDir, err := conf.GetDataLoc()
+	require.NoError(t, err)
+	tempDir := filepath.Join(dataDir, "uploads", "schemas")
+	require.NoError(t, os.MkdirAll(tempDir, 0o755))
+	paths := make([]string, 2)
+	contents := []string{
+		"message First { required string name = 1; }",
+		"message Second { required int32 id = 1; }",
+	}
+	for i, content := range contents {
+		file, createErr := os.CreateTemp(tempDir, ".upsert-test-*.proto")
+		require.NoError(t, createErr)
+		paths[i] = file.Name()
+		_, writeErr := file.WriteString(content)
+		require.NoError(t, writeErr)
+		require.NoError(t, file.Close())
+		defer os.Remove(paths[i])
+	}
+
+	createdResults := make(chan bool, 2)
+	errorResults := make(chan error, 2)
+	var wg sync.WaitGroup
+	for _, path := range paths {
+		wg.Add(1)
+		go func(path string) {
+			defer wg.Done()
+			created, upsertErr := Upsert(&Info{
+				Type:     modules.PROTOBUF,
+				Name:     name,
+				FilePath: localFileURL(path),
+			})
+			createdResults <- created
+			errorResults <- upsertErr
+		}(path)
+	}
+	wg.Wait()
+	close(createdResults)
+	close(errorResults)
+	for upsertErr := range errorResults {
+		require.NoError(t, upsertErr)
+	}
+	createdCount := 0
+	for created := range createdResults {
+		if created {
+			createdCount++
+		}
+	}
+	require.Equal(t, 1, createdCount)
+
+	gotten, err := GetSchema(modules.PROTOBUF, name)
+	require.NoError(t, err)
+	require.Contains(t, contents, gotten.Content)
+	_, script := GetSchemaInstallScript(modules.PROTOBUF + "_" + name)
+	require.NotContains(t, script, ".upsert-test-")
+	require.True(t, strings.Contains(script, "/schemas/protobuf/") || strings.Contains(script, "\\schemas\\protobuf\\"))
 }

--- a/internal/server/rest.go
+++ b/internal/server/rest.go
@@ -106,6 +106,21 @@ func handleError(w http.ResponseWriter, err error, prefix string, logger api.Log
 	http.Error(w, packageInternalErrorCode(err, message), ec)
 }
 
+func handleErrorWithStatus(w http.ResponseWriter, err error, prefix string, status int, logger api.Logger) {
+	message := prefix
+	if message != "" {
+		message += ": "
+	}
+	message += err.Error()
+	logger.Error(message)
+	w.Header().Set(ContentType, ContentTypeJSON)
+	w.WriteHeader(status)
+	_, writeErr := w.Write([]byte(packageInternalErrorCode(err, message)))
+	if writeErr != nil {
+		logger.Errorf("Error writing error response: %v", writeErr)
+	}
+}
+
 func packageInternalErrorCode(err error, msg string) string {
 	errCode := errorx.Undefined_Err
 	if errWithCode, ok := err.(errorx.ErrorWithCode); ok {

--- a/internal/server/schema_init.go
+++ b/internal/server/schema_init.go
@@ -19,10 +19,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"html/template"
+	"io"
+	"mime"
+	"mime/multipart"
 	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
 
 	"github.com/gorilla/mux"
 
+	"github.com/lf-edge/ekuiper/v2/internal/conf"
 	"github.com/lf-edge/ekuiper/v2/internal/schema"
 	"github.com/lf-edge/ekuiper/v2/pkg/errorx"
 	"github.com/lf-edge/ekuiper/v2/pkg/validate"
@@ -43,7 +50,180 @@ func (sc schemaComp) register() {
 
 func (sc schemaComp) rest(r *mux.Router) {
 	r.HandleFunc("/schemas/{type}", schemasHandler).Methods(http.MethodGet, http.MethodPost)
+	r.HandleFunc("/schemas/{type}/{name}/upload", schemaUploadHandler).Methods(http.MethodPut)
 	r.HandleFunc("/schemas/{type}/{name}", schemaHandler).Methods(http.MethodPut, http.MethodDelete, http.MethodGet)
+}
+
+const maxSchemaUploadFieldSize = 4 << 10
+
+type schemaUpload struct {
+	path    string
+	version string
+}
+
+func (u *schemaUpload) cleanup() {
+	if u != nil && u.path != "" {
+		_ = os.Remove(u.path)
+	}
+}
+
+func (u *schemaUpload) fileURL() string {
+	return (&url.URL{Scheme: "file", Path: u.path}).String()
+}
+
+type schemaUploadResponse struct {
+	Type string `json:"type"`
+	Name string `json:"name"`
+}
+
+func schemaUploadHandler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	vars := mux.Vars(r)
+	st := vars["type"]
+	name := vars["name"]
+	if err := validate.ValidateID(name); err != nil {
+		handleErrorWithStatus(w, err, "", http.StatusBadRequest, logger)
+		return
+	}
+
+	mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil || mediaType != "multipart/form-data" {
+		if err == nil {
+			err = fmt.Errorf("content type must be multipart/form-data")
+		}
+		handleErrorWithStatus(w, err, "Invalid content type", http.StatusUnsupportedMediaType, logger)
+		return
+	}
+	mr, err := r.MultipartReader()
+	if err != nil {
+		handleErrorWithStatus(w, err, "Invalid multipart body", http.StatusBadRequest, logger)
+		return
+	}
+	upload, err := receiveSchemaUpload(mr)
+	if err != nil {
+		handleErrorWithStatus(w, err, "Invalid multipart body", http.StatusBadRequest, logger)
+		return
+	}
+	defer upload.cleanup()
+
+	sch := &schema.Info{
+		Type:     st,
+		Name:     name,
+		FilePath: upload.fileURL(),
+		Version:  upload.version,
+	}
+	if err = sch.Validate(); err != nil {
+		handleErrorWithStatus(w, err, "Invalid schema", http.StatusBadRequest, logger)
+		return
+	}
+	created, err := schema.Upsert(sch)
+	if err != nil {
+		handleErrorWithStatus(w, err, "schema upsert error", http.StatusBadRequest, logger)
+		return
+	}
+
+	payload, err := json.Marshal(schemaUploadResponse{Type: st, Name: name})
+	if err != nil {
+		handleErrorWithStatus(w, err, "Error encoding response", http.StatusInternalServerError, logger)
+		return
+	}
+	w.Header().Set(ContentType, ContentTypeJSON)
+	w.Header().Set("Location", fmt.Sprintf("/schemas/%s/%s", st, name))
+	if created {
+		w.WriteHeader(http.StatusCreated)
+	} else {
+		w.WriteHeader(http.StatusOK)
+	}
+	if _, err = w.Write(payload); err != nil {
+		logger.Errorf("Error writing schema upload response: %v", err)
+	}
+}
+
+func receiveSchemaUpload(mr *multipart.Reader) (_ *schemaUpload, retErr error) {
+	dataDir, err := conf.GetDataLoc()
+	if err != nil {
+		return nil, err
+	}
+	tempDir := filepath.Join(dataDir, "uploads", "schemas")
+	if err = os.MkdirAll(tempDir, 0o755); err != nil {
+		return nil, err
+	}
+	upload := &schemaUpload{}
+	defer func() {
+		if retErr != nil {
+			upload.cleanup()
+		}
+	}()
+	fileSeen := false
+	versionSeen := false
+	for {
+		part, nextErr := mr.NextPart()
+		if nextErr == io.EOF {
+			break
+		}
+		if nextErr != nil {
+			return nil, nextErr
+		}
+		fieldName := part.FormName()
+		switch fieldName {
+		case "file":
+			if fileSeen {
+				_ = part.Close()
+				return nil, fmt.Errorf("file field must appear exactly once")
+			}
+			fileSeen = true
+			ext := filepath.Ext(part.FileName())
+			tempFile, createErr := os.CreateTemp(tempDir, ".upload-*"+ext)
+			if createErr != nil {
+				_ = part.Close()
+				return nil, createErr
+			}
+			upload.path = tempFile.Name()
+			_, copyErr := io.Copy(tempFile, part)
+			closeErr := tempFile.Close()
+			partCloseErr := part.Close()
+			if copyErr != nil {
+				return nil, copyErr
+			}
+			if closeErr != nil {
+				return nil, closeErr
+			}
+			if partCloseErr != nil {
+				return nil, partCloseErr
+			}
+		case "version":
+			if versionSeen {
+				_ = part.Close()
+				return nil, fmt.Errorf("version field must not be repeated")
+			}
+			versionSeen = true
+			value, readErr := io.ReadAll(io.LimitReader(part, maxSchemaUploadFieldSize+1))
+			partCloseErr := part.Close()
+			if readErr != nil {
+				return nil, readErr
+			}
+			if partCloseErr != nil {
+				return nil, partCloseErr
+			}
+			if len(value) > maxSchemaUploadFieldSize {
+				return nil, fmt.Errorf("version field is too large")
+			}
+			upload.version = string(value)
+		default:
+			_, copyErr := io.Copy(io.Discard, part)
+			partCloseErr := part.Close()
+			if copyErr != nil {
+				return nil, copyErr
+			}
+			if partCloseErr != nil {
+				return nil, partCloseErr
+			}
+		}
+	}
+	if !fileSeen {
+		return nil, fmt.Errorf("file field is required")
+	}
+	return upload, nil
 }
 
 func (sc schemaComp) exporter() ConfManager {

--- a/internal/server/schema_init_test.go
+++ b/internal/server/schema_init_test.go
@@ -16,12 +16,21 @@ package server
 
 import (
 	"bytes"
+	"encoding/json"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/lf-edge/ekuiper/v2/internal/conf"
+	"github.com/lf-edge/ekuiper/v2/internal/schema"
 )
 
 type SchemaTestSuite struct {
@@ -65,6 +74,93 @@ func (suite *SchemaTestSuite) TestSchema() {
 	w = httptest.NewRecorder()
 	suite.r.ServeHTTP(w, req)
 	suite.Equal(http.StatusOK, w.Code)
+}
+
+func (suite *SchemaTestSuite) TestSchemaUploadUpsert() {
+	const name = "upload_upsert_test"
+	defer func() {
+		_ = schema.DeleteSchema("protobuf", name)
+	}()
+
+	request := newSchemaUploadRequest(suite.T(), "/schemas/protobuf/"+name+"/upload", "first.proto", []byte("message First { required string name = 1; }"), "1")
+	w := httptest.NewRecorder()
+	suite.r.ServeHTTP(w, request)
+	suite.Equal(http.StatusCreated, w.Code)
+	suite.Equal("application/json", w.Header().Get("Content-Type"))
+	suite.Equal("/schemas/protobuf/"+name, w.Header().Get("Location"))
+	suite.JSONEq(`{"type":"protobuf","name":"`+name+`"}`, w.Body.String())
+
+	request = newSchemaUploadRequest(suite.T(), "/schemas/protobuf/"+name+"/upload", "second.proto", []byte("message Second { required int32 id = 1; }"), "1")
+	w = httptest.NewRecorder()
+	suite.r.ServeHTTP(w, request)
+	suite.Equal(http.StatusOK, w.Code)
+
+	gotten, err := schema.GetSchema("protobuf", name)
+	require.NoError(suite.T(), err)
+	suite.Equal("message Second { required int32 id = 1; }", gotten.Content)
+
+	key, script := schema.GetSchemaInstallScript("protobuf_" + name)
+	suite.Equal("protobuf_"+name, key)
+	suite.NotContains(script, ".upload-")
+	stored := &schema.Info{}
+	require.NoError(suite.T(), json.Unmarshal([]byte(script), stored))
+	suite.Equal(gotten.FilePath, strings.TrimPrefix(stored.FilePath, "file://"))
+
+	dataDir, err := conf.GetDataLoc()
+	require.NoError(suite.T(), err)
+	tempFiles, err := filepath.Glob(filepath.Join(dataDir, "uploads", "schemas", ".upload-*"))
+	require.NoError(suite.T(), err)
+	suite.Empty(tempFiles)
+}
+
+func (suite *SchemaTestSuite) TestSchemaUploadZip() {
+	const name = "test1"
+	_ = schema.DeleteSchema("protobuf", name)
+	defer func() {
+		_ = schema.DeleteSchema("protobuf", name)
+	}()
+	content, err := os.ReadFile("../schema/test/test1.zip")
+	require.NoError(suite.T(), err)
+	request := newSchemaUploadRequest(suite.T(), "/schemas/protobuf/"+name+"/upload", "schema.zip", content, "")
+	w := httptest.NewRecorder()
+	suite.r.ServeHTTP(w, request)
+	suite.Equal(http.StatusCreated, w.Code)
+	gotten, err := schema.GetSchema("protobuf", name)
+	require.NoError(suite.T(), err)
+	suite.Contains(gotten.Content, "message Person")
+}
+
+func (suite *SchemaTestSuite) TestSchemaUploadErrors() {
+	request, err := http.NewRequest(http.MethodPut, "/schemas/protobuf/bad.name/upload", strings.NewReader("not multipart"))
+	require.NoError(suite.T(), err)
+	w := httptest.NewRecorder()
+	suite.r.ServeHTTP(w, request)
+	suite.Equal(http.StatusBadRequest, w.Code)
+
+	request, err = http.NewRequest(http.MethodPut, "/schemas/protobuf/valid_name/upload", strings.NewReader("not multipart"))
+	require.NoError(suite.T(), err)
+	request.Header.Set("Content-Type", "application/octet-stream")
+	w = httptest.NewRecorder()
+	suite.r.ServeHTTP(w, request)
+	suite.Equal(http.StatusUnsupportedMediaType, w.Code)
+}
+
+func newSchemaUploadRequest(t *testing.T, target, filename string, content []byte, version string) *http.Request {
+	t.Helper()
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", filename)
+	require.NoError(t, err)
+	_, err = part.Write(content)
+	require.NoError(t, err)
+	if version != "" {
+		require.NoError(t, writer.WriteField("version", version))
+	}
+	require.NoError(t, writer.Close())
+	request, err := http.NewRequest(http.MethodPut, target, &body)
+	require.NoError(t, err)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	return request
 }
 
 func TestSchemaTestSuite(t *testing.T) {

--- a/internal/server/schema_init_test.go
+++ b/internal/server/schema_init_test.go
@@ -17,6 +17,7 @@ package server
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -143,24 +144,168 @@ func (suite *SchemaTestSuite) TestSchemaUploadErrors() {
 	w = httptest.NewRecorder()
 	suite.r.ServeHTTP(w, request)
 	suite.Equal(http.StatusUnsupportedMediaType, w.Code)
+
+	request, err = http.NewRequest(http.MethodPut, "/schemas/protobuf/valid_name/upload", strings.NewReader("not multipart"))
+	require.NoError(suite.T(), err)
+	request.Header.Set("Content-Type", "multipart/form-data")
+	w = httptest.NewRecorder()
+	suite.r.ServeHTTP(w, request)
+	suite.Equal(http.StatusBadRequest, w.Code)
+
+	request, err = http.NewRequest(http.MethodPut, "/schemas/protobuf/valid_name/upload", strings.NewReader("not multipart"))
+	require.NoError(suite.T(), err)
+	request.Header.Set("Content-Type", "%%%")
+	w = httptest.NewRecorder()
+	suite.r.ServeHTTP(w, request)
+	suite.Equal(http.StatusUnsupportedMediaType, w.Code)
+
+	request = newSchemaMultipartRequest(suite.T(), "/schemas/protobuf/valid_name/upload", func(writer *multipart.Writer) {
+		require.NoError(suite.T(), writer.WriteField("version", "1"))
+	})
+	w = httptest.NewRecorder()
+	suite.r.ServeHTTP(w, request)
+	suite.Equal(http.StatusBadRequest, w.Code)
+
+	request = newSchemaUploadRequest(suite.T(), "/schemas/unsupported/valid_name/upload", "schema.data", []byte("schema"), "")
+	w = httptest.NewRecorder()
+	suite.r.ServeHTTP(w, request)
+	suite.Equal(http.StatusBadRequest, w.Code)
+
+	const name = "upload_older_version_test"
+	defer func() { _ = schema.DeleteSchema("protobuf", name) }()
+	request = newSchemaUploadRequest(suite.T(), "/schemas/protobuf/"+name+"/upload", "schema.proto", []byte("message Newer {}"), "2")
+	w = httptest.NewRecorder()
+	suite.r.ServeHTTP(w, request)
+	suite.Equal(http.StatusCreated, w.Code)
+	request = newSchemaUploadRequest(suite.T(), "/schemas/protobuf/"+name+"/upload", "schema.proto", []byte("message Older {}"), "1")
+	w = httptest.NewRecorder()
+	suite.r.ServeHTTP(w, request)
+	suite.Equal(http.StatusBadRequest, w.Code)
 }
 
 func newSchemaUploadRequest(t *testing.T, target, filename string, content []byte, version string) *http.Request {
 	t.Helper()
+	return newSchemaMultipartRequest(t, target, func(writer *multipart.Writer) {
+		part, err := writer.CreateFormFile("file", filename)
+		require.NoError(t, err)
+		_, err = part.Write(content)
+		require.NoError(t, err)
+		if version != "" {
+			require.NoError(t, writer.WriteField("version", version))
+		}
+	})
+}
+
+func newSchemaMultipartRequest(t *testing.T, target string, writeParts func(*multipart.Writer)) *http.Request {
+	t.Helper()
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
-	part, err := writer.CreateFormFile("file", filename)
-	require.NoError(t, err)
-	_, err = part.Write(content)
-	require.NoError(t, err)
-	if version != "" {
-		require.NoError(t, writer.WriteField("version", version))
-	}
+	writeParts(writer)
 	require.NoError(t, writer.Close())
 	request, err := http.NewRequest(http.MethodPut, target, &body)
 	require.NoError(t, err)
 	request.Header.Set("Content-Type", writer.FormDataContentType())
 	return request
+}
+
+func TestReceiveSchemaUpload(t *testing.T) {
+	t.Run("accepts version before file and ignores unknown fields", func(t *testing.T) {
+		request := newSchemaMultipartRequest(t, "/", func(writer *multipart.Writer) {
+			require.NoError(t, writer.WriteField("version", "v1"))
+			require.NoError(t, writer.WriteField("description", "ignored"))
+			part, err := writer.CreateFormFile("file", "schema.proto")
+			require.NoError(t, err)
+			_, err = part.Write([]byte("message Test {}"))
+			require.NoError(t, err)
+		})
+		reader, err := request.MultipartReader()
+		require.NoError(t, err)
+		upload, err := receiveSchemaUpload(reader)
+		require.NoError(t, err)
+		defer upload.cleanup()
+		require.Equal(t, "v1", upload.version)
+		content, err := os.ReadFile(upload.path)
+		require.NoError(t, err)
+		require.Equal(t, "message Test {}", string(content))
+	})
+
+	tests := []struct {
+		name      string
+		expected  string
+		writeBody func(*testing.T, *multipart.Writer)
+	}{
+		{
+			name:     "missing file",
+			expected: "file field is required",
+			writeBody: func(t *testing.T, writer *multipart.Writer) {
+				require.NoError(t, writer.WriteField("version", "1"))
+			},
+		},
+		{
+			name:     "duplicate file",
+			expected: "file field must appear exactly once",
+			writeBody: func(t *testing.T, writer *multipart.Writer) {
+				_, err := writer.CreateFormFile("file", "first.proto")
+				require.NoError(t, err)
+				_, err = writer.CreateFormFile("file", "second.proto")
+				require.NoError(t, err)
+			},
+		},
+		{
+			name:     "duplicate version",
+			expected: "version field must not be repeated",
+			writeBody: func(t *testing.T, writer *multipart.Writer) {
+				require.NoError(t, writer.WriteField("version", "1"))
+				require.NoError(t, writer.WriteField("version", "2"))
+			},
+		},
+		{
+			name:     "version too large",
+			expected: "version field is too large",
+			writeBody: func(t *testing.T, writer *multipart.Writer) {
+				require.NoError(t, writer.WriteField("version", strings.Repeat("v", maxSchemaUploadFieldSize+1)))
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := newSchemaMultipartRequest(t, "/", func(writer *multipart.Writer) {
+				tt.writeBody(t, writer)
+			})
+			reader, err := request.MultipartReader()
+			require.NoError(t, err)
+			upload, err := receiveSchemaUpload(reader)
+			require.Nil(t, upload)
+			require.EqualError(t, err, tt.expected)
+		})
+	}
+
+	t.Run("malformed multipart", func(t *testing.T) {
+		reader := multipart.NewReader(strings.NewReader("--boundary\r\nmalformed"), "boundary")
+		upload, err := receiveSchemaUpload(reader)
+		require.Nil(t, upload)
+		require.Error(t, err)
+	})
+}
+
+type failingResponseWriter struct {
+	header http.Header
+}
+
+func (w *failingResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (*failingResponseWriter) Write([]byte) (int, error) {
+	return 0, errors.New("injected response write failure")
+}
+
+func (*failingResponseWriter) WriteHeader(int) {}
+
+func TestHandleErrorWithStatusWriteFailure(t *testing.T) {
+	w := &failingResponseWriter{header: make(http.Header)}
+	handleErrorWithStatus(w, errors.New("request failed"), "schema upload error", http.StatusBadRequest, logger)
+	require.Equal(t, ContentTypeJSON, w.Header().Get(ContentType))
 }
 
 func TestSchemaTestSuite(t *testing.T) {


### PR DESCRIPTION
Fix flaky TestShowScanTableContent by moving response parsing and record count check inside require.Eventually. The test previously only waited for HTTP 200 but not for all 3 table records to load into the JoinAlignNode.