### PR TITLE
perf(sql): optimize expression evaluation

### DIFF
--- a/internal/binder/function/funcs_cols.go
+++ b/internal/binder/function/funcs_cols.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 EMQ Technologies Co., Ltd.
+// Copyright 2022-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ func changedFunc(ctx api.FunctionContext, args []interface{}, keys []string) (Re
 		if err != nil {
 			return nil, err
 		}
-		if !reflect.DeepEqual(v, lv) {
+		if !changedValueEqual(v, lv) {
 			if r == nil {
 				r = make(ResultCols)
 			}
@@ -101,4 +101,33 @@ func changedFunc(ctx api.FunctionContext, args []interface{}, keys []string) (Re
 		}
 	}
 	return r, nil
+}
+
+func changedValueEqual(v1, v2 interface{}) bool {
+	if v1 == nil || v2 == nil {
+		return v1 == v2
+	}
+	switch t1 := v1.(type) {
+	case string:
+		if t2, ok := v2.(string); ok {
+			return t1 == t2
+		}
+	case int64:
+		if t2, ok := v2.(int64); ok {
+			return t1 == t2
+		}
+	case float64:
+		if t2, ok := v2.(float64); ok {
+			return t1 == t2
+		}
+	case bool:
+		if t2, ok := v2.(bool); ok {
+			return t1 == t2
+		}
+	case int:
+		if t2, ok := v2.(int); ok {
+			return t1 == t2
+		}
+	}
+	return reflect.DeepEqual(v1, v2)
 }

--- a/internal/binder/function/funcs_cols_test.go
+++ b/internal/binder/function/funcs_cols_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 EMQ Technologies Co., Ltd.
+// Copyright 2022-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -302,6 +302,56 @@ func TestExecIgnoreNull(t *testing.T) {
 		result, _ := f.exec(fctx, tt.args)
 		if !reflect.DeepEqual(result, tt.result) {
 			t.Errorf("%d result mismatch,\ngot:\t%v \nwant:\t%v", i, result, tt.result)
+		}
+	}
+}
+
+func TestChangedValueEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		v1   any
+		v2   any
+		want bool
+	}{
+		{name: "nil", want: true},
+		{name: "one nil", v1: int64(1), want: false},
+		{name: "string", v1: "value", v2: "value", want: true},
+		{name: "different string", v1: "value", v2: "other", want: false},
+		{name: "int64", v1: int64(1), v2: int64(1), want: true},
+		{name: "different numeric types", v1: int64(1), v2: int(1), want: false},
+		{name: "float64", v1: float64(1.5), v2: float64(1.5), want: true},
+		{name: "bool", v1: true, v2: true, want: true},
+		{name: "int", v1: int(1), v2: int(1), want: true},
+		{name: "slice fallback", v1: []int{1, 2}, v2: []int{1, 2}, want: true},
+		{name: "map fallback", v1: map[string]any{"a": 1}, v2: map[string]any{"a": 2}, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := changedValueEqual(tt.v1, tt.v2); got != tt.want {
+				t.Errorf("changedValueEqual(%v, %v) = %v, want %v", tt.v1, tt.v2, got, tt.want)
+			}
+		})
+	}
+}
+
+func BenchmarkChangedColsStable(b *testing.B) {
+	contextLogger := conf.Log.WithField("rule", "BenchmarkChangedColsStable")
+	ctx := kctx.WithValue(kctx.Background(), kctx.LoggerKey, contextLogger)
+	tempStore, err := state.CreateStore("BenchmarkChangedColsStable", def.AtMostOnce)
+	if err != nil {
+		b.Fatal(err)
+	}
+	fctx := kctx.NewDefaultFuncContext(ctx.WithMeta("BenchmarkChangedColsStable", "changed_cols", tempStore), 1)
+	args := []any{"p_", true, "same", int64(42), true}
+	keys := []string{"prefix", "ignore", "string", "integer", "boolean"}
+	if _, err := changedFunc(fctx, args, keys); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := changedFunc(fctx, args, keys); err != nil {
+			b.Fatal(err)
 		}
 	}
 }

