### PR TITLE
fix(sqlgen): order by index columns

### DIFF
--- a/extensions/impl/sql/sqldatabase/sqlgen/commonSqlDialect.go
+++ b/extensions/impl/sql/sqldatabase/sqlgen/commonSqlDialect.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 EMQ Technologies Co., Ltd.
+// Copyright 2022-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@ type CommonQueryGenerator struct {
 	*InternalSqlQueryCfg
 }
 
-func (q *CommonQueryGenerator) quoteIdentifier(identifier string) string {
-	return "'" + identifier + "'"
+func (q *CommonQueryGenerator) quoteValue(value string) string {
+	return "'" + value + "'"
 }
 
 func (q *CommonQueryGenerator) getSelect() string {
@@ -35,11 +35,11 @@ func (q *CommonQueryGenerator) getSelect() string {
 }
 
 func (q *CommonQueryGenerator) getCondition() (string, error) {
-	return getCondition(q.InternalSqlQueryCfg, q.quoteIdentifier)
+	return getCondition(q.InternalSqlQueryCfg, q.quoteValue)
 }
 
 func (q *CommonQueryGenerator) getOrderby() string {
-	return getOrderBy(q.InternalSqlQueryCfg, q.quoteIdentifier)
+	return getOrderBy(q.InternalSqlQueryCfg)
 }
 
 func (q *CommonQueryGenerator) getLimit() string {
@@ -96,13 +96,13 @@ func (q *OracleQueryGenerate) UpdateMaxIndexValue(row map[string]interface{}) {
 	q.CommonQueryGenerator.UpdateMaxIndexValue(row)
 }
 
-func getCondition(cfg *InternalSqlQueryCfg, quoteIdentifier func(string) string) (string, error) {
+func getCondition(cfg *InternalSqlQueryCfg, quoteValue func(string) string) (string, error) {
 	fieldlist := cfg.store.GetFieldList()
 	if len(fieldlist) > 0 {
 		b := bytes.NewBufferString("where")
 		index := 0
 		for _, w := range fieldlist {
-			condition, err := buildSingleIndexCondition(w, quoteIdentifier)
+			condition, err := buildSingleIndexCondition(w, quoteValue)
 			if err != nil {
 				return "", err
 			}
@@ -119,7 +119,7 @@ func getCondition(cfg *InternalSqlQueryCfg, quoteIdentifier func(string) string)
 	return "", nil
 }
 
-func buildSingleIndexCondition(w *store.IndexField, quoteIdentifier func(string) string) (string, error) {
+func buildSingleIndexCondition(w *store.IndexField, quoteValue func(string) string) (string, error) {
 	var val string
 	if w.IndexFieldDataType == DATETIME_TYPE && w.IndexFieldDateTimeFormat != "" {
 		t, err := cast.InterfaceToTime(w.IndexFieldValue, w.IndexFieldDateTimeFormat)
@@ -135,16 +135,16 @@ func buildSingleIndexCondition(w *store.IndexField, quoteIdentifier func(string)
 	} else {
 		val = fmt.Sprintf("%v", w.IndexFieldValue)
 	}
-	return w.IndexFieldName + " > " + quoteIdentifier(val), nil
+	return w.IndexFieldName + " > " + quoteValue(val), nil
 }
 
-func getOrderBy(cfg *InternalSqlQueryCfg, quoteIdentifier func(string) string) string {
+func getOrderBy(cfg *InternalSqlQueryCfg) string {
 	fieldList := cfg.store.GetFieldList()
 	if len(fieldList) > 0 {
 		b := bytes.NewBufferString("order by")
 		for i, w := range fieldList {
 			b.WriteString(" ")
-			orderBy := buildSingleOrderBy(w, quoteIdentifier)
+			orderBy := buildSingleOrderBy(w)
 			b.WriteString(orderBy)
 			if i < len(fieldList)-1 {
 				b.WriteString(",")
@@ -155,8 +155,8 @@ func getOrderBy(cfg *InternalSqlQueryCfg, quoteIdentifier func(string) string) s
 	return ""
 }
 
-func buildSingleOrderBy(w *store.IndexField, quoteIdentifier func(string) string) string {
-	return quoteIdentifier(w.IndexFieldName) + " ASC"
+func buildSingleOrderBy(w *store.IndexField) string {
+	return w.IndexFieldName + " ASC"
 }
 
 func updateMaxIndexValue(cfg *InternalSqlQueryCfg, row map[string]interface{}) {

--- a/extensions/impl/sql/sqldatabase/sqlgen/sqlServerDialect.go
+++ b/extensions/impl/sql/sqldatabase/sqlgen/sqlServerDialect.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 EMQ Technologies Co., Ltd.
+// Copyright 2022-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ type SqlServerQueryGenerator struct {
 	*InternalSqlQueryCfg
 }
 
-func (q *SqlServerQueryGenerator) quoteIdentifier(identifier string) string {
-	return "'" + identifier + "'"
+func (q *SqlServerQueryGenerator) quoteValue(value string) string {
+	return "'" + value + "'"
 }
 
 func (q *SqlServerQueryGenerator) getSelect() string {
@@ -35,13 +35,11 @@ func (q *SqlServerQueryGenerator) getSelect() string {
 }
 
 func (q *SqlServerQueryGenerator) getCondition() (string, error) {
-	return getCondition(q.InternalSqlQueryCfg, q.quoteIdentifier)
+	return getCondition(q.InternalSqlQueryCfg, q.quoteValue)
 }
 
 func (q *SqlServerQueryGenerator) getOrderby() string {
-	return getOrderBy(q.InternalSqlQueryCfg, func(s string) string {
-		return s
-	})
+	return getOrderBy(q.InternalSqlQueryCfg)
 }
 
 func NewSqlServerQuery(cfg *InternalSqlQueryCfg) SqlQueryGenerator {

--- a/extensions/impl/sql/sqldatabase/sqlgen/sqlServerDialect_test.go
+++ b/extensions/impl/sql/sqldatabase/sqlgen/sqlServerDialect_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 EMQ Technologies Co., Ltd.
+// Copyright 2022-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -141,6 +141,21 @@ func TestInternalQuery(t *testing.T) {
 	}
 }
 
+func TestCommonQueryOrderByColumn(t *testing.T) {
+	cfg := &InternalSqlQueryCfg{
+		Table: "table",
+		Limit: 10,
+		store: store.NewIndexFieldWrap(&store.IndexField{
+			IndexFieldName:  "responseTime",
+			IndexFieldValue: 10,
+		}),
+	}
+
+	query, err := NewCommonSqlQuery(cfg).SqlQueryStatement()
+	require.NoError(t, err)
+	require.Equal(t, "select * from table where responseTime > '10' order by responseTime ASC limit 10", query)
+}
+
 func TestGenerateSQLWithMultiIndex(t *testing.T) {
 	testcases := []struct {
 		cfg *InternalSqlQueryCfg
@@ -159,7 +174,7 @@ func TestGenerateSQLWithMultiIndex(t *testing.T) {
 						IndexFieldValue: 2,
 					}),
 			},
-			sql: `select * from t where col1 > '1' AND col2 > '2' order by 'col1' ASC, 'col2' ASC`,
+			sql: `select * from t where col1 > '1' AND col2 > '2' order by col1 ASC, col2 ASC`,
 		},
 		{
 			cfg: &InternalSqlQueryCfg{
@@ -174,7 +189,7 @@ func TestGenerateSQLWithMultiIndex(t *testing.T) {
 						IndexFieldValue: 1,
 					}),
 			},
-			sql: `select * from t where col2 > '2' AND col1 > '1' order by 'col2' ASC, 'col1' ASC`,
+			sql: `select * from t where col2 > '2' AND col1 > '1' order by col2 ASC, col1 ASC`,
 		},
 		{
 			cfg: &InternalSqlQueryCfg{
@@ -190,7 +205,7 @@ func TestGenerateSQLWithMultiIndex(t *testing.T) {
 						IndexFieldValue: 1,
 					}),
 			},
-			sql: `select * from t where col2 > '2' AND col1 > '1' order by 'col2' ASC, 'col1' ASC limit 3`,
+			sql: `select * from t where col2 > '2' AND col1 > '1' order by col2 ASC, col1 ASC limit 3`,
 		},
 		{
 			cfg: &InternalSqlQueryCfg{


### PR DESCRIPTION
## Summary

- Generate `ORDER BY` clauses from the configured index columns instead of single-quoted string literals.
- Keep single-quote handling limited to index values used by the generated `WHERE` conditions.
- Add regression coverage for single- and multi-index Common SQL queries.

## Why

The Common SQL generator reused one quoting callback for two different SQL concepts. It correctly wrapped an index value as `'10'` in the `WHERE` clause, but also wrapped the index column as `'responseTime'` in the `ORDER BY` clause.

Databases interpret `'responseTime'` as a constant string, not a column. The query may therefore run without sorting. SQL source pagination assumes ascending rows and stores the last row's index as the next offset; arbitrary row order can make later polls skip unseen rows or read rows again.

## Changes In This PR

- Rename the value callback to describe its actual responsibility.
- Remove value quoting from `getOrderBy` and emit each configured index column unchanged, matching its use on the left side of the generated `WHERE` clause.
- Simplify the SQL Server path to use the same column-ordering builder; its generated SQL remains unchanged.
- Update the existing multi-index expectations and add a focused single-index regression test that distinguishes `'10'` from `responseTime`.

## Notes

- The fix affects generated `internalSqlQueryCfg` queries for Common and Oracle SQL source paths.
- SQL Server already emitted unquoted ORDER BY columns, so this is a refactor-only change for that dialect.
- Template SQL queries are unchanged.
- The existing English and Chinese documentation already show the intended unquoted ORDER BY syntax.
- The branch contains one signed-off commit based on the latest `master`.
- Verified with `go test ./extensions/impl/sql/... -count=1`, `go test -race ./extensions/impl/sql/sqldatabase/sqlgen -count=1`, `go vet ./extensions/impl/sql/sqldatabase/sqlgen`, `golangci-lint run ./extensions/impl/sql/sqldatabase/sqlgen/...`, and `git diff --check`.
