### PR TITLE
fix(neuron): stop closed socket receive loop

### DIFF
--- a/internal/io/neuron/source.go
+++ b/internal/io/neuron/source.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/lf-edge/ekuiper/contract/v2/api"
 	"go.nanomsg.org/mangos/v3"
@@ -96,7 +95,6 @@ func (s *source) Subscribe(ctx api.StreamContext, ingest api.BytesIngest, ingest
 	ctx.GetLogger().Infof("neuron source receiving loop started")
 	go func() {
 		err := infra.SafeRun(func() error {
-			connected := true
 			for {
 				select {
 				case <-ctx.Done():
@@ -109,18 +107,13 @@ func (s *source) Subscribe(ctx api.StreamContext, ingest api.BytesIngest, ingest
 					s.mu.RUnlock()
 					if cli != nil {
 						if msg, err := cli.Recv(); err == nil {
-							connected = true
 							ctx.GetLogger().Debugf("nng received message %s", string(msg))
 							rawData, meta := extractTraceMeta(ctx, msg)
 							ingest(ctx, rawData, meta, timex.GetNow())
 						} else if err == mangos.ErrClosed {
-							if connected {
-								ctx.GetLogger().Infof("neuron connection closed, retry after 1 second")
-								ingestErr(ctx, errors.New("neuron connection closed"))
-								time.Sleep(1 * time.Second)
-								connected = false
-							}
-							continue
+							ctx.GetLogger().Infof("neuron connection closed, stopping receive loop")
+							ingestErr(ctx, errors.New("neuron connection closed"))
+							return nil
 						}
 					}
 				}

--- a/internal/io/neuron/source_test.go
+++ b/internal/io/neuron/source_test.go
@@ -15,18 +15,32 @@
 package neuron
 
 import (
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/lf-edge/ekuiper/contract/v2/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.nanomsg.org/mangos/v3"
 	_ "go.nanomsg.org/mangos/v3/transport/ipc"
 
 	"github.com/lf-edge/ekuiper/v2/pkg/mock"
 	mockContext "github.com/lf-edge/ekuiper/v2/pkg/mock/context"
 	"github.com/lf-edge/ekuiper/v2/pkg/model"
+	"github.com/lf-edge/ekuiper/v2/pkg/nng"
 	"github.com/lf-edge/ekuiper/v2/pkg/timex"
 )
+
+type closedSocket struct {
+	mangos.Socket
+	calls atomic.Int32
+}
+
+func (s *closedSocket) Recv() ([]byte, error) {
+	s.calls.Add(1)
+	return nil, mangos.ErrClosed
+}
 
 func TestRun(t *testing.T) {
 	exp := []api.MessageTuple{
@@ -43,6 +57,27 @@ func TestRun(t *testing.T) {
 	}, exp, func() {
 		// do nothing
 	})
+}
+
+func TestSubscribeStopsAfterSocketClosed(t *testing.T) {
+	ctx, cancel := mockContext.NewMockContext("neuronClosed", "source").WithCancel()
+	defer cancel()
+	sock := &closedSocket{}
+	s := &source{c: &nng.SockConf{}, cli: &nng.Sock{Socket: sock}}
+	errCh := make(chan error, 1)
+
+	require.NoError(t, s.Subscribe(ctx, func(api.StreamContext, []byte, map[string]any, time.Time) {}, func(_ api.StreamContext, err error) {
+		errCh <- err
+	}))
+	select {
+	case err := <-errCh:
+		require.EqualError(t, err, "neuron connection closed")
+	case <-time.After(time.Second):
+		t.Fatal("closed socket error was not reported")
+	}
+	require.Never(t, func() bool {
+		return sock.calls.Load() > 1
+	}, 1200*time.Millisecond, 20*time.Millisecond)
 }
 
 func TestProvision(t *testing.T) {


### PR DESCRIPTION
## Summary
- Stop the Neuron source receive goroutine immediately when its local NNG socket is closed.
- Limit the behavior change to topology shutdown and cleanup.
- Keep runtime disconnection and NNG automatic reconnection behavior unchanged.

## Why
- The local NNG socket is closed by eKuiper when the source is being cleaned up, normally after the topology context has been canceled.
- The previous receive loop treated `mangos.ErrClosed` like a recoverable receive error: it reported the error, waited for one second, and retried the already closed socket. During the normal lifecycle, the canceled context then made the next loop iteration exit.
- A locally closed socket cannot reconnect, so that final wait and retry during topology shutdown are unnecessary.

## Changes In This PR
- Return from the existing receive loop when `Recv()` returns `mangos.ErrClosed`.
- Remove the receive-loop state and import that become unused.
- Add a focused regression test proving that the closed socket is not received from again after the old retry interval.

## Notes
- This only affects topology stopping: it makes the Neuron receive goroutine exit immediately during source cleanup.
- A remote Neuron or network disconnection does not close the local socket. Mangos keeps that socket open and continues its existing automatic pipe reconnection, so active-rule reconnect behavior is unchanged.
- The change does not cause a running rule to stop and has no compatibility, protocol, or configuration impact.
- Validated with `go test ./internal/io/neuron -run TestSubscribeStopsAfterSocketClosed -count=10`, `go test -race ./internal/io/neuron`, and `go test ./internal/io/neuron`.
