### PR TITLE
fix(protobuf): resolve absolute schema paths

### DIFF
--- a/internal/converter/protobuf/converter.go
+++ b/internal/converter/protobuf/converter.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 EMQ Technologies Co., Ltd.
+// Copyright 2022-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,9 +16,6 @@ package protobuf
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/jhump/protoreflect/desc"            //nolint:staticcheck
 	"github.com/jhump/protoreflect/desc/protoparse" //nolint:staticcheck
@@ -26,6 +23,7 @@ import (
 
 	kconf "github.com/lf-edge/ekuiper/v2/internal/conf"
 	"github.com/lf-edge/ekuiper/v2/internal/converter/static"
+	"github.com/lf-edge/ekuiper/v2/internal/pkg/protoutil"
 	"github.com/lf-edge/ekuiper/v2/pkg/errorx"
 	"github.com/lf-edge/ekuiper/v2/pkg/message"
 )
@@ -47,9 +45,13 @@ func NewConverter(schemaFile string, soFile string, messageName string) (message
 	if soFile != "" {
 		return static.LoadStaticConverter(soFile, messageName)
 	} else {
-		protoFiles, err := collectProtoFiles(schemaFile)
+		protoFiles, err := protoutil.CollectFiles(schemaFile)
 		if err != nil {
 			return nil, fmt.Errorf("collect proto files from %s failed: %s", schemaFile, err)
+		}
+		protoFiles, err = protoutil.ResolveFiles(protoParser.ImportPaths, protoFiles)
+		if err != nil {
+			return nil, fmt.Errorf("resolve proto files from %s failed: %s", schemaFile, err)
 		}
 		fds, err := protoParser.ParseFiles(protoFiles...)
 		if err != nil {
@@ -66,33 +68,6 @@ func NewConverter(schemaFile string, soFile string, messageName string) (message
 		}
 		return nil, fmt.Errorf("message type %s not found in schema path %s", messageName, schemaFile)
 	}
-}
-
-// collectProtoFiles returns a list of .proto file paths for the given path.
-// If the path is a directory, it returns full paths for directory entries.
-// If it is a single file, it returns the path as-is.
-func collectProtoFiles(path string) ([]string, error) {
-	info, err := os.Stat(path)
-	if err != nil {
-		return nil, err
-	}
-	if !info.IsDir() {
-		return []string{path}, nil
-	}
-	entries, err := os.ReadDir(path)
-	if err != nil {
-		return nil, err
-	}
-	var result []string
-	for _, e := range entries {
-		if !e.IsDir() && strings.HasSuffix(e.Name(), ".proto") {
-			result = append(result, filepath.Join(path, e.Name()))
-		}
-	}
-	if len(result) == 0 {
-		return nil, fmt.Errorf("no .proto files found in directory %s", path)
-	}
-	return result, nil
 }
 
 func (c *Converter) Encode(ctx api.StreamContext, d any) (b []byte, err error) {

--- a/internal/converter/protobuf/converter_test.go
+++ b/internal/converter/protobuf/converter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 EMQ Technologies Co., Ltd.
+// Copyright 2022-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,10 +16,12 @@ package protobuf
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
 
+	"github.com/jhump/protoreflect/desc/protoparse" //nolint:staticcheck
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -302,34 +304,6 @@ func TestErr(t *testing.T) {
 	require.Equal(t, errorx.CovnerterErr, errWithCode.Code())
 }
 
-// ---- collectProtoFiles tests ----
-
-func TestCollectProtoFiles_SingleFile(t *testing.T) {
-	result, err := collectProtoFiles("../../schema/test/test1.proto")
-	require.NoError(t, err)
-	assert.Equal(t, []string{"../../schema/test/test1.proto"}, result)
-}
-
-func TestCollectProtoFiles_Directory(t *testing.T) {
-	result, err := collectProtoFiles("../../schema/test/multidir")
-	require.NoError(t, err)
-	assert.Len(t, result, 2)
-	assert.Contains(t, result, filepath.Join("../../schema/test/multidir", "msg_a.proto"))
-	assert.Contains(t, result, filepath.Join("../../schema/test/multidir", "msg_b.proto"))
-}
-
-func TestCollectProtoFiles_EmptyDir(t *testing.T) {
-	emptyDir := t.TempDir()
-	_, err := collectProtoFiles(emptyDir)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "no .proto files found")
-}
-
-func TestCollectProtoFiles_NotExist(t *testing.T) {
-	_, err := collectProtoFiles("../../schema/test/nonexistent")
-	assert.Error(t, err)
-}
-
 // ---- Directory-based NewConverter tests ----
 
 func TestNewConverter_FromDirectory(t *testing.T) {
@@ -350,4 +324,60 @@ func TestNewConverter_FromDirectory_NotFound(t *testing.T) {
 	_, err := NewConverter("../../schema/test/multidir", "", "NonExistentMsg")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestNewConverter_AbsolutePaths(t *testing.T) {
+	root := createAbsolutePathTestSchemas(t)
+	originalParser := protoParser
+	protoParser = &protoparse.Parser{ImportPaths: []string{root}}
+	t.Cleanup(func() { protoParser = originalParser })
+
+	tests := []struct {
+		name        string
+		schemaPath  string
+		messageName string
+	}{
+		{
+			name:        "single file",
+			schemaPath:  filepath.Join(root, "single.proto"),
+			messageName: "SingleMessage",
+		},
+		{
+			name:        "directory",
+			schemaPath:  filepath.Join(root, "bundle"),
+			messageName: "SecondMessage",
+		},
+		{
+			name:        "proto import",
+			schemaPath:  filepath.Join(root, "importing.proto"),
+			messageName: "ImportingMessage",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			converter, err := NewConverter(tt.schemaPath, "", tt.messageName)
+			require.NoError(t, err)
+			require.NotNil(t, converter)
+		})
+	}
+}
+
+func createAbsolutePathTestSchemas(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "bundle"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "support"), 0o755))
+	files := map[string]string{
+		"single.proto":         `syntax = "proto3"; message SingleMessage { string value = 1; }`,
+		"bundle/first.proto":   `syntax = "proto3"; message FirstMessage { string value = 1; }`,
+		"bundle/second.proto":  `syntax = "proto3"; message SecondMessage { int32 value = 1; }`,
+		"support/common.proto": `syntax = "proto3"; message CommonMessage { string value = 1; }`,
+		"importing.proto": `syntax = "proto3";
+import "support/common.proto";
+message ImportingMessage { CommonMessage common = 1; }`,
+	}
+	for name, content := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(root, filepath.FromSlash(name)), []byte(content), 0o600))
+	}
+	return root
 }

