### PR TITLE
feat: defer rule planning during startup

### DIFF
--- a/docs/en_US/api/restapi/overview.md
+++ b/docs/en_US/api/restapi/overview.md
@@ -22,6 +22,11 @@ GET http://localhost:9081
 
 ## ping
 
+The endpoint returns HTTP 200 when the REST management API is available. It
+does not indicate that all persisted rules have finished startup recovery.
+During server startup, triggered rules may still have the `loaded` or
+`starting` status while their topologies are planned in the background.
+
 ```shell
 GET http://localhost:9081/ping
 ```

--- a/docs/en_US/api/restapi/rules.md
+++ b/docs/en_US/api/restapi/rules.md
@@ -161,10 +161,19 @@ POST http://localhost:9081/rules/{id}/restart
 
 ## get the status of a rule
 
-The command is used to get the status of the rule. If the rule is running, the metrics will be retrieved realtime. The status can be
+The command is used to get the status of the rule. If the rule is running, the metrics will be retrieved in real time. The `status` field can be:
 
-- $metrics
-- stopped: $reason
+- `loaded`: the rule is registered and waiting for background topology planning during server startup
+- `starting`: the rule is being planned and started
+- `running`: the rule is running; metric fields are populated in the response
+- `stopping`: the rule is being stopped
+- `stopped`: the rule was stopped intentionally or has not been started
+- `stopped by error`: the rule stopped because of a planning or runtime error
+- `stopped: waiting for next schedule.`: a scheduled rule is waiting for its next run
+
+The REST API becomes available before persisted triggered rules are planned. Clients that need to wait for startup recovery can query `GET /rules` until no rule has the `loaded` or `starting` status. A `stopped by error` status means that the startup attempt finished but failed.
+
+Topology and sink-schema endpoints require a planned rule and may temporarily return a not-started error while its status is `loaded` or `starting`.
 
 ```shell
 GET http://localhost:9081/rules/{id}/status

--- a/docs/zh_CN/api/restapi/overview.md
+++ b/docs/zh_CN/api/restapi/overview.md
@@ -20,6 +20,8 @@ GET http://localhost:9081
 
 ## ping
 
+当 REST 管理接口可用时，该接口返回 HTTP 200。它不表示所有持久化规则均已完成启动恢复。服务器启动期间，已触发的规则会在后台依次完成拓扑规划，其状态可能暂时为 `loaded` 或 `starting`。
+
 ```shell
 GET http://localhost:9081/ping
 ```

--- a/docs/zh_CN/api/restapi/rules.md
+++ b/docs/zh_CN/api/restapi/rules.md
@@ -156,10 +156,19 @@ POST http://localhost:9081/rules/{id}/restart
 
 ## 获取规则的状态
 
-该命令用于获取规则的状态。 如果规则正在运行，则将实时检索状态指标。 状态可以是：
+该命令用于获取规则状态。规则运行时，响应会包含实时指标。`status` 字段可能为：
 
-- $metrics
-- 停止： $reason
+- `loaded`：服务器启动期间，规则已注册并等待后台拓扑规划
+- `starting`：规则正在规划和启动
+- `running`：规则正在运行，响应包含指标字段
+- `stopping`：规则正在停止
+- `stopped`：规则被主动停止或尚未启动
+- `stopped by error`：规则因规划错误或运行时错误停止
+- `stopped: waiting for next schedule.`：定时规则正在等待下一次运行
+
+REST 管理接口会在持久化的 triggered 规则完成规划前可用。需要等待启动恢复完成的客户端可查询 `GET /rules`，直到所有规则均不再处于 `loaded` 或 `starting` 状态。`stopped by error` 表示该规则的启动尝试已经结束，但启动失败。
+
+拓扑和 sink schema 接口依赖已经完成规划的规则，因此规则处于 `loaded` 或 `starting` 状态时，这些接口可能暂时返回规则尚未启动的错误。
 
 ```shell
 GET http://localhost:9081/rules/{id}/status

