### PR TITLE
perf(topo): optimize runtime hot paths

### DIFF
--- a/internal/topo/node/dedup_trigger_op_test.go
+++ b/internal/topo/node/dedup_trigger_op_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 EMQ Technologies Co., Ltd.
+// Copyright 2024-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
 	"github.com/lf-edge/ekuiper/v2/internal/topo/topotest/mockclock"
@@ -204,7 +205,7 @@ func TestExec(t *testing.T) {
 	ctx := context.NewMockContext("test", "test")
 	resultChan := make(chan any, 100)
 	errChan := make(chan error)
-	node.outputs["output"] = resultChan
+	require.NoError(t, node.AddOutput(resultChan, "output"))
 	node.Exec(ctx, errChan)
 	expResults := []any{
 		map[string]any{"begin": int64(90), "finish": int64(180), "ts": int64(180), "ruleId": "new", "ranges": []map[string]any{{"start_key": "90", "end_key": "180"}}},

--- a/internal/topo/node/node.go
+++ b/internal/topo/node/node.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 EMQ Technologies Co., Ltd.
+// Copyright 2021-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ type defaultNode struct {
 	qos         def.Qos
 	outputMu    syncx.RWMutex
 	outputs     map[string]chan any
+	outputSlice []namedOutput
 	opsWg       *sync.WaitGroup
 	// tracing state
 	span                     trace.Span
@@ -74,6 +75,7 @@ func (o *defaultNode) AddOutput(output chan any, name string) error {
 	o.outputMu.Lock()
 	defer o.outputMu.Unlock()
 	o.outputs[name] = output
+	o.rebuildOutputSlice()
 	return nil
 }
 
@@ -89,7 +91,23 @@ func (o *defaultNode) RemoveOutput(name string) error {
 			}
 		}
 	}
+	o.rebuildOutputSlice()
 	return nil
+}
+
+type namedOutput struct {
+	name string
+	ch   chan any
+}
+
+// rebuildOutputSlice refreshes the broadcast view of outputs.
+// The caller must hold outputMu for writing.
+func (o *defaultNode) rebuildOutputSlice() {
+	outputs := make([]namedOutput, 0, len(o.outputs))
+	for name, ch := range o.outputs {
+		outputs = append(outputs, namedOutput{name: name, ch: ch})
+	}
+	o.outputSlice = outputs
 }
 
 func (o *defaultNode) GetName() string {
@@ -139,10 +157,15 @@ func (o *defaultNode) BroadcastCustomized(val any, broadcastFunc func(val any)) 
 func (o *defaultNode) doBroadcast(val any) {
 	o.outputMu.RLock()
 	defer o.outputMu.RUnlock()
-	last := len(o.outputs) - 1
-	i := 0
+	outputs := o.outputSlice
+	if len(outputs) == 0 {
+		return
+	}
+	last := len(outputs) - 1
 	var valCopy any
-	for name, out := range o.outputs {
+	done := o.ctx.Done()
+	for i, output := range outputs {
+		out := output.ch
 		// Only copy tuples except the last one(copy previous one may change val, so copy the last) when there are many outputs to save one copy time
 		if i != last {
 			switch vt := val.(type) {
@@ -172,7 +195,6 @@ func (o *defaultNode) doBroadcast(val any) {
 		} else {
 			valCopy = val
 		}
-		i++
 		// Fallback to set the context when sending out so that all children have the same parent ctx
 		// If has set ctx in the node impl, do not override it
 		if vt, ok := valCopy.(xsql.HasTracerCtx); ok && vt.GetTracerCtx() == nil {
@@ -183,7 +205,7 @@ func (o *defaultNode) doBroadcast(val any) {
 			select {
 			case out <- valCopy:
 				continue
-			case <-o.ctx.Done():
+			case <-done:
 				return
 			}
 		}
@@ -193,13 +215,13 @@ func (o *defaultNode) doBroadcast(val any) {
 			select {
 			case out <- valCopy:
 				break forlabel
-			case <-o.ctx.Done():
+			case <-done:
 				return
 			default:
 				// read the oldest to drop.
 				oldest := <-out
 				// record the error and stop propagating to avoid infinite loop
-				o.onErrorOpt(o.ctx, fmt.Errorf("buffer full, drop message %v from %s to %s", xsql.GetId(oldest), o.name, name), false)
+				o.onErrorOpt(o.ctx, fmt.Errorf("buffer full, drop message %v from %s to %s", xsql.GetId(oldest), o.name, output.name), false)
 			}
 		}
 	}
@@ -334,7 +356,7 @@ func (o *defaultNode) onProcessStart(ctx api.StreamContext, val any) {
 	o.statManager.IncTotalRecordsIn()
 	o.statManager.ProcessTimeStart()
 	// Source just pass nil val so that no trace. The trace will start after extracting trace id
-	if val != nil {
+	if val != nil && ctx.IsTraceEnabled() {
 		traced, spanCtx, span := tracenode.TraceInput(ctx, val, o.name)
 		if traced {
 			tracenode.RecordRowOrCollection(val, span)

--- a/internal/topo/node/node_test.go
+++ b/internal/topo/node/node_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 EMQ Technologies Co., Ltd.
+// Copyright 2024-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package node
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -39,6 +40,8 @@ func TestOutputs(t *testing.T) {
 	err = n.RemoveOutput("rule.4")
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(n.outputs))
+	assert.Len(t, n.outputSlice, 1)
+	assert.Equal(t, "rule.2_test", n.outputSlice[0].name)
 }
 
 func TestMultipleOutputsBroadcast(t *testing.T) {
@@ -110,6 +113,29 @@ func TestMultipleOutputsBroadcast(t *testing.T) {
 			assert.False(t, result1 == result2)
 			assert.Equal(t, tt.data, result1)
 			assert.Equal(t, tt.data, result2)
+		})
+	}
+}
+
+func BenchmarkBroadcastOutputs(b *testing.B) {
+	for _, outputCount := range []int{1, 4, 16} {
+		b.Run(fmt.Sprintf("outputs_%d", outputCount), func(b *testing.B) {
+			ctx := mockContext.NewMockContext("benchmark", "broadcast")
+			n := newDefaultNode("test", &def.RuleOption{})
+			n.ctx = ctx
+			outputs := make([]chan any, outputCount)
+			for i := range outputs {
+				outputs[i] = make(chan any, 1)
+				require.NoError(b, n.AddOutput(outputs[i], fmt.Sprintf("output_%d", i)))
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				n.Broadcast(i)
+				for _, output := range outputs {
+					<-output
+				}
+			}
 		})
 	}
 }

--- a/internal/topo/node/operations.go
+++ b/internal/topo/node/operations.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2024 EMQ Technologies Co., Ltd.
+// Copyright 2021-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -94,6 +94,7 @@ func (o *UnaryOperator) doOp(ctx api.StreamContext, errCh chan<- error) {
 	}()
 
 	fv, afv := xsql.NewFunctionValuersForOp(exeCtx)
+	done := ctx.Done()
 
 	for {
 		select {
@@ -122,7 +123,7 @@ func (o *UnaryOperator) doOp(ctx api.StreamContext, errCh chan<- error) {
 			o.onProcessEnd(ctx)
 			o.statManager.SetBufferLength(int64(len(o.input)))
 		// is cancelling
-		case <-ctx.Done():
+		case <-done:
 			logger.Infof("unary operator %s instance %d cancelling....", o.name, ctx.GetInstanceId())
 			cancel()
 			return

--- a/internal/topo/node/watermark_op_test.go
+++ b/internal/topo/node/watermark_op_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 EMQ Technologies Co., Ltd.
+// Copyright 2023-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/lf-edge/ekuiper/v2/internal/conf"
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
@@ -212,7 +213,7 @@ func TestSingleStreamWatermark(t *testing.T) {
 			})
 			errCh := make(chan error)
 			outputCh := make(chan interface{}, 50)
-			w.outputs["mock"] = outputCh
+			require.NoError(t, w.AddOutput(outputCh, "mock"))
 			w.Exec(nctx, errCh)
 
 			in := 0
@@ -464,7 +465,7 @@ func TestMultiStreamWatermark(t *testing.T) {
 			})
 			errCh := make(chan error)
 			outputCh := make(chan interface{}, 50)
-			w.outputs["mock"] = outputCh
+			require.NoError(t, w.AddOutput(outputCh, "mock"))
 			w.Exec(nctx, errCh)
 
 			in := 0


### PR DESCRIPTION
## Summary
- Speed up topology message broadcasting by iterating a cached output slice instead of a map.
- Cache cancellation channels in hot loops to avoid repeated `ctx.Done()` lookups.
- Skip trace setup calls early when tracing is disabled.

## Why
- These paths run for every message, while topology outputs and cancellation channels change rarely or never during execution.
- The previous implementation repeatedly paid for map iteration, interface calls, and trace helper calls even in the common non-tracing case.
- The changes move output-list rebuilding to the infrequent add/remove path and keep message behavior unchanged.

## Changes In This PR
- Maintain `outputSlice` together with the existing named output map under `outputMu`.
- Use the cached slice in `doBroadcast` and cache its context cancellation channel once per broadcast.
- Cache the cancellation channel once before the unary operator loop.
- Guard `TraceInput` with `IsTraceEnabled` in `onProcessStart`.
- Update tests to register outputs through `AddOutput`, verify the output cache, and add a broadcast benchmark.

## Notes
- No API, message ownership, or output semantics change. This PR does not share mutable `RawTuple` values and does not change function-context state caching.
- `go test -race ./internal/topo/node -count=1` passes.
- `git diff --check` passes.
- Median benchmark results over five runs on linux/amd64:

  | Outputs | Before | After | Change |
  | --- | ---: | ---: | ---: |
  | 1 | 96.9 ns/op | 63.3 ns/op | -34.7% |
  | 4 | 253.9 ns/op | 205.1 ns/op | -19.2% |
  | 16 | 910.6 ns/op | 750.4 ns/op | -17.6% |

- `go vet ./internal/topo/node` remains blocked by the existing lock-copy warning in `window_op_test.go:335`; this PR does not modify that code.