--- a/internal/pkg/protoutil/files.go
+++ b/internal/pkg/protoutil/files.go
@@ -1,0 +1,76 @@
+// Copyright 2026 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protoutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jhump/protoreflect/desc/protoparse" //nolint:staticcheck
+)
+
+// CollectFiles returns the .proto files at path. A single file is returned as-is;
+// a directory is expanded to its direct .proto children.
+func CollectFiles(path string) ([]string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.IsDir() {
+		return []string{path}, nil
+	}
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+	var result []string
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".proto") {
+			result = append(result, filepath.Join(path, entry.Name()))
+		}
+	}
+	if len(result) == 0 {
+		return nil, fmt.Errorf("no .proto files found in directory %s", path)
+	}
+	return result, nil
+}
+
+// ResolveFiles converts absolute file paths to names relative to the parser's
+// import paths. Relative names are kept as-is for compatibility with callers
+// that resolve schemas from the current working directory.
+func ResolveFiles(importPaths, protoFiles []string) ([]string, error) {
+	validImportPaths := make([]string, 0, len(importPaths))
+	for _, importPath := range importPaths {
+		if importPath != "" {
+			validImportPaths = append(validImportPaths, importPath)
+		}
+	}
+	if len(validImportPaths) == 0 {
+		return protoFiles, nil
+	}
+	for i, protoFile := range protoFiles {
+		if !filepath.IsAbs(protoFile) {
+			continue
+		}
+		resolved, err := protoparse.ResolveFilenames(validImportPaths, protoFile)
+		if err != nil {
+			return nil, err
+		}
+		protoFiles[i] = resolved[0]
+	}
+	return protoFiles, nil
+}