--- a/internal/server/rule_manager.go
+++ b/internal/server/rule_manager.go
@@ -220,7 +220,6 @@ func (rr *RuleRegistry) upsertRule(ruleId, ruleJson string, persist func(string,
 
 	// do upsert.
 	rs, isUpdate := rr.internal[ruleId]
-	var previousRule *def.Rule
 	if !isUpdate { // if not exist, create it
 		rs = rule.NewState(r, func(id string, b bool) {
 			err = rr.updateTrigger(id, b)
@@ -230,9 +229,9 @@ func (rr *RuleRegistry) upsertRule(ruleId, ruleJson string, persist func(string,
 		})
 	} else {
 		// Version check is now atomic with the rest of the operation
-		previousRule = rs.GetRule()
-		if !processor.CanReplace(previousRule.Version, r.Version) {
-			return fmt.Errorf("rule %s already exists with version (%s), new version (%s) is lower", ruleId, previousRule.Version, r.Version)
+		rule := rs.GetRule()
+		if !processor.CanReplace(rule.Version, r.Version) {
+			return fmt.Errorf("rule %s already exists with version (%s), new version (%s) is lower", ruleId, rule.Version, r.Version)
 		}
 	}
 	err = rs.ValidateAndRun(r)
@@ -250,14 +249,11 @@ func (rr *RuleRegistry) upsertRule(ruleId, ruleJson string, persist func(string,
 		rr.internal[r.Id] = rs
 	}
 	if err != nil {
-		// A newly created state is not registered and can be invalidated. Restore
-		// an existing state to the last persisted rule so runtime and storage do
-		// not diverge after a failed update.
+		// A newly created state is not registered and can be invalidated. An
+		// existing state remains in the registry, so only stop its topology;
+		// marking it deleted would make all later operations return NOT_FOUND.
 		if isUpdate {
-			if rollbackErr := rs.ValidateAndRun(previousRule); rollbackErr != nil {
-				conf.Log.Errorf("failed to roll back rule %s after persistence failure: %v", ruleId, rollbackErr)
-				rs.StopWithLastWill("stopped by persistence and rollback failure")
-			}
+			rs.StopWithLastWill("stopped by persistence failure")
 		} else {
 			rs.Delete()
 		}

--- a/internal/server/rule_manager.go
+++ b/internal/server/rule_manager.go
@@ -220,6 +220,7 @@ func (rr *RuleRegistry) upsertRule(ruleId, ruleJson string, persist func(string,
 
 	// do upsert.
 	rs, isUpdate := rr.internal[ruleId]
+	var previousRule *def.Rule
 	if !isUpdate { // if not exist, create it
 		rs = rule.NewState(r, func(id string, b bool) {
 			err = rr.updateTrigger(id, b)
@@ -229,9 +230,9 @@ func (rr *RuleRegistry) upsertRule(ruleId, ruleJson string, persist func(string,
 		})
 	} else {
 		// Version check is now atomic with the rest of the operation
-		rule := rs.GetRule()
-		if !processor.CanReplace(rule.Version, r.Version) {
-			return fmt.Errorf("rule %s already exists with version (%s), new version (%s) is lower", ruleId, rule.Version, r.Version)
+		previousRule = rs.GetRule()
+		if !processor.CanReplace(previousRule.Version, r.Version) {
+			return fmt.Errorf("rule %s already exists with version (%s), new version (%s) is lower", ruleId, previousRule.Version, r.Version)
 		}
 	}
 	err = rs.ValidateAndRun(r)
@@ -249,11 +250,14 @@ func (rr *RuleRegistry) upsertRule(ruleId, ruleJson string, persist func(string,
 		rr.internal[r.Id] = rs
 	}
 	if err != nil {
-		// A newly created state is not registered and can be invalidated. An
-		// existing state remains in the registry, so only stop its topology;
-		// marking it deleted would make all later operations return NOT_FOUND.
+		// A newly created state is not registered and can be invalidated. Restore
+		// an existing state to the last persisted rule so runtime and storage do
+		// not diverge after a failed update.
 		if isUpdate {
-			rs.StopWithLastWill("stopped by persistence failure")
+			if rollbackErr := rs.ValidateAndRun(previousRule); rollbackErr != nil {
+				conf.Log.Errorf("failed to roll back rule %s after persistence failure: %v", ruleId, rollbackErr)
+				rs.StopWithLastWill("stopped by persistence and rollback failure")
+			}
 		} else {
 			rs.Delete()
 		}

--- a/internal/server/rule_manager.go
+++ b/internal/server/rule_manager.go
@@ -203,6 +203,10 @@ func (rr *RuleRegistry) LoadRule(r *def.Rule) string {
 // UpsertRule validates the new rule, then update the db, then restart the rule
 // The entire operation is protected by a lock to ensure atomic version checking.
 func (rr *RuleRegistry) UpsertRule(ruleId, ruleJson string) error {
+	return rr.upsertRule(ruleId, ruleJson, ruleProcessor.ExecUpsert)
+}
+
+func (rr *RuleRegistry) upsertRule(ruleId, ruleJson string, persist func(string, string) error) error {
 	ruleJson = replace.ReplaceRuleJson(ruleJson, conf.IsTesting)
 	// Validate the rule json (can be done outside lock - no state change)
 	r, err := ruleProcessor.GetRuleByJson(ruleId, ruleJson)
@@ -236,7 +240,7 @@ func (rr *RuleRegistry) UpsertRule(ruleId, ruleJson string) error {
 	}
 	if !r.Temp {
 		// Persist directly - we already hold the lock
-		err = ruleProcessor.ExecUpsert(r.Id, ruleJson)
+		err = persist(r.Id, ruleJson)
 		if err == nil {
 			rr.internal[r.Id] = rs
 		}
@@ -245,8 +249,14 @@ func (rr *RuleRegistry) UpsertRule(ruleId, ruleJson string) error {
 		rr.internal[r.Id] = rs
 	}
 	if err != nil {
-		// rollback clean up
-		rs.Delete()
+		// A newly created state is not registered and can be invalidated. An
+		// existing state remains in the registry, so only stop its topology;
+		// marking it deleted would make all later operations return NOT_FOUND.
+		if isUpdate {
+			rs.StopWithLastWill("stopped by persistence failure")
+		} else {
+			rs.Delete()
+		}
 	}
 	return err
 }

--- a/internal/server/rule_manager.go
+++ b/internal/server/rule_manager.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 EMQ Technologies Co., Ltd.
+// Copyright 2021-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -177,6 +177,27 @@ func (rr *RuleRegistry) RecoverRule(r *def.Rule) string {
 		}
 	}
 	return fmt.Sprintf("Rule %s was started.", r.Id)
+}
+
+// LoadRule registers a recovered rule without planning it. Triggered rules
+// enter Loaded state until the startup recovery worker processes them.
+func (rr *RuleRegistry) LoadRule(r *def.Rule) string {
+	triggerFunc := func(id string, b bool) {
+		if err := rr.updateTrigger(id, b); err != nil {
+			conf.Log.Warnf("update trigger error: %v", err)
+		}
+	}
+	var rs *rule.State
+	if r.Triggered {
+		rs = rule.NewLoadedState(r, triggerFunc)
+	} else {
+		rs = rule.NewState(r, triggerFunc)
+	}
+	rr.register(r.Id, rs)
+	if r.Triggered {
+		return fmt.Sprintf("Rule %s loaded (pending start).", r.Id)
+	}
+	return fmt.Sprintf("Rule %s was stopped.", r.Id)
 }
 
 // UpsertRule validates the new rule, then update the db, then restart the rule

--- a/internal/server/rule_manager_test.go
+++ b/internal/server/rule_manager_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 EMQ Technologies Co., Ltd.
+// Copyright 2024-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,12 +15,16 @@
 package server
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
+	"github.com/lf-edge/ekuiper/v2/internal/processor"
 	"github.com/lf-edge/ekuiper/v2/internal/topo/rule"
+	"github.com/lf-edge/ekuiper/v2/internal/topo/rule/machine"
 	"github.com/lf-edge/ekuiper/v2/pkg/ast"
 )
 
@@ -52,6 +56,56 @@ func TestErrors(t *testing.T) {
 	registry.register("test", rule.NewState(def.GetDefaultRule("testErrors", "select * from demo"), func(string, bool) {}))
 	err = registry.StartRule("test")
 	assert.EqualError(t, err, "fail to get stream demo, please check if stream is created")
+}
+
+func TestLoadRule(t *testing.T) {
+	rr := &RuleRegistry{internal: make(map[string]*rule.State)}
+	triggered := def.GetDefaultRule("loadedRule", "select * from demo")
+	triggered.Triggered = true
+	stopped := def.GetDefaultRule("stoppedRule", "select * from demo")
+	stopped.Triggered = false
+
+	require.Contains(t, rr.LoadRule(triggered), "pending start")
+	require.Contains(t, rr.LoadRule(stopped), "was stopped")
+
+	loadedState, ok := rr.load(triggered.Id)
+	require.True(t, ok)
+	require.Equal(t, machine.Loaded, loadedState.GetState())
+	status, err := rr.GetRuleStatusV2(triggered.Id)
+	require.NoError(t, err)
+	require.Equal(t, "loaded", status["status"])
+	stoppedState, ok := rr.load(stopped.Id)
+	require.True(t, ok)
+	require.Equal(t, machine.Stopped, stoppedState.GetState())
+	loadedState.Delete()
+	stoppedState.Delete()
+}
+
+func TestStartLoadedRules(t *testing.T) {
+	sp := processor.NewStreamProcessor()
+	_, err := sp.ExecStmt(`CREATE STREAM recoveryDemo () WITH (FORMAT="JSON", TYPE="memory", DATASOURCE="test")`)
+	require.NoError(t, err)
+	defer sp.ExecStmt(`DROP STREAM recoveryDemo`)
+
+	rr := &RuleRegistry{internal: make(map[string]*rule.State)}
+	invalid := rule.NewLoadedState(def.GetDefaultRule("invalidLoaded", "select * from missingRecoveryStream"), func(string, bool) {})
+	valid := rule.NewLoadedState(def.GetDefaultRule("validLoaded", "select * from recoveryDemo"), func(string, bool) {})
+	defer invalid.Delete()
+	defer valid.Delete()
+	rr.register("invalidLoaded", invalid)
+	rr.register("validLoaded", valid)
+
+	startLoadedRules(context.Background(), rr, []string{"invalidLoaded", "validLoaded"})
+	require.Equal(t, machine.StoppedByErr, invalid.GetState())
+	require.Equal(t, machine.Running, valid.GetState())
+
+	canceled := rule.NewLoadedState(def.GetDefaultRule("canceledLoaded", "select * from recoveryDemo"), func(string, bool) {})
+	defer canceled.Delete()
+	rr.register("canceledLoaded", canceled)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	startLoadedRules(ctx, rr, []string{"canceledLoaded"})
+	require.Equal(t, machine.Loaded, canceled.GetState())
 }
 
 func TestCoverage(t *testing.T) {

--- a/internal/server/rule_manager_test.go
+++ b/internal/server/rule_manager_test.go
@@ -118,7 +118,6 @@ func TestUpdatePersistenceFailureKeepsStateUsable(t *testing.T) {
 	rr := &RuleRegistry{internal: make(map[string]*rule.State)}
 	const stoppedRule = `{"id":"persistenceRule","triggered":false,"sql":"select * from persistenceDemo","actions":[{"log":{}}]}`
 	const runningRule = `{"id":"persistenceRule","triggered":true,"sql":"select * from persistenceDemo","actions":[{"log":{}}]}`
-	const changedRunningRule = `{"id":"persistenceRule","triggered":true,"sql":"select * from persistenceDemo where true","actions":[{"log":{}}]}`
 	_, err = rr.CreateRule("persistenceRule", stoppedRule)
 	require.NoError(t, err)
 	defer rr.DeleteRule("persistenceRule")
@@ -133,18 +132,9 @@ func TestUpdatePersistenceFailureKeepsStateUsable(t *testing.T) {
 	require.True(t, ok)
 	require.Same(t, rs, retained)
 	require.Equal(t, machine.Stopped, retained.GetState())
-	require.False(t, retained.GetRule().Triggered)
-	require.Equal(t, "select * from persistenceDemo", retained.GetRule().Sql)
 
 	require.NoError(t, rr.UpsertRule("persistenceRule", runningRule))
 	require.Equal(t, machine.Running, retained.GetState())
-
-	err = rr.upsertRule("persistenceRule", changedRunningRule, func(string, string) error {
-		return errors.New("mock rule upsert error")
-	})
-	require.EqualError(t, err, "mock rule upsert error")
-	require.Equal(t, machine.Running, retained.GetState())
-	require.Equal(t, "select * from persistenceDemo", retained.GetRule().Sql)
 }
 
 func TestCoverage(t *testing.T) {

--- a/internal/server/rule_manager_test.go
+++ b/internal/server/rule_manager_test.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -106,6 +107,34 @@ func TestStartLoadedRules(t *testing.T) {
 	cancel()
 	startLoadedRules(ctx, rr, []string{"canceledLoaded"})
 	require.Equal(t, machine.Loaded, canceled.GetState())
+}
+
+func TestUpdatePersistenceFailureKeepsStateUsable(t *testing.T) {
+	sp := processor.NewStreamProcessor()
+	_, err := sp.ExecStmt(`CREATE STREAM persistenceDemo () WITH (FORMAT="JSON", TYPE="memory", DATASOURCE="test")`)
+	require.NoError(t, err)
+	defer sp.ExecStmt(`DROP STREAM persistenceDemo`)
+
+	rr := &RuleRegistry{internal: make(map[string]*rule.State)}
+	const stoppedRule = `{"id":"persistenceRule","triggered":false,"sql":"select * from persistenceDemo","actions":[{"log":{}}]}`
+	const runningRule = `{"id":"persistenceRule","triggered":true,"sql":"select * from persistenceDemo","actions":[{"log":{}}]}`
+	_, err = rr.CreateRule("persistenceRule", stoppedRule)
+	require.NoError(t, err)
+	defer rr.DeleteRule("persistenceRule")
+
+	rs, ok := rr.load("persistenceRule")
+	require.True(t, ok)
+	err = rr.upsertRule("persistenceRule", runningRule, func(string, string) error {
+		return errors.New("mock rule upsert error")
+	})
+	require.EqualError(t, err, "mock rule upsert error")
+	retained, ok := rr.load("persistenceRule")
+	require.True(t, ok)
+	require.Same(t, rs, retained)
+	require.Equal(t, machine.Stopped, retained.GetState())
+
+	require.NoError(t, rr.UpsertRule("persistenceRule", runningRule))
+	require.Equal(t, machine.Running, retained.GetState())
 }
 
 func TestCoverage(t *testing.T) {

--- a/internal/server/rule_manager_test.go
+++ b/internal/server/rule_manager_test.go
@@ -118,6 +118,7 @@ func TestUpdatePersistenceFailureKeepsStateUsable(t *testing.T) {
 	rr := &RuleRegistry{internal: make(map[string]*rule.State)}
 	const stoppedRule = `{"id":"persistenceRule","triggered":false,"sql":"select * from persistenceDemo","actions":[{"log":{}}]}`
 	const runningRule = `{"id":"persistenceRule","triggered":true,"sql":"select * from persistenceDemo","actions":[{"log":{}}]}`
+	const changedRunningRule = `{"id":"persistenceRule","triggered":true,"sql":"select * from persistenceDemo where true","actions":[{"log":{}}]}`
 	_, err = rr.CreateRule("persistenceRule", stoppedRule)
 	require.NoError(t, err)
 	defer rr.DeleteRule("persistenceRule")
@@ -132,9 +133,18 @@ func TestUpdatePersistenceFailureKeepsStateUsable(t *testing.T) {
 	require.True(t, ok)
 	require.Same(t, rs, retained)
 	require.Equal(t, machine.Stopped, retained.GetState())
+	require.False(t, retained.GetRule().Triggered)
+	require.Equal(t, "select * from persistenceDemo", retained.GetRule().Sql)
 
 	require.NoError(t, rr.UpsertRule("persistenceRule", runningRule))
 	require.Equal(t, machine.Running, retained.GetState())
+
+	err = rr.upsertRule("persistenceRule", changedRunningRule, func(string, string) error {
+		return errors.New("mock rule upsert error")
+	})
+	require.EqualError(t, err, "mock rule upsert error")
+	require.Equal(t, machine.Running, retained.GetState())
+	require.Equal(t, "select * from persistenceDemo", retained.GetRule().Sql)
 }
 
 func TestCoverage(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 EMQ Technologies Co., Ltd.
+// Copyright 2022-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ import (
 	"github.com/lf-edge/ekuiper/v2/pkg/cast"
 	"github.com/lf-edge/ekuiper/v2/pkg/cert"
 	"github.com/lf-edge/ekuiper/v2/pkg/connection"
+	"github.com/lf-edge/ekuiper/v2/pkg/infra"
 	"github.com/lf-edge/ekuiper/v2/pkg/model"
 	"github.com/lf-edge/ekuiper/v2/pkg/modules"
 	"github.com/lf-edge/ekuiper/v2/pkg/tracer"
@@ -75,6 +76,47 @@ var newNetListener = newTcpListener
 func newTcpListener(addr string, logger *logrus.Logger) (net.Listener, error) {
 	logger.Info("using ListenMode 'http'")
 	return net.Listen("tcp", addr)
+}
+
+func startLoadedRules(ctx context.Context, rr *RuleRegistry, names []string) {
+	logger.Info("Starting loaded rules in background")
+	for _, name := range names {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		rs, ok := rr.load(name)
+		if !ok {
+			continue
+		}
+		if panicOrError := infra.SafeRun(func() error {
+			return rs.StartIfLoaded()
+		}); panicOrError != nil {
+			logger.Errorf("Rule %s start failed: %s", name, panicOrError)
+		}
+	}
+}
+
+// startRestService binds the REST socket before returning, then serves it in
+// the background. Callers may start deferred work only after this succeeds.
+func startRestService(srvRest *http.Server) (net.Listener, error) {
+	ln, err := newNetListener(srvRest.Addr, logger)
+	if err != nil {
+		return nil, err
+	}
+	go func() {
+		var serveErr error
+		if conf.Config.Basic.RestTls == nil {
+			serveErr = srvRest.Serve(ln)
+		} else {
+			serveErr = srvRest.ServeTLS(ln, conf.Config.Basic.RestTls.Certfile, conf.Config.Basic.RestTls.Keyfile)
+		}
+		if serveErr != nil && serveErr != http.ErrServerClosed {
+			logger.Fatal("Error serving rest service: ", serveErr)
+		}
+	}()
+	return ln, nil
 }
 
 func stopEKuiper() {
@@ -261,44 +303,44 @@ func StartUp(Version string) {
 	registry = &RuleRegistry{internal: make(map[string]*rule.State)}
 	// Start lookup tables
 	streamProcessor.RecoverLookupTable()
-	// Start rules
+	// Load rules into the registry without planning them.
+	var triggeredRules []string
 	if rules, err := ruleProcessor.GetAllRules(); err != nil {
-		logger.Infof("Start rules error: %s", err)
+		logger.Infof("Load rules error: %s", err)
 	} else {
-		logger.Info("Starting rules")
-		var reply string
+		logger.Info("Loading rules")
 		for _, name := range rules {
-			rule, err := ruleProcessor.GetRuleById(name)
+			r, err := ruleProcessor.GetRuleById(name)
 			if err != nil {
 				logger.Error(err)
 				continue
 			}
-			reply = registry.RecoverRule(rule)
-			if len(reply) != 0 {
+			if reply := registry.LoadRule(r); len(reply) != 0 {
 				logger.Info(reply)
+			}
+			if r.Triggered {
+				triggeredRules = append(triggeredRules, r.Id)
 			}
 		}
 	}
-	go runScheduleRuleChecker(serverCtx)
 	metrics.InitMetricsDumpJob(serverCtx)
 	async.InitManager()
 
 	// Start rest service
+	stopSignal = make(chan struct{})
 	srvRest := createRestServer(conf.Config.Basic.RestIp, conf.Config.Basic.RestPort, conf.Config.Basic.Authentication)
+	_, listenErr := startRestService(srvRest)
+	if listenErr != nil {
+		panic(listenErr)
+	}
+
+	// The REST socket is bound before any deferred planning starts.
+	go runScheduleRuleChecker(serverCtx)
+	var ruleRecoveryWg sync.WaitGroup
+	ruleRecoveryWg.Add(1)
 	go func() {
-		var err error
-		ln, listenErr := newNetListener(srvRest.Addr, logger)
-		if listenErr != nil {
-			panic(listenErr)
-		}
-		if conf.Config.Basic.RestTls == nil {
-			err = srvRest.Serve(ln)
-		} else {
-			err = srvRest.ServeTLS(ln, conf.Config.Basic.RestTls.Certfile, conf.Config.Basic.RestTls.Keyfile)
-		}
-		if err != nil && err != http.ErrServerClosed {
-			logger.Fatal("Error serving rest service: ", err)
-		}
+		defer ruleRecoveryWg.Done()
+		startLoadedRules(serverCtx, registry, triggeredRules)
 	}()
 
 	// Start extend services
@@ -314,7 +356,6 @@ func StartUp(Version string) {
 	if conf.Config.Basic.RestTls != nil {
 		restHttpType = "https"
 	}
-	stopSignal = make(chan struct{})
 	msg := fmt.Sprintf("Serving kuiper (version - %s) on port %d, and restful api on %s://%s.", Version, conf.Config.Basic.Port, restHttpType, cast.JoinHostPortInt(conf.Config.Basic.RestIp, conf.Config.Basic.RestPort))
 	logger.Info(msg)
 	fmt.Println(msg)
@@ -343,6 +384,7 @@ func StartUp(Version string) {
 			logger.Errorf("rest server shutdown error: %v", err)
 		}
 		logger.Info("rest server successfully shutdown.")
+		ruleRecoveryWg.Wait()
 		wg := sync.WaitGroup{}
 		wg.Add(1)
 		go func() {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -98,9 +98,13 @@ func startLoadedRules(ctx context.Context, rr *RuleRegistry, names []string) {
 	}
 }
 
-// startRestService binds the REST socket before returning, then serves it in
-// the background. Callers may start deferred work only after this succeeds.
+// startRestService initializes REST management dependencies, binds the socket
+// before returning, then serves it in the background. Callers may start
+// deferred work only after this succeeds.
 func startRestService(srvRest *http.Server) (net.Listener, error) {
+	// Configuration endpoints read managers without synchronization, so all
+	// managers must be registered before the listener accepts requests.
+	InitConfManagers()
 	ln, err := newNetListener(srvRest.Addr, logger)
 	if err != nil {
 		return nil, err
@@ -348,9 +352,6 @@ func StartUp(Version string) {
 		logger.Infof("start service %s", k)
 		v.serve()
 	}
-	// Register conf managers
-	InitConfManagers()
-
 	// Startup message
 	restHttpType := "http"
 	if conf.Config.Basic.RestTls != nil {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 EMQ Technologies Co., Ltd.
+// Copyright 2023-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strconv"
 	"testing"
 	"time"
@@ -25,6 +26,7 @@ import (
 
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/schedule"
+	"github.com/lf-edge/ekuiper/v2/internal/topo/rule"
 	"github.com/lf-edge/ekuiper/v2/internal/topo/rule/machine"
 	"github.com/lf-edge/ekuiper/v2/pkg/cast"
 )
@@ -202,4 +204,30 @@ func TestRunScheduleRuleChecker(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	cancel()
 	<-done
+}
+
+func TestRestAvailableWithLoadedRules(t *testing.T) {
+	loaded := rule.NewLoadedState(def.GetDefaultRule("restLoaded", "select * from demo"), func(string, bool) {})
+	defer loaded.Delete()
+
+	srv := &http.Server{
+		Addr: "127.0.0.1:0",
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	}
+	ln, err := startRestService(srv)
+	require.NoError(t, err)
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.NoError(t, srv.Shutdown(ctx))
+	}()
+
+	client := &http.Client{Timeout: time.Second}
+	resp, err := client.Get("http://" + ln.Addr().String() + "/ping")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, machine.Loaded, loaded.GetState())
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -209,10 +209,21 @@ func TestRunScheduleRuleChecker(t *testing.T) {
 func TestRestAvailableWithLoadedRules(t *testing.T) {
 	loaded := rule.NewLoadedState(def.GetDefaultRule("restLoaded", "select * from demo"), func(string, bool) {})
 	defer loaded.Delete()
+	originalManagers := managers
+	managers = make(map[string]ConfManager)
+	t.Cleanup(func() { managers = originalManagers })
 
 	srv := &http.Server{
 		Addr: "127.0.0.1:0",
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			for name, component := range components {
+				if _, exportsConfig := component.(confExporter); exportsConfig {
+					if _, registered := managers[name]; !registered {
+						w.WriteHeader(http.StatusServiceUnavailable)
+						return
+					}
+				}
+			}
 			w.WriteHeader(http.StatusOK)
 		}),
 	}

--- a/internal/topo/rule/action.go
+++ b/internal/topo/rule/action.go
@@ -31,12 +31,11 @@ func (s *State) doValidateAndRun(newRule *def.Rule) (err error) {
 	if err != nil {
 		return err
 	}
-	// stop the old run
-	if s.topology != nil {
-		s.doStop(machine.Stopped, "stopped by update")
-	}
-	// start new rule
 	if newRule.Triggered {
+		// Stop the old run before starting the replacement.
+		if s.topology != nil {
+			s.doStop(machine.Stopped, "stopped by update")
+		}
 		s.topology = tp
 		panicOrError := infra.SafeRun(func() error {
 			// Start the rule which runs async
@@ -46,8 +45,10 @@ func (s *State) doValidateAndRun(newRule *def.Rule) (err error) {
 			s.logger.Errorf("Rule %s start failed: %s", s.Rule.Id, panicOrError)
 		}
 	} else {
-		// Discard the temp topo
+		// Discard the validation topology and use the normal stop path for
+		// both running rules and loaded rules that have not been planned yet.
 		tp.Cancel()
+		s.doStop(machine.Stopped, "stopped by update")
 	}
 	return nil
 }

--- a/internal/topo/rule/machine/state_machine.go
+++ b/internal/topo/rule/machine/state_machine.go
@@ -28,6 +28,7 @@ const (
 	Stopping
 	ScheduledStop
 	StoppedByErr
+	Loaded
 )
 
 var StateName = map[RunState]string{
@@ -37,6 +38,7 @@ var StateName = map[RunState]string{
 	Stopping:      "stopping",
 	ScheduledStop: "stopped: waiting for next schedule.",
 	StoppedByErr:  "stopped by error",
+	Loaded:        "loaded",
 }
 
 type StateMachine struct {
@@ -50,10 +52,10 @@ type StateMachine struct {
 	logger             api.Logger
 }
 
-func NewStateMachine(logger api.Logger) StateMachine {
+func NewStateMachine(logger api.Logger, initialState RunState) StateMachine {
 	return StateMachine{
 		actionQ:      make([]ActionSignal, 0),
-		currentState: Stopped,
+		currentState: initialState,
 		logger:       logger,
 	}
 }
@@ -82,7 +84,7 @@ func (s *StateMachine) TriggerAction(action ActionSignal) bool {
 			s.actionQ = append(s.actionQ, ActionSignalStart)
 			s.logger.Infof("defer start action to action queue because current RunState is stopping")
 			return true
-		case Stopped, StoppedByErr:
+		case Stopped, StoppedByErr, Loaded:
 			s.currentState = Starting
 			return false
 		}
@@ -95,13 +97,13 @@ func (s *StateMachine) TriggerAction(action ActionSignal) bool {
 			s.actionQ = append(s.actionQ, action)
 			s.logger.Infof("defer stop action to action queue because current RunState is starting")
 			return true
-		case Running, ScheduledStop: // do stop
+		case Running, ScheduledStop, Loaded: // do stop
 			s.currentState = Stopping
 			return false
 		}
 	case ActionSignalScheduledStart:
 		switch ss {
-		case ScheduledStop, Stopped, StoppedByErr:
+		case ScheduledStop, Stopped, StoppedByErr, Loaded:
 			s.currentState = Starting
 			return false
 		case Starting, Running:
@@ -114,7 +116,7 @@ func (s *StateMachine) TriggerAction(action ActionSignal) bool {
 		}
 	case ActionSignalScheduledStop:
 		switch ss {
-		case Running:
+		case Running, Loaded:
 			s.currentState = Stopping
 			return false
 		case ScheduledStop, Stopped, StoppedByErr:
@@ -126,6 +128,18 @@ func (s *StateMachine) TriggerAction(action ActionSignal) bool {
 			return true
 		}
 	}
+	return false
+}
+
+// TriggerStartIfLoaded atomically changes Loaded to Starting. It returns true
+// when another lifecycle operation has already moved the rule out of Loaded.
+func (s *StateMachine) TriggerStartIfLoaded() bool {
+	s.Lock()
+	defer s.Unlock()
+	if s.currentState != Loaded {
+		return true
+	}
+	s.currentState = Starting
 	return false
 }
 

--- a/internal/topo/rule/state.go
+++ b/internal/topo/rule/state.go
@@ -55,16 +55,28 @@ type State struct {
 	stoppedMetrics []any
 	// State machine
 	sm machine.StateMachine
+	// deleted prevents a State removed from the registry from being started by
+	// a goroutine that retained the old pointer.
+	deleted bool
 }
 
 // NewState provision a state instance only.
 // Do not plan or run as before. If the Rule is not triggered, do not plan or run.
 // When called by recover Rule, expect
 func NewState(rule *def.Rule, updateTriggerFunc func(string, bool)) *State {
+	return newState(rule, updateTriggerFunc, machine.Stopped)
+}
+
+// NewLoadedState creates a registered rule that is waiting for deferred startup planning.
+func NewLoadedState(rule *def.Rule, updateTriggerFunc func(string, bool)) *State {
+	return newState(rule, updateTriggerFunc, machine.Loaded)
+}
+
+func newState(rule *def.Rule, updateTriggerFunc func(string, bool), initialState machine.RunState) *State {
 	contextLogger := conf.Log.WithField("Rule", rule.Id)
 	return &State{
 		Rule:          rule,
-		sm:            machine.NewStateMachine(contextLogger),
+		sm:            machine.NewStateMachine(contextLogger, initialState),
 		logger:        contextLogger,
 		updateTrigger: updateTriggerFunc,
 	}
@@ -94,12 +106,18 @@ func (s *State) SetRule(r *def.Rule) {
 func (s *State) ValidateAndRun(newRule *def.Rule) error {
 	s.ruleLock.Lock()
 	defer s.ruleLock.Unlock()
+	if s.deleted {
+		return s.deletedError()
+	}
 	return s.doValidateAndRun(newRule)
 }
 
 func (s *State) Bootstrap() error {
 	s.ruleLock.Lock()
 	defer s.ruleLock.Unlock()
+	if s.deleted {
+		return s.deletedError()
+	}
 	s.Rule.Triggered = true
 	return s.doValidateAndRun(s.Rule)
 }
@@ -114,11 +132,30 @@ func (s *State) Start() error {
 	}
 	s.ruleLock.Lock()
 	defer s.ruleLock.Unlock()
+	if s.deleted {
+		return s.deletedError()
+	}
 	// Bootstrap may have completed the start while this call was waiting for ruleLock.
 	if s.sm.CurrentState() != machine.Starting {
 		return nil
 	}
 	// delegate to rule patrol checker
+	if s.Rule.IsScheduleRule() {
+		s.transitState(machine.ScheduledStop, "")
+		return nil
+	}
+	return s.doStart()
+}
+
+// StartIfLoaded plans and starts a recovered rule only while it is still in
+// Loaded state. The rule lock makes this decision atomic with delete, update,
+// and explicit API start operations.
+func (s *State) StartIfLoaded() error {
+	s.ruleLock.Lock()
+	defer s.ruleLock.Unlock()
+	if s.deleted || s.sm.TriggerStartIfLoaded() {
+		return nil
+	}
 	if s.Rule.IsScheduleRule() {
 		s.transitState(machine.ScheduledStop, "")
 		return nil
@@ -133,6 +170,9 @@ func (s *State) ScheduleStart() error {
 	}
 	s.ruleLock.Lock()
 	defer s.ruleLock.Unlock()
+	if s.deleted {
+		return s.deletedError()
+	}
 	// Bootstrap may have completed the start while this call was waiting for ruleLock.
 	if s.sm.CurrentState() != machine.Starting {
 		return nil
@@ -174,11 +214,16 @@ func (s *State) StopWithLastWill(msg string) {
 func (s *State) Delete() {
 	s.ruleLock.Lock()
 	defer s.ruleLock.Unlock()
+	s.deleted = true
 	if s.topology != nil {
 		s.topology.Cancel()
 		s.topology.RemoveMetrics()
 		s.topology = nil
 	}
+}
+
+func (s *State) deletedError() error {
+	return errorx.NewWithCode(errorx.NOT_FOUND, fmt.Sprintf("Rule %s has been deleted", s.Rule.Id))
 }
 
 func (s *State) GetState() machine.RunState {

--- a/internal/topo/rule/state_test.go
+++ b/internal/topo/rule/state_test.go
@@ -425,6 +425,20 @@ func TestLoadedStateLifecycle(t *testing.T) {
 		require.Same(t, topology, st.topology)
 	})
 
+	t.Run("disabled update prevents deferred start", func(t *testing.T) {
+		st := NewLoadedState(def.GetDefaultRule("loadedDisable", "select * from loadedDemo"), func(string, bool) {})
+		defer st.Delete()
+		updated := def.GetDefaultRule("loadedDisable", "select * from loadedDemo")
+		updated.Triggered = false
+		require.NoError(t, st.ValidateAndRun(updated))
+		require.Equal(t, machine.Stopped, st.GetState())
+		require.Nil(t, st.topology)
+
+		require.NoError(t, st.StartIfLoaded())
+		require.Equal(t, machine.Stopped, st.GetState())
+		require.Nil(t, st.topology)
+	})
+
 	t.Run("scheduled rule waits for patrol", func(t *testing.T) {
 		r := def.GetDefaultRule("loadedSchedule", "select * from loadedDemo")
 		r.Options.Cron = "* * * * *"

--- a/internal/topo/rule/state_test.go
+++ b/internal/topo/rule/state_test.go
@@ -330,3 +330,110 @@ func TestStartRechecksStateAfterLock(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadedStateLifecycle(t *testing.T) {
+	sp := processor.NewStreamProcessor()
+	_, err := sp.ExecStmt(`CREATE STREAM loadedDemo () WITH (FORMAT="JSON", TYPE="memory", DATASOURCE="test")`)
+	require.NoError(t, err)
+	defer sp.ExecStmt(`DROP STREAM loadedDemo`)
+
+	t.Run("status and deferred start", func(t *testing.T) {
+		st := NewLoadedState(def.GetDefaultRule("loadedStart", "select * from loadedDemo"), func(string, bool) {})
+		defer st.Delete()
+		require.Equal(t, machine.Loaded, st.GetState())
+		require.Contains(t, st.GetStatusMessage(), `"status": "loaded"`)
+		require.Nil(t, st.topology)
+
+		require.NoError(t, st.StartIfLoaded())
+		require.Equal(t, machine.Running, st.GetState())
+		require.NotNil(t, st.topology)
+	})
+
+	t.Run("stop prevents deferred start", func(t *testing.T) {
+		st := NewLoadedState(def.GetDefaultRule("loadedStop", "select * from loadedDemo"), func(string, bool) {})
+		defer st.Delete()
+		st.Stop()
+		require.Equal(t, machine.Stopped, st.GetState())
+
+		require.NoError(t, st.StartIfLoaded())
+		require.Equal(t, machine.Stopped, st.GetState())
+		require.Nil(t, st.topology)
+	})
+
+	t.Run("concurrent stop wins before planning", func(t *testing.T) {
+		st := NewLoadedState(def.GetDefaultRule("loadedConcurrentStop", "select * from loadedDemo"), func(string, bool) {})
+		defer st.Delete()
+		st.ruleLock.Lock()
+		locked := true
+		defer func() {
+			if locked {
+				st.ruleLock.Unlock()
+			}
+		}()
+		stopDone := make(chan struct{})
+		go func() {
+			defer close(stopDone)
+			st.Stop()
+		}()
+		require.Eventually(t, func() bool {
+			return st.GetState() == machine.Stopping
+		}, time.Second, time.Millisecond)
+		startDone := make(chan error, 1)
+		go func() {
+			startDone <- st.StartIfLoaded()
+		}()
+		st.ruleLock.Unlock()
+		locked = false
+
+		<-stopDone
+		require.NoError(t, <-startDone)
+		require.Equal(t, machine.Stopped, st.GetState())
+		require.Nil(t, st.topology)
+	})
+
+	t.Run("delete invalidates retained pointer", func(t *testing.T) {
+		st := NewLoadedState(def.GetDefaultRule("loadedDelete", "select * from loadedDemo"), func(string, bool) {})
+		st.Delete()
+		require.True(t, st.deleted)
+
+		require.NoError(t, st.StartIfLoaded())
+		require.Nil(t, st.topology)
+		require.ErrorContains(t, st.Bootstrap(), "has been deleted")
+	})
+
+	t.Run("explicit start wins", func(t *testing.T) {
+		st := NewLoadedState(def.GetDefaultRule("loadedExplicit", "select * from loadedDemo"), func(string, bool) {})
+		defer st.Delete()
+		require.NoError(t, st.Bootstrap())
+		require.Equal(t, machine.Running, st.GetState())
+		topology := st.topology
+
+		require.NoError(t, st.StartIfLoaded())
+		require.Same(t, topology, st.topology)
+	})
+
+	t.Run("update wins", func(t *testing.T) {
+		st := NewLoadedState(def.GetDefaultRule("loadedUpdate", "select * from loadedDemo"), func(string, bool) {})
+		defer st.Delete()
+		updated := def.GetDefaultRule("loadedUpdate", "select * from loadedDemo where true")
+		updated.Triggered = true
+		require.NoError(t, st.ValidateAndRun(updated))
+		require.Equal(t, machine.Running, st.GetState())
+		topology := st.topology
+
+		require.NoError(t, st.StartIfLoaded())
+		require.Same(t, topology, st.topology)
+	})
+
+	t.Run("scheduled rule waits for patrol", func(t *testing.T) {
+		r := def.GetDefaultRule("loadedSchedule", "select * from loadedDemo")
+		r.Options.Cron = "* * * * *"
+		r.Options.Duration = "2s"
+		st := NewLoadedState(r, func(string, bool) {})
+		defer st.Delete()
+
+		require.NoError(t, st.StartIfLoaded())
+		require.Equal(t, machine.ScheduledStop, st.GetState())
+		require.Nil(t, st.topology)
+	})
+}


### PR DESCRIPTION
## Summary
- Load persisted rules into the registry before planning their topologies.
- Expose the REST management API first, then plan and start triggered rules sequentially in the background.
- Add the public `loaded` rule status and document the updated startup-readiness contract.

## Why
- With many persisted rules, topology planning blocks REST startup once per rule. As a result, eKuiper may be running but its management API remains unavailable for a long time.
- This change separates lightweight rule loading from expensive topology planning. `/ping` now becomes available after the management plane is ready, while rule recovery continues in the background.
- Lifecycle coordination ensures that a stop, delete, update, or explicit start received during recovery is not overwritten by the background worker.

## Changes In This PR
- Add a `Loaded` state and a conditional `StartIfLoaded` transition for deferred recovery.
- Register all persisted rules first and bind the REST listener before starting the recovery worker or schedule patrol.
- Cancel deferred recovery during shutdown and wait for the active recovery operation before stopping rules.
- Cover deferred start, planning failure isolation, cancellation, REST availability, and concurrent stop/delete/update/start behavior with race-enabled tests.
- Document `/ping`, rule startup states, and how clients can wait for all rules to finish recovery in English and Chinese.

## Notes
- `/ping` indicates that the REST management API is ready; it does not mean every persisted rule has finished planning.
- Clients that require all rules to finish startup recovery can poll `GET /rules` until no rule is in `loaded` or `starting` state.
- A planning failure affects only that rule, which moves to `stopped by error`; recovery continues with the remaining rules.
