### PR TITLE
feat(planner): validate memory stream slice

### DIFF
--- a/internal/topo/planner/planner_source.go
+++ b/internal/topo/planner/planner_source.go
@@ -35,7 +35,8 @@ import (
 
 func transformSourceNode(ctx api.StreamContext, t *DataSourcePlan, mockSourcesProp map[string]map[string]any, ruleId string, options *def.RuleOption, index int) (node.DataSourceNode, []node.OperatorNode, int, error) {
 	isSchemaless := t.isSchemaless
-	if t.streamFields == nil && options.Experiment != nil && options.Experiment.UseSliceTuple {
+	isSliceMode := options.Experiment != nil && options.Experiment.UseSliceTuple
+	if t.streamFields == nil && isSliceMode {
 		return nil, nil, 0, errors.New("slice tuple mode does not support wildcard/schemaless")
 	}
 	emitterName := t.name
@@ -54,6 +55,9 @@ func transformSourceNode(ctx api.StreamContext, t *DataSourcePlan, mockSourcesPr
 			strType = "file"
 		}
 		t.streamStmt.Options.TYPE = strType
+	}
+	if strType == "memory" && isSliceMode {
+		return nil, nil, 0, errors.New("slice tuple mode does not support memory source")
 	}
 	si, err := io.Source(strType)
 	if err != nil {

--- a/internal/topo/planner/planner_source_test.go
+++ b/internal/topo/planner/planner_source_test.go
@@ -540,6 +540,27 @@ func TestPlanError(t *testing.T) {
 	}
 }
 
+func TestPlanMemorySourceInSliceMode(t *testing.T) {
+	kv, err := store.GetKV("stream")
+	require.NoError(t, err)
+
+	const streamName = "sliceMemorySource"
+	stream, err := json.Marshal(&xsql.StreamInfo{
+		StreamType: ast.TypeStream,
+		Statement:  `CREATE STREAM sliceMemorySource (id BIGINT) WITH (DATASOURCE="sliceMemorySource", FORMAT="json", TYPE="memory");`,
+	})
+	require.NoError(t, err)
+	require.NoError(t, kv.Set(streamName, string(stream)))
+	t.Cleanup(func() {
+		require.NoError(t, kv.Delete(streamName))
+	})
+
+	rule := def.GetDefaultRule("sliceMemorySourceRule", "SELECT id FROM "+streamName)
+	rule.Options.Experiment.UseSliceTuple = true
+	_, _, err = PlanSQLWithSourcesAndSinks(rule, nil)
+	require.EqualError(t, err, "slice tuple mode does not support memory source")
+}
+
 func TestPlanLookup(t *testing.T) {
 	ctx := mockContext.NewMockContext("Test", "test")
 	t.Run("undefined source", func(t *testing.T) {


### PR DESCRIPTION
Ports commit 7c0dc9e from emqx/lfek.

## Summary
- Reject slice tuple rules that consume memory streams during planning.
- Return a clear validation error before the incompatible topology is created.

## Why
- Memory sources pass map-based tuples through directly, which is incompatible with the tuple representation expected by slice mode.
- Validating this combination during planning prevents rules from starting with a topology that cannot process memory stream data correctly.

## Changes In This PR
- Reuse the computed slice-mode flag while transforming source nodes.
- Reject `TYPE="memory"` sources when `useSliceTuple` is enabled.
- Add a planner regression test using a memory stream with an explicit schema.

## Notes
- Non-slice rules using memory streams are unaffected.
- Validated with `go test ./internal/topo/planner -count=1`.

Original commit: https://github.com/emqx/lfek/commit/7c0dc9e5c1c7a43b33a0b4c14bcce1bd948dcb4f