### PR TITLE
fix(conf): avoid log formatter race

### DIFF
--- a/internal/conf/conf.go
+++ b/internal/conf/conf.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 EMQ Technologies Co., Ltd.
+// Copyright 2023-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -260,7 +260,11 @@ func SetConsoleAndFileLog(consoleLog, fileLog bool) error {
 }
 
 func SetLogFormat(disableTimestamp bool) {
-	Log.Formatter.(*logrus.TextFormatter).DisableTimestamp = disableTimestamp
+	Log.SetFormatter(&logrus.TextFormatter{
+		DisableColors:    true,
+		DisableTimestamp: disableTimestamp,
+		FullTimestamp:    true,
+	})
 }
 
 func ValidateRuleOption(option *def.RuleOption) error {

--- a/internal/conf/conf_test.go
+++ b/internal/conf/conf_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2025 EMQ Technologies Co., Ltd.
+// Copyright 2023-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,15 +17,51 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
 	"github.com/lf-edge/ekuiper/v2/pkg/cast"
 )
+
+func TestSetLogFormatConcurrent(t *testing.T) {
+	originalFormatter := Log.Formatter
+	t.Cleanup(func() {
+		Log.SetFormatter(originalFormatter)
+	})
+
+	const iterations = 1000
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		for range iterations {
+			Log.Info("test concurrent log format update")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := range iterations {
+			SetLogFormat(i%2 == 0)
+		}
+	}()
+	close(start)
+	wg.Wait()
+
+	formatter, ok := Log.Formatter.(*logrus.TextFormatter)
+	require.True(t, ok)
+	require.True(t, formatter.DisableColors)
+	require.True(t, formatter.FullTimestamp)
+	require.False(t, formatter.DisableTimestamp)
+}
 
 func TestRuleOptionValidate(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary
- Make log format updates safe while other goroutines are writing logs.
- Add a race regression test that updates the formatter concurrently with logging.

## Why
- `SetLogFormat` directly changed `TextFormatter.DisableTimestamp` on the formatter already in use by logrus. When configuration was reinitialized while an asynchronous topology cleanup was logging, one goroutine could write that field while another read it.
- This is easiest to trigger in tests because they reinitialize global configuration, but the unsafe update was in the shared logging implementation. Replacing the formatter through logrus keeps the update protected by the logger's own mutex.

## Changes In This PR
- Build a new text formatter and install it with `Logger.SetFormatter` instead of mutating the active formatter.
- Preserve the existing disabled-color and full-timestamp settings.
- Cover concurrent log writes and format updates with `TestSetLogFormatConcurrent`.
- Refresh copyright years in the modified files to 2026.

## Notes
- The change only affects log formatter configuration. Rule execution, topology cleanup, and log message contents are otherwise unchanged.
- Validated with focused race tests for the new regression case and `TestYamlImportErr`, plus `go vet` and `git diff --check`.