--- a/internal/pkg/protoutil/files_test.go
+++ b/internal/pkg/protoutil/files_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package protoutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectFiles(t *testing.T) {
+	root := t.TempDir()
+	protoFile := filepath.Join(root, "schema.proto")
+	require.NoError(t, os.WriteFile(protoFile, []byte(`message Test {}`), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "ignored.txt"), nil, 0o600))
+
+	t.Run("single file", func(t *testing.T) {
+		files, err := CollectFiles(protoFile)
+		require.NoError(t, err)
+		assert.Equal(t, []string{protoFile}, files)
+	})
+
+	t.Run("directory", func(t *testing.T) {
+		files, err := CollectFiles(root)
+		require.NoError(t, err)
+		assert.Equal(t, []string{protoFile}, files)
+	})
+
+	t.Run("empty directory", func(t *testing.T) {
+		_, err := CollectFiles(t.TempDir())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no .proto files found")
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := CollectFiles(filepath.Join(root, "missing.proto"))
+		require.Error(t, err)
+	})
+}
+
+func TestResolveFiles(t *testing.T) {
+	root := t.TempDir()
+	absoluteFile := filepath.Join(root, "nested", "schema.proto")
+	require.NoError(t, os.MkdirAll(filepath.Dir(absoluteFile), 0o755))
+	require.NoError(t, os.WriteFile(absoluteFile, []byte(`message Test {}`), 0o600))
+
+	t.Run("absolute path", func(t *testing.T) {
+		files, err := ResolveFiles([]string{root}, []string{absoluteFile})
+		require.NoError(t, err)
+		assert.Equal(t, []string{filepath.ToSlash(filepath.Join("nested", "schema.proto"))}, files)
+	})
+
+	t.Run("relative path", func(t *testing.T) {
+		files, err := ResolveFiles([]string{root}, []string{"nested/schema.proto"})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"nested/schema.proto"}, files)
+	})
+
+	t.Run("empty import paths", func(t *testing.T) {
+		files, err := ResolveFiles([]string{""}, []string{absoluteFile})
+		require.NoError(t, err)
+		assert.Equal(t, []string{absoluteFile}, files)
+	})
+
+	t.Run("outside import paths", func(t *testing.T) {
+		_, err := ResolveFiles([]string{t.TempDir()}, []string{absoluteFile})
+		require.Error(t, err)
+	})
+}

--- a/internal/schema/protobuf.go
+++ b/internal/schema/protobuf.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lf-edge/ekuiper/contract/v2/api"
 
 	"github.com/lf-edge/ekuiper/v2/internal/conf"
+	"github.com/lf-edge/ekuiper/v2/internal/pkg/protoutil"
 	"github.com/lf-edge/ekuiper/v2/pkg/ast"
 	"github.com/lf-edge/ekuiper/v2/pkg/modules"
 )
@@ -72,9 +73,13 @@ func (p *PbType) Scan(logger api.Logger, schemaDir string) (map[string]*modules.
 }
 
 func (p *PbType) Infer(_ api.Logger, filePath string, messageId string) (ast.StreamFields, error) {
-	protoFiles, err := collectProtoFiles(filePath)
+	protoFiles, err := protoutil.CollectFiles(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("collect proto files from %s failed: %s", filePath, err)
+	}
+	protoFiles, err = protoutil.ResolveFiles(protoParser.ImportPaths, protoFiles)
+	if err != nil {
+		return nil, fmt.Errorf("resolve proto files from %s failed: %s", filePath, err)
 	}
 	fds, err := protoParser.ParseFiles(protoFiles...)
 	if err != nil {
@@ -87,33 +92,6 @@ func (p *PbType) Infer(_ api.Logger, filePath string, messageId string) (ast.Str
 		}
 	}
 	return nil, fmt.Errorf("message type %s not found in schema path %s", messageId, filePath)
-}
-
-// collectProtoFiles returns a list of .proto file paths for the given path.
-// If the path is a directory, it returns dir-relative paths (e.g. "multidir/msg_a.proto").
-// If it is a single file, it returns the path as-is.
-func collectProtoFiles(path string) ([]string, error) {
-	info, err := os.Stat(path)
-	if err != nil {
-		return nil, err
-	}
-	if !info.IsDir() {
-		return []string{path}, nil
-	}
-	entries, err := os.ReadDir(path)
-	if err != nil {
-		return nil, err
-	}
-	var result []string
-	for _, e := range entries {
-		if !e.IsDir() && strings.HasSuffix(e.Name(), ".proto") {
-			result = append(result, filepath.Join(path, e.Name()))
-		}
-	}
-	if len(result) == 0 {
-		return nil, fmt.Errorf("no .proto files found in directory %s", path)
-	}
-	return result, nil
 }
 
 func convertMessage(m *desc.MessageDescriptor) (ast.StreamFields, error) {

--- a/internal/schema/protobuf_test.go
+++ b/internal/schema/protobuf_test.go
@@ -1,9 +1,11 @@
 package schema
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/jhump/protoreflect/desc/protoparse" //nolint:staticcheck
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -51,34 +53,6 @@ func TestInferProtobufWithEmbedType(t *testing.T) {
 	if !assert.Equal(t, expected, result) {
 		t.Errorf("InferProtobuf result is not expected, got %v, expected %v", result, expected)
 	}
-}
-
-// ---- collectProtoFiles tests ----
-
-func TestCollectProtoFiles_SingleFile(t *testing.T) {
-	result, err := collectProtoFiles("test/test1.proto")
-	require.NoError(t, err)
-	assert.Equal(t, []string{"test/test1.proto"}, result)
-}
-
-func TestCollectProtoFiles_Directory(t *testing.T) {
-	result, err := collectProtoFiles("test/multidir")
-	require.NoError(t, err)
-	assert.Len(t, result, 2)
-	assert.Contains(t, result, filepath.Join("test/multidir", "msg_a.proto"))
-	assert.Contains(t, result, filepath.Join("test/multidir", "msg_b.proto"))
-}
-
-func TestCollectProtoFiles_EmptyDir(t *testing.T) {
-	emptyDir := t.TempDir()
-	_, err := collectProtoFiles(emptyDir)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "no .proto files found")
-}
-
-func TestCollectProtoFiles_NotExist(t *testing.T) {
-	_, err := collectProtoFiles("test/nonexistent")
-	assert.Error(t, err)
 }
 
 // ---- Directory-based Scan tests ----
@@ -140,4 +114,61 @@ func TestInfer_FromDirectory_MessageNotFound(t *testing.T) {
 	_, err := pt.Infer(nil, "test/multidir", "NonExistentMessage")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestInfer_AbsolutePaths(t *testing.T) {
+	root := createAbsolutePathTestSchemas(t)
+	originalParser := protoParser
+	protoParser = &protoparse.Parser{ImportPaths: []string{root}}
+	t.Cleanup(func() { protoParser = originalParser })
+
+	tests := []struct {
+		name        string
+		schemaPath  string
+		messageName string
+	}{
+		{
+			name:        "single file",
+			schemaPath:  filepath.Join(root, "single.proto"),
+			messageName: "SingleMessage",
+		},
+		{
+			name:        "directory",
+			schemaPath:  filepath.Join(root, "bundle"),
+			messageName: "SecondMessage",
+		},
+		{
+			name:        "proto import",
+			schemaPath:  filepath.Join(root, "importing.proto"),
+			messageName: "ImportingMessage",
+		},
+	}
+	pt := &PbType{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fields, err := pt.Infer(nil, tt.schemaPath, tt.messageName)
+			require.NoError(t, err)
+			require.Len(t, fields, 1)
+		})
+	}
+}
+
+func createAbsolutePathTestSchemas(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "bundle"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "support"), 0o755))
+	files := map[string]string{
+		"single.proto":         `syntax = "proto3"; message SingleMessage { string value = 1; }`,
+		"bundle/first.proto":   `syntax = "proto3"; message FirstMessage { string value = 1; }`,
+		"bundle/second.proto":  `syntax = "proto3"; message SecondMessage { int32 value = 1; }`,
+		"support/common.proto": `syntax = "proto3"; message CommonMessage { string value = 1; }`,
+		"importing.proto": `syntax = "proto3";
+import "support/common.proto";
+message ImportingMessage { CommonMessage common = 1; }`,
+	}
+	for name, content := range files {
+		require.NoError(t, os.WriteFile(filepath.Join(root, filepath.FromSlash(name)), []byte(content), 0o600))
+	}
+	return root
 }


### PR DESCRIPTION
## Summary
- Fix Protobuf schemas registered with absolute paths failing to load because the schema root was added twice.
- Apply the same path handling to converter creation and schema inference through shared Protobuf file utilities.
- Cover absolute single files, schema directories, and schemas that import another proto file.

## Why
The schema registry stores files under the configured Protobuf schema directory and returns their absolute paths. The Protobuf parser already uses that directory as an import root, so passing the absolute path directly makes it prepend the root again and try to open a non-existent doubled path.

In plain terms, a schema that exists at `data/schemas/protobuf/test.proto` could be looked up as `data/schemas/protobuf/data/schemas/protobuf/test.proto`. This prevents rules using the registered Protobuf schema from creating a converter, and it also prevents stream fields from being inferred from that schema.

## Changes In This PR
- Move the previously duplicated proto file collection logic from converter and schema packages into `internal/pkg/protoutil`.
- Resolve absolute proto file paths relative to the parser's non-empty import paths before calling `ParseFiles`.
- Reuse `protoparse.ResolveFilenames` so path boundaries, symbolic links, and platform-specific separators follow the parser's own rules.
- Keep relative paths and empty import paths unchanged for compatibility with existing callers and tests.
- Add shared utility tests plus regression tests for both converter creation and schema inference, covering a single file, a directory containing multiple proto files, and a proto file with an import.

## Notes
- The change only affects Protobuf schema loading; JSON and other converters are unchanged.
- Validation: relevant package tests, focused race tests, `TestInferredStream`, `go vet`, and `git diff --check` all pass.
