### PR TITLE
fix(test): fix flacky fvt test

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -358,6 +358,7 @@ jobs:
         file: deploy/docker/Dockerfile-kubernetes-tool
 
   release:
+    if: contains(fromJSON('["release", "workflow_dispatch"]'), github.event_name)
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/fvt/init_test.go
+++ b/fvt/init_test.go
@@ -70,7 +70,7 @@ func init() {
 	// Start eKuiper
 	cmd.Version = "fvt"
 	go cmd.Main()
-	count := 10
+	count := 300
 	for count > 0 {
 		time.Sleep(ConstantInterval)
 		resp, err := client.Get("ping")
@@ -81,6 +81,6 @@ func init() {
 		count--
 	}
 	if count == 0 {
-		fmt.Println("service not ready after 10 tries")
+		log.Fatal("service not ready after 30s")
 	}
 }

--- a/fvt/rule_test.go
+++ b/fvt/rule_test.go
@@ -886,7 +886,7 @@ func (s *RuleTestSuite) TestShowScanTableContent() {
 	s.T().Log(GetResponseText(resp))
 	s.Require().Equal(http.StatusCreated, resp.StatusCode)
 
-	var res *http.Response
+	var result []server.ShowScanTablesResponse
 	require.Eventually(s.T(), func() bool {
 		resp, err = client.GetRuleScanTablesSnapshot("joinTestRule")
 		if err != nil {
@@ -894,18 +894,28 @@ func (s *RuleTestSuite) TestShowScanTableContent() {
 		}
 
 		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
 			return false
 		}
 
-		res = resp
-		return true
-	}, 3*time.Second, 200*time.Millisecond)
+		body, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if readErr != nil {
+			return false
+		}
 
-	body, err := io.ReadAll(res.Body)
-	defer res.Body.Close()
-	var result []server.ShowScanTablesResponse
-	err = json.Unmarshal(body, &result)
-	s.Require().NoError(err)
+		var r []server.ShowScanTablesResponse
+		if unmarshalErr := json.Unmarshal(body, &r); unmarshalErr != nil {
+			return false
+		}
+
+		if len(r) < 3 {
+			return false
+		}
+
+		result = r
+		return true
+	}, 5*time.Second, 200*time.Millisecond)
 
 	expectedDevices := []map[string]interface{}{
 		{"id": float64(1), "name": "Device1", "location": "Room1"},


### PR DESCRIPTION
Fix flaky TestShowScanTableContent by moving response parsing and record count check inside require.Eventually. The test previously only waited for HTTP 200 but not for all 3 table records to load into the JoinAlignNode.