### PR TITLE
fix(topo): clear stale project caches

### DIFF
--- a/internal/topo/operator/project_operator.go
+++ b/internal/topo/operator/project_operator.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 EMQ Technologies Co., Ltd.
+// Copyright 2022-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -203,6 +203,8 @@ func (pp *ProjectOp) project(row xsql.RawRow, ve *xsql.ValuerEval) error {
 		// Calculate all fields then pick the needed ones
 		// To make sure all calculations are run with the same context (e.g. alias values)
 		// Do not set value during calculations
+		pp.kvs = pp.kvs[:0]
+		pp.alias = pp.alias[:0]
 
 		for _, f := range pp.ExprFields {
 			if f.Invisible {
@@ -240,11 +242,9 @@ func (pp *ProjectOp) project(row xsql.RawRow, ve *xsql.ValuerEval) error {
 		for i := 0; i < len(pp.kvs); i += 2 {
 			row.Set(pp.kvs[i].(string), pp.kvs[i+1])
 		}
-		pp.kvs = pp.kvs[:0]
 		for i := 0; i < len(pp.alias); i += 2 {
 			row.AppendAlias(pp.alias[i].(string), pp.alias[i+1])
 		}
-		pp.alias = pp.alias[:0]
 	}
 	return nil
 }

--- a/internal/topo/operator/project_test.go
+++ b/internal/topo/operator/project_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 EMQ Technologies Co., Ltd.
+// Copyright 2022-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -3561,4 +3561,72 @@ func TestProjectSliceInvisibleManualExprField(t *testing.T) {
 	require.Equal(t, &xsql.SliceTuple{
 		SourceContent: model.SliceVal{int64(3)},
 	}, result)
+}
+
+func TestProjectClearsCachedValuesAfterError(t *testing.T) {
+	contextLogger := conf.Log.WithField("rule", "TestProjectClearsCachedValuesAfterError")
+	ctx := context.WithValue(context.Background(), context.LoggerKey, contextLogger)
+	pp := &ProjectOp{
+		ExprFields: ast.Fields{
+			{Name: "carry", Expr: &ast.FieldRef{Name: "carry"}},
+			{
+				Name: "calculated",
+				Expr: &ast.BinaryExpr{
+					OP:  ast.MUL,
+					LHS: &ast.FieldRef{Name: "value"},
+					RHS: &ast.IntegerLiteral{Val: 2},
+				},
+			},
+		},
+	}
+	fv, afv := xsql.NewFunctionValuersForOp(nil)
+
+	failed := &xsql.Tuple{
+		Emitter: "test",
+		Message: xsql.Message{"carry": "stale", "value": "not-a-number"},
+	}
+	result := pp.Apply(ctx, failed, fv, afv)
+	require.Error(t, result.(error))
+
+	succeeded := &xsql.Tuple{
+		Emitter: "test",
+		Message: xsql.Message{"value": int64(2)},
+	}
+	result = pp.Apply(ctx, succeeded, fv, afv)
+	require.Same(t, succeeded, result)
+	require.Equal(t, map[string]any{"calculated": int64(4)}, succeeded.ToMap())
+}
+
+func TestProjectClearsCachedAliasesAfterError(t *testing.T) {
+	contextLogger := conf.Log.WithField("rule", "TestProjectClearsCachedAliasesAfterError")
+	ctx := context.WithValue(context.Background(), context.LoggerKey, contextLogger)
+	pp := &ProjectOp{
+		AliasFields: ast.Fields{
+			{AName: "carry", Expr: &ast.FieldRef{Name: "carry"}},
+			{
+				AName: "calculated",
+				Expr: &ast.BinaryExpr{
+					OP:  ast.MUL,
+					LHS: &ast.FieldRef{Name: "value"},
+					RHS: &ast.IntegerLiteral{Val: 2},
+				},
+			},
+		},
+	}
+	fv, afv := xsql.NewFunctionValuersForOp(nil)
+
+	failed := &xsql.Tuple{
+		Emitter: "test",
+		Message: xsql.Message{"carry": "stale", "value": "not-a-number"},
+	}
+	result := pp.Apply(ctx, failed, fv, afv)
+	require.Error(t, result.(error))
+
+	succeeded := &xsql.Tuple{
+		Emitter: "test",
+		Message: xsql.Message{"value": int64(2)},
+	}
+	result = pp.Apply(ctx, succeeded, fv, afv)
+	require.Same(t, succeeded, result)
+	require.Equal(t, map[string]any{"calculated": int64(4)}, succeeded.ToMap())
 }


### PR DESCRIPTION
## Summary
- Clear temporary project value and alias caches before evaluating each input row.
- Prevent values left by a failed row from appearing in a later successful row.
- Add regression coverage for both expression values and aliases.

## Why
- The project operator reused temporary slices across input rows, but previously cleared them only after a row completed successfully.
- If an earlier expression produced a value and a later expression returned an error, the function exited before clearing those slices. The next row could therefore inherit output from the failed row.
- Starting every row with empty temporary slices keeps failed-row data isolated while continuing to reuse the existing backing arrays.

## Changes In This PR
- Move `kvs` and `alias` slice resets to the beginning of the map-based project path.
- Add tests that process a failing row followed by a successful row and verify that neither calculated values nor aliases leak forward.
- Refresh copyright years in the modified files to 2026.

## Notes
- This affects only the map-based project path that uses these temporary caches; SliceTuple projection does not use them.
- The successful path still performs the same two constant-time slice resets and does not add allocations or change output semantics.
- Verified with `go test -race ./internal/topo/operator -count=1`, `go vet ./internal/topo/operator`, and `git diff --check`.