--- a/internal/topo/operator/project_operator.go
+++ b/internal/topo/operator/project_operator.go
@@ -50,6 +50,12 @@ type ProjectOp struct {
 
 	kvs   []interface{}
 	alias []interface{}
+
+	ve  *xsql.ValuerEval
+	wv  *xsql.WildcardValuer
+	wrv *xsql.WindowRangeValuer
+	mvs xsql.MultiValuerList
+	mav *xsql.AggregateMultiValuer
 }
 
 // Apply
@@ -121,14 +127,41 @@ func (pp *ProjectOp) Apply(ctx api.StreamContext, data interface{}, fv *xsql.Fun
 
 func (pp *ProjectOp) getVE(tuple xsql.RawRow, agg xsql.AggregateData, wr *xsql.WindowRange, fv *xsql.FunctionValuer, afv *xsql.AggregateFunctionValuer) *xsql.ValuerEval {
 	afv.SetData(agg)
+	if pp.ve == nil {
+		pp.ve = &xsql.ValuerEval{}
+		pp.wv = &xsql.WildcardValuer{}
+		pp.wrv = &xsql.WindowRangeValuer{}
+		pp.mvs = make(xsql.MultiValuerList, 4)
+		if pp.IsAggregate {
+			pp.mav = &xsql.AggregateMultiValuer{MultiValuerList: pp.mvs}
+			pp.ve.Valuer = pp.mav
+		} else {
+			pp.ve.Valuer = &pp.mvs
+		}
+	}
+	pp.wv.Data = tuple
 	if pp.IsAggregate {
-		return &xsql.ValuerEval{Valuer: xsql.MultiAggregateValuer(agg, fv, tuple, fv, afv, &xsql.WildcardValuer{Data: tuple})}
+		pp.mvs[0] = tuple
+		pp.mvs[1] = fv
+		pp.mvs[2] = afv
+		pp.mvs[3] = pp.wv
+		pp.mav.Reset(agg, fv)
 	} else {
 		if wr != nil {
-			return &xsql.ValuerEval{Valuer: xsql.MultiValuer(tuple, &xsql.WindowRangeValuer{WindowRange: wr}, fv, &xsql.WildcardValuer{Data: tuple})}
+			pp.mvs = pp.mvs[:4]
+			pp.wrv.WindowRange = wr
+			pp.mvs[0] = tuple
+			pp.mvs[1] = pp.wrv
+			pp.mvs[2] = fv
+			pp.mvs[3] = pp.wv
+		} else {
+			pp.mvs = pp.mvs[:3]
+			pp.mvs[0] = tuple
+			pp.mvs[1] = fv
+			pp.mvs[2] = pp.wv
 		}
-		return &xsql.ValuerEval{Valuer: xsql.MultiValuer(tuple, fv, &xsql.WildcardValuer{Data: tuple})}
 	}
+	return pp.ve
 }
 
 func (pp *ProjectOp) getRowVE(tuple xsql.Row, wr *xsql.WindowRange, fv *xsql.FunctionValuer, afv *xsql.AggregateFunctionValuer) *xsql.ValuerEval {

--- a/internal/topo/operator/project_test.go
+++ b/internal/topo/operator/project_test.go
@@ -3630,3 +3630,48 @@ func TestProjectClearsCachedAliasesAfterError(t *testing.T) {
 	require.Same(t, succeeded, result)
 	require.Equal(t, map[string]any{"calculated": int64(4)}, succeeded.ToMap())
 }
+
+func TestProjectReusesValuer(t *testing.T) {
+	pp := &ProjectOp{}
+	fv, afv := xsql.NewFunctionValuersForOp(nil)
+	first := &xsql.Tuple{Emitter: "test", Message: xsql.Message{"a": int64(1)}}
+	second := &xsql.Tuple{Emitter: "test", Message: xsql.Message{"a": int64(2)}}
+	field := &ast.FieldRef{Name: "a"}
+
+	ve := pp.getRowVE(first, nil, fv, afv)
+	require.Equal(t, int64(1), ve.Eval(field))
+	reused := pp.getRowVE(second, nil, fv, afv)
+	require.Same(t, ve, reused)
+	require.Equal(t, int64(2), reused.Eval(field))
+
+	windowed := pp.getVE(second, nil, xsql.NewWindowRange(10, 20, 30), fv, afv)
+	require.Same(t, ve, windowed)
+	require.Equal(t, int64(10), windowed.Eval(&ast.Call{Name: "window_start"}))
+
+	withoutWindow := pp.getRowVE(first, nil, fv, afv)
+	require.Same(t, ve, withoutWindow)
+	require.Equal(t, int64(1), withoutWindow.Eval(field))
+}
+
+func BenchmarkSliceProjectEvaluation(b *testing.B) {
+	stmt, err := xsql.NewParser(strings.NewReader("SELECT a, b, c FROM test")).Parse()
+	if err != nil {
+		b.Fatal(err)
+	}
+	pp := &ProjectOp{}
+	parseStmtWithSlice(pp, stmt.Fields, true)
+	fv, afv := xsql.NewFunctionValuersForOp(nil)
+	source := model.SliceVal{int64(10), int64(20), int64(30)}
+	sink := make(model.SliceVal, 0, pp.FieldLen)
+	tuple := &xsql.SliceTuple{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		tuple.SourceContent = source
+		tuple.SinkContent = sink[:0]
+		ve := pp.getRowVE(tuple, nil, fv, afv)
+		if err := pp.project(tuple, ve); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/xsql/valuer.go
+++ b/internal/xsql/valuer.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 EMQ Technologies Co., Ltd.
+// Copyright 2022-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1245,27 +1245,31 @@ func invalidOpError(lhs interface{}, op ast.Token, rhs interface{}) error {
 }
 
 func convertNum(para interface{}) interface{} {
-	if isInt(para) {
-		// Already check type of para so that there will be no error, just ignore error
-		para, _ = cast.ToInt64(para, cast.CONVERT_SAMEKIND)
-	} else if isFloat(para) {
-		para, _ = cast.ToFloat64(para, cast.CONVERT_SAMEKIND)
+	switch v := para.(type) {
+	case int:
+		return int64(v)
+	case int8:
+		return int64(v)
+	case int16:
+		return int64(v)
+	case int32:
+		return int64(v)
+	case int64:
+		return v
+	case uint:
+		return int64(v)
+	case uint8:
+		return int64(v)
+	case uint16:
+		return int64(v)
+	case uint32:
+		return int64(v)
+	case uint64:
+		return int64(v)
+	case float32:
+		return float64(v)
+	case float64:
+		return v
 	}
 	return para
-}
-
-func isInt(para interface{}) bool {
-	switch para.(type) {
-	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-		return true
-	}
-	return false
-}
-
-func isFloat(para interface{}) bool {
-	switch para.(type) {
-	case float32, float64:
-		return true
-	}
-	return false
 }

--- a/internal/xsql/valuer.go
+++ b/internal/xsql/valuer.go
@@ -100,12 +100,13 @@ func (wv *WildcardValuer) Meta(_, _ string) (interface{}, bool) {
 // MultiValuer returns a Valuer that iterates over multiple Valuer instances
 // to find a match.
 func MultiValuer(valuers ...Valuer) Valuer {
-	return multiValuer(valuers)
+	return MultiValuerList(valuers)
 }
 
-type multiValuer []Valuer
+// MultiValuerList evaluates against an ordered, reusable list of valuers.
+type MultiValuerList []Valuer
 
-func (a multiValuer) Value(key, table string) (interface{}, bool) {
+func (a MultiValuerList) Value(key, table string) (interface{}, bool) {
 	for _, valuer := range a {
 		if v, ok := valuer.Value(key, table); ok {
 			return v, true
@@ -114,7 +115,7 @@ func (a multiValuer) Value(key, table string) (interface{}, bool) {
 	return nil, false
 }
 
-func (a multiValuer) Meta(key, table string) (interface{}, bool) {
+func (a MultiValuerList) Meta(key, table string) (interface{}, bool) {
 	for _, valuer := range a {
 		if v, ok := valuer.Meta(key, table); ok {
 			return v, true
@@ -123,7 +124,7 @@ func (a multiValuer) Meta(key, table string) (interface{}, bool) {
 	return nil, false
 }
 
-func (a multiValuer) AppendAlias(key string, value interface{}) bool {
+func (a MultiValuerList) AppendAlias(key string, value interface{}) bool {
 	for _, valuer := range a {
 		if vv, ok := valuer.(AliasValuer); ok {
 			if ok := vv.AppendAlias(key, value); ok {
@@ -134,7 +135,7 @@ func (a multiValuer) AppendAlias(key string, value interface{}) bool {
 	return false
 }
 
-func (a multiValuer) AliasValue(key string) (interface{}, bool) {
+func (a MultiValuerList) AliasValue(key string) (interface{}, bool) {
 	for _, valuer := range a {
 		if vv, ok := valuer.(AliasValuer); ok {
 			return vv.AliasValue(key)
@@ -143,7 +144,7 @@ func (a multiValuer) AliasValue(key string) (interface{}, bool) {
 	return nil, false
 }
 
-func (a multiValuer) FuncValue(key string) (interface{}, bool) {
+func (a MultiValuerList) FuncValue(key string) (interface{}, bool) {
 	for _, valuer := range a {
 		if vv, ok := valuer.(FuncValuer); ok {
 			if r, ok := vv.FuncValue(key); ok {
@@ -154,7 +155,7 @@ func (a multiValuer) FuncValue(key string) (interface{}, bool) {
 	return nil, false
 }
 
-func (a multiValuer) Call(name string, funcId int, args []interface{}) (interface{}, bool) {
+func (a MultiValuerList) Call(name string, funcId int, args []interface{}) (interface{}, bool) {
 	for _, valuer := range a {
 		if valuer, ok := valuer.(CallValuer); ok {
 			if v, ok := valuer.Call(name, funcId, args); ok {
@@ -167,7 +168,7 @@ func (a multiValuer) Call(name string, funcId int, args []interface{}) (interfac
 	return nil, false
 }
 
-func (a multiValuer) ValueByIndex(index int, sourceIndex int) (any, bool) {
+func (a MultiValuerList) ValueByIndex(index int, sourceIndex int) (any, bool) {
 	for _, valuer := range a {
 		if iv, ok := valuer.(model.IndexValuer); ok {
 			return iv.ValueByIndex(index, sourceIndex)
@@ -176,7 +177,7 @@ func (a multiValuer) ValueByIndex(index int, sourceIndex int) (any, bool) {
 	return nil, false
 }
 
-func (a multiValuer) SetByIndex(index int, value any) {
+func (a MultiValuerList) SetByIndex(index int, value any) {
 	for _, valuer := range a {
 		if iv, ok := valuer.(model.IndexValuer); ok {
 			iv.SetByIndex(index, value)
@@ -186,7 +187,7 @@ func (a multiValuer) SetByIndex(index int, value any) {
 	panic("implement me")
 }
 
-func (a multiValuer) TempByIndex(index int) any {
+func (a MultiValuerList) TempByIndex(index int) any {
 	for _, valuer := range a {
 		if iv, ok := valuer.(model.IndexValuer); ok {
 			return iv.TempByIndex(index)
@@ -195,7 +196,7 @@ func (a multiValuer) TempByIndex(index int) any {
 	return nil
 }
 
-func (a multiValuer) SetTempByIndex(index int, value any) {
+func (a MultiValuerList) SetTempByIndex(index int, value any) {
 	for _, valuer := range a {
 		if iv, ok := valuer.(model.IndexValuer); ok {
 			iv.SetTempByIndex(index, value)
@@ -205,24 +206,31 @@ func (a multiValuer) SetTempByIndex(index int, value any) {
 	panic("implement me")
 }
 
-type multiAggregateValuer struct {
+// AggregateMultiValuer combines aggregate and scalar valuers for reuse across input rows.
+type AggregateMultiValuer struct {
 	data AggregateData
-	multiValuer
+	MultiValuerList
 	singleCallValuer CallValuer
 }
 
 func MultiAggregateValuer(data AggregateData, singleCallValuer CallValuer, valuers ...Valuer) Valuer {
-	return &multiAggregateValuer{
+	return &AggregateMultiValuer{
 		data:             data,
-		multiValuer:      valuers,
+		MultiValuerList:  valuers,
 		singleCallValuer: singleCallValuer,
 	}
 }
 
-func (a *multiAggregateValuer) Call(name string, funcId int, args []interface{}) (interface{}, bool) {
+// Reset updates the per-input aggregate data and scalar call valuer.
+func (a *AggregateMultiValuer) Reset(data AggregateData, singleCallValuer CallValuer) {
+	a.data = data
+	a.singleCallValuer = singleCallValuer
+}
+
+func (a *AggregateMultiValuer) Call(name string, funcId int, args []interface{}) (interface{}, bool) {
 	// assume the aggFuncMap already cache the custom agg funcs in IsAggFunc()
 	isAgg := function.IsAggFunc(name)
-	for _, valuer := range a.multiValuer {
+	for _, valuer := range a.MultiValuerList {
 		if a, ok := valuer.(AggregateCallValuer); ok && isAgg {
 			if v, ok := a.Call(name, funcId, args); ok {
 				return v, true
@@ -238,30 +246,30 @@ func (a *multiAggregateValuer) Call(name string, funcId int, args []interface{})
 	return nil, false
 }
 
-func (a *multiAggregateValuer) GetAllTuples() AggregateData {
+func (a *AggregateMultiValuer) GetAllTuples() AggregateData {
 	return a.data
 }
 
-func (a *multiAggregateValuer) GetSingleCallValuer() CallValuer {
+func (a *AggregateMultiValuer) GetSingleCallValuer() CallValuer {
 	return a.singleCallValuer
 }
 
-func (a *multiAggregateValuer) AppendAlias(key string, value interface{}) bool {
+func (a *AggregateMultiValuer) AppendAlias(key string, value interface{}) bool {
 	if vv, ok := a.data.(AliasValuer); ok {
 		if ok := vv.AppendAlias(key, value); ok {
 			return true
 		}
 		return false
 	} else {
-		return a.multiValuer.AppendAlias(key, value)
+		return a.MultiValuerList.AppendAlias(key, value)
 	}
 }
 
-func (a *multiAggregateValuer) AliasValue(key string) (interface{}, bool) {
+func (a *AggregateMultiValuer) AliasValue(key string) (interface{}, bool) {
 	if vv, ok := a.data.(AliasValuer); ok {
 		return vv.AliasValue(key)
 	} else {
-		return a.multiValuer.AliasValue(key)
+		return a.MultiValuerList.AliasValue(key)
 	}
 }
 

--- a/internal/xsql/valuer_test.go
+++ b/internal/xsql/valuer_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2024 EMQ Technologies Co., Ltd.
+// Copyright 2021-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package xsql
 import (
 	"errors"
 	"fmt"
+	"math"
 	"reflect"
 	"strings"
 	"testing"
@@ -461,5 +462,46 @@ func TestLike(t *testing.T) {
 				t.Errorf("%d-%s. \nstmt mismatch:\n\nexp=%#v\n\ngot=%#v\n\n", i, sqls[j], tt.r[j], result)
 			}
 		}
+	}
+}
+
+func TestConvertNum(t *testing.T) {
+	type namedInt int64
+	tests := []struct {
+		name  string
+		input any
+		want  any
+	}{
+		{name: "int", input: int(-1), want: int64(-1)},
+		{name: "int8", input: int8(-8), want: int64(-8)},
+		{name: "int16", input: int16(-16), want: int64(-16)},
+		{name: "int32", input: int32(-32), want: int64(-32)},
+		{name: "int64", input: int64(-64), want: int64(-64)},
+		{name: "uint", input: uint(1), want: int64(1)},
+		{name: "uint8", input: uint8(8), want: int64(8)},
+		{name: "uint16", input: uint16(16), want: int64(16)},
+		{name: "uint32", input: uint32(32), want: int64(32)},
+		{name: "uint64 overflow", input: uint64(math.MaxUint64), want: int64(-1)},
+		{name: "float32", input: float32(1.25), want: float64(1.25)},
+		{name: "float64", input: float64(2.5), want: float64(2.5)},
+		{name: "string", input: "1", want: "1"},
+		{name: "bool", input: true, want: true},
+		{name: "nil", input: nil, want: nil},
+		{name: "uintptr", input: uintptr(1), want: uintptr(1)},
+		{name: "named int", input: namedInt(1), want: namedInt(1)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := convertNum(tt.input); !reflect.DeepEqual(tt.want, got) {
+				t.Errorf("convertNum(%T(%v)) = %T(%v), want %T(%v)", tt.input, tt.input, got, got, tt.want, tt.want)
+			}
+		})
+	}
+}
+
+func BenchmarkSimpleDataEvalInt64(b *testing.B) {
+	ve := &ValuerEval{}
+	for i := 0; i < b.N; i++ {
+		_ = ve.SimpleDataEval(int64(10), int64(20), ast.ADD)
 	}
 }


### PR DESCRIPTION
## Summary
- Reuse the project evaluator and its valuer chain across input rows.
- Normalize numeric operands with one type switch instead of repeated type checks and cast dispatch.
- Compare common `changed_cols` value types directly before falling back to `reflect.DeepEqual`.

## Why
- SQL expression evaluation runs for every input row, so small setup and dispatch costs accumulate in projection, arithmetic, filtering, sorting, and change detection.
- The project operator rebuilt the same evaluator scaffolding for every row even though only the current tuple, window, and aggregate data changed.
- Numeric normalization inspected each operand type multiple times, while `changed_cols` used reflection even for primitive values.

## Changes In This PR
- Expose reusable internal multi-valuer implementations and reset their per-row data from `ProjectOp` without changing expression indices or SliceTuple output semantics.
- Replace `convertNum` helper dispatch with a single type switch that preserves the existing integer and floating-point conversions.
- Add primitive fast paths for string, int64, float64, bool, and int comparisons in `changed_cols`; complex values retain `reflect.DeepEqual` behavior.
- Add focused regression tests and benchmarks for all three paths.
- Organize the changes as three independent commits for review.

## Notes
- Benchmark medians on linux/amd64, Intel i9-14900HX, seven runs:
  - int64 `SimpleDataEval`: 10.82 ns/op to 8.08 ns/op (about 25% faster), 0 allocations before and after.
  - SliceTuple projection: 158.6 ns/op to 54.9 ns/op (about 65% faster), from 112 B / 4 allocations to 0 B / 0 allocations.
  - stable `changed_cols`: 337.0 ns/op to 304.8 ns/op (about 10% faster), with allocations unchanged.
- Passed `go test -race ./internal/xsql ./internal/topo/operator -count=1` and focused race tests for the changed column functions.
- `git diff --check` passes.
- A full local binder/function run still hits the pre-existing `TestIncAggFunctionErr` failure, reproduced unchanged on `upstream/master`. `go vet` likewise reports the existing lock-copy warning in untouched `internal/xsql/row.go:187`.
