### PR TITLE
fix: createRule callback data race

### DIFF
--- a/internal/server/rule_manager.go
+++ b/internal/server/rule_manager.go
@@ -135,9 +135,8 @@ func (rr *RuleRegistry) CreateRule(name, ruleJson string) (id string, err error)
 	ruleJson = replace.ReplaceRuleJson(ruleJson, conf.IsTesting)
 	// create state and save
 	rs := rule.NewState(r, func(id string, b bool) {
-		err = rr.updateTrigger(id, b)
-		if err != nil {
-			conf.Log.Warnf("update trigger error: %v", err)
+		if e := rr.updateTrigger(id, b); e != nil {
+			conf.Log.Warnf("update trigger error: %v", e)
 		}
 	})
 	// Validate the topo


### PR DESCRIPTION
## Summary
- Stop the asynchronous rule-state callback from writing to `CreateRule`'s return error.
- Keep trigger-update failures local to the callback and log them without changing the rule creation result.

## Why
- `CreateRule` starts the rule topology before its save path has finished. A rule that exits quickly can invoke the trigger callback concurrently with the remaining creation work.
- The callback captured the outer named return variable `err`, so both goroutines could read and write the same variable. This data race could make a successful creation look failed, hide a save failure, or cause the wrong cleanup path to run.
- The callback only needs to log a trigger-update failure, so a callback-local error is the appropriate scope.

## Changes In This PR
- Use a callback-local error when calling `updateTrigger` in `RuleRegistry.CreateRule`.
- Limit the change to `internal/server/rule_manager.go`; no NNG or data-processing behavior is changed.

## Notes
- Impact is limited to rule creation, especially rules that finish and report EOF before `CreateRule` returns. Long-running rule execution and SQL processing are unchanged.
- Passed: `go test ./internal/server -run '^(TestErrors|TestCoverage)$' -count=1`.
- Passed: `git diff --check`.
- The full `go test ./internal/server` suite was attempted but currently fails in unrelated shared-state/fixture tests (`TestServerTestSuite/TestRule`, `TestMetaConfiguration`, and `TestYamlImportErr`).
