### PR TITLE
fix(rule): prevent concurrent double start

### DIFF
--- a/internal/topo/rule/state.go
+++ b/internal/topo/rule/state.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 EMQ Technologies Co., Ltd.
+// Copyright 2024-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -114,6 +114,10 @@ func (s *State) Start() error {
 	}
 	s.ruleLock.Lock()
 	defer s.ruleLock.Unlock()
+	// Bootstrap may have completed the start while this call was waiting for ruleLock.
+	if s.sm.CurrentState() != machine.Starting {
+		return nil
+	}
 	// delegate to rule patrol checker
 	if s.Rule.IsScheduleRule() {
 		s.transitState(machine.ScheduledStop, "")
@@ -129,6 +133,10 @@ func (s *State) ScheduleStart() error {
 	}
 	s.ruleLock.Lock()
 	defer s.ruleLock.Unlock()
+	// Bootstrap may have completed the start while this call was waiting for ruleLock.
+	if s.sm.CurrentState() != machine.Starting {
+		return nil
+	}
 	// doStart trigger the Rule run. If no trigger error, the Rule will run async and control the state by itself
 	s.logger.Infof("schedule to run rule %s", s.Rule.Id)
 	return s.doStart()

--- a/internal/topo/rule/state_test.go
+++ b/internal/topo/rule/state_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 EMQ Technologies Co., Ltd.
+// Copyright 2022-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/schedule"
@@ -277,4 +278,55 @@ func sendAction(st *State, a machine.ActionSignal) {
 
 func TestRuleRestart(t *testing.T) {
 	// TODO added later
+}
+
+func TestStartRechecksStateAfterLock(t *testing.T) {
+	tests := []struct {
+		name  string
+		start func(*State) error
+	}{
+		{
+			name: "start",
+			start: func(st *State) error {
+				return st.Start()
+			},
+		},
+		{
+			name: "scheduled start",
+			start: func(st *State) error {
+				return st.ScheduleStart()
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			st := NewState(def.GetDefaultRule("testLockRecheck", "select * from demo"), func(string, bool) {})
+
+			// Hold ruleLock so the start operation stops after changing the state to Starting.
+			st.ruleLock.Lock()
+			locked := true
+			defer func() {
+				if locked {
+					st.ruleLock.Unlock()
+				}
+				st.Delete()
+			}()
+			done := make(chan error, 1)
+			go func() {
+				done <- tt.start(st)
+			}()
+			require.Eventually(t, func() bool {
+				return st.GetState() == machine.Starting
+			}, time.Second, time.Millisecond)
+
+			// Model Bootstrap winning ruleLock and completing the API start first.
+			st.transitState(machine.Running, "")
+			st.ruleLock.Unlock()
+			locked = false
+
+			require.NoError(t, <-done)
+			assert.Equal(t, machine.Running, st.GetState())
+			assert.Nil(t, st.topology, "the stale start operation must not plan or launch the topology")
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- Prevent a stale rule start operation from launching a topology after another start path has already completed.
- Cover both normal and scheduled start paths with a deterministic concurrency regression test.
- Refresh the modified files' copyright years to 2026.

## Why
- `RestartRule` eventually calls `State.Start`, while a concurrent `StartRule` calls `State.Bootstrap`.
- `Start` changed the state to `Starting` before acquiring `ruleLock`. If `Bootstrap` acquired the lock and completed first, the waiting `Start` continued without checking the new state and launched a second `runTopo` goroutine for the same topology.
- This is a logical race rather than an unsynchronized memory access, so the Go race detector does not report it.

## Changes In This PR
- Recheck that the rule is still in `Starting` state after `Start` or `ScheduleStart` acquires `ruleLock`.
- Return without planning or launching when another lifecycle operation has already advanced the state.
- Add a deterministic test that holds `ruleLock`, lets the start path enter `Starting`, models `Bootstrap` completing first, and verifies the stale start performs no topology work.

## Notes
- The change only affects concurrent lifecycle operations on the same rule.
- Sequential start, restart, stop, recovery, and scheduled-rule behavior are unchanged.
- Validated with:
  - `go test -race ./internal/topo/rule/... -count=1`
  - focused regression test under `-race` for 10 consecutive runs
  - focused REST rule-management tests under `-race`
  - `go vet ./internal/topo/rule/...`
  - `git diff --check`
