### PR TITLE
fix(ast): check all schema fields for indexes

### DIFF
--- a/pkg/ast/sourceStmt.go
+++ b/pkg/ast/sourceStmt.go
@@ -407,7 +407,9 @@ func doPrintFieldTypeForJson(ft FieldType) (result string, isLiteral bool) {
 
 func CheckSchemaIndex(schema map[string]*JsonStreamField) bool {
 	for _, field := range schema {
-		return field != nil && field.HasIndex
+		if field != nil && field.HasIndex {
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
## Summary
- Make `CheckSchemaIndex` inspect every schema field instead of returning after the first map entry.
- Correctly enable the slice-tuple evaluation path whenever any schema field has an index.

## Why
- The previous implementation returned while checking the first field produced by map iteration. Since Go map iteration order is not defined, it could report that a schema had no indexes even when another field did.
- This made the optimized slice-tuple path depend on which map entry happened to be visited first. Scanning until an indexed field is found makes the result correct and stable.

## Changes In This PR
- Update `pkg/ast/sourceStmt.go` to return `true` when any non-nil schema field has `HasIndex` set.
- Return `false` only after all schema fields have been checked.

## Notes
- The impact is limited to schema index detection and selection of the slice-tuple evaluation path.
- There are no API, configuration, storage, or data-format changes.
- Validated with `go test ./pkg/ast ./internal/converter/json`.
