### PR TITLE
fix: validate rule id at DeleteRule boundary

### DIFF
--- a/internal/server/rule_manager.go
+++ b/internal/server/rule_manager.go
@@ -37,6 +37,7 @@ import (
 	"github.com/lf-edge/ekuiper/v2/pkg/infra"
 	"github.com/lf-edge/ekuiper/v2/pkg/replace"
 	"github.com/lf-edge/ekuiper/v2/pkg/syncx"
+	"github.com/lf-edge/ekuiper/v2/pkg/validate"
 )
 
 // Rule storage includes kv and in memory registry
@@ -231,6 +232,9 @@ func (rr *RuleRegistry) UpsertRule(ruleId, ruleJson string) error {
 }
 
 func (rr *RuleRegistry) DeleteRule(name string) error {
+	if err := validate.ValidateID(name); err != nil {
+		return err
+	}
 	// lock registry and db. rs level has its own lock
 	rs, err := rr.delete(name)
 	if rs != nil {

--- a/internal/server/rule_manager_test.go
+++ b/internal/server/rule_manager_test.go
@@ -15,10 +15,14 @@
 package server
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/lf-edge/ekuiper/v2/internal/conf"
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
 	"github.com/lf-edge/ekuiper/v2/internal/topo/rule"
 	"github.com/lf-edge/ekuiper/v2/pkg/ast"
@@ -52,6 +56,89 @@ func TestErrors(t *testing.T) {
 	registry.register("test", rule.NewState(def.GetDefaultRule("testErrors", "select * from demo"), func(string, bool) {}))
 	err = registry.StartRule("test")
 	assert.EqualError(t, err, "fail to get stream demo, please check if stream is created")
+}
+
+// TestDeleteRuleValidateID ensures that DeleteRule rejects invalid rule ids (path
+// traversal, special characters, empty) before any registry, DB or filesystem
+// mutation happens.
+func TestDeleteRuleValidateID(t *testing.T) {
+	invalidIDs := []string{
+		"../../target",
+		"..",
+		"foo/bar",
+		"a.b",
+		"a b",
+	}
+	for _, id := range invalidIDs {
+		err := registry.DeleteRule(id)
+		require.Error(t, err, "expected validation error for id %q", id)
+	}
+	// Empty id has its own message but must still be rejected.
+	require.Error(t, registry.DeleteRule(""))
+
+	// A path traversal id must report invalid characters.
+	err := registry.DeleteRule("../../target")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid characters")
+
+	// The rejected id must not have mutated the in-memory registry.
+	_, ok := registry.load("../../target")
+	require.False(t, ok)
+}
+
+// TestDeleteRuleMaliciousIDNoSideEffect reproduces the reporter's attack vector:
+// a malicious rule id reaching deleteRuleData, which joins the id onto the data
+// location and calls os.RemoveAll. The fix must reject the id before any
+// filesystem operation, so the sentinel file survives.
+func TestDeleteRuleMaliciousIDNoSideEffect(t *testing.T) {
+	dataLoc, err := conf.GetDataLoc()
+	require.NoError(t, err)
+
+	// "rule_" + this id traverses one level (the ".." cancels "rule_.."), so
+	// deleteRuleData would resolve to dataLoc/<sentinelDir> without validation.
+	maliciousName := "../../malicious_delete_target"
+	targetPath := filepath.Join(dataLoc, "rule_"+maliciousName)
+	require.NoError(t, os.MkdirAll(targetPath, 0o755))
+	sentinel := filepath.Join(targetPath, "sentinel.txt")
+	require.NoError(t, os.WriteFile(sentinel, []byte("sentinel"), 0o644))
+	defer os.RemoveAll(targetPath)
+
+	err = registry.DeleteRule(maliciousName)
+	require.Error(t, err)
+
+	// The sentinel must be intact: no filesystem side effect occurred.
+	data, statErr := os.ReadFile(sentinel)
+	require.NoError(t, statErr)
+	require.Equal(t, "sentinel", string(data))
+}
+
+// TestDeleteRuleValidID ensures that the new validation does not break the
+// normal deletion path for well-formed ids, including the original "not found"
+// semantics for absent rules.
+func TestDeleteRuleValidID(t *testing.T) {
+	streamSQL := `CREATE STREAM valid_delete_stream () WITH (DATASOURCE="valid_delete_stream", TYPE="mqtt")`
+	_, err := streamProcessor.ExecStreamSql(streamSQL)
+	require.NoError(t, err)
+	defer streamProcessor.DropStream("valid_delete_stream", ast.TypeStream)
+
+	ruleID := "valid_delete_rule"
+	ruleJson := `{"trigger":false,"id":"valid_delete_rule","sql":"select * from valid_delete_stream","actions":[{"log":{}}]}`
+	_, err = registry.CreateRule(ruleID, ruleJson)
+	require.NoError(t, err)
+	_, ok := registry.load(ruleID)
+	require.True(t, ok)
+
+	// A valid id must pass validation and delete the rule from registry and DB.
+	require.NoError(t, registry.DeleteRule(ruleID))
+	_, ok = registry.load(ruleID)
+	require.False(t, ok)
+	_, err = ruleProcessor.GetRuleById(ruleID)
+	require.Error(t, err) // gone from KV/DB as well
+
+	// Deleting a non-existent rule keeps the original "not found" semantics.
+	err = registry.DeleteRule(ruleID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
 }
 
 func TestCoverage(t *testing.T) {

--- a/internal/server/yaml_import_export_test.go
+++ b/internal/server/yaml_import_export_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/pingcap/failpoint"
@@ -153,4 +154,49 @@ func TestReplaceConfigurations(t *testing.T) {
 	}, replaceConfigurations("sources.kafka.kafka1", map[string]any{
 		"saslPassword": "123",
 	}))
+}
+
+// TestYamlImportMaliciousRuleID covers the reporter's real attack entry point:
+// YAML import feeds the rules map key directly into registry.DeleteRule and
+// registry.CreateRule. A malicious key must not reach the file deletion logic
+// in deleteRuleData, so the sentinel file placed at the traversed path survives.
+func TestYamlImportMaliciousRuleID(t *testing.T) {
+	conf.InitConf()
+	conf.IsTesting = true
+	connection.InitConnectionManager4Test()
+	for _, v := range components {
+		v.register()
+	}
+	InitConfManagers()
+
+	dataLoc, err := conf.GetDataLoc()
+	require.NoError(t, err)
+
+	// The map key used as the rule id; with the "rule_" prefix it resolves to a
+	// path inside the data location that deleteRuleData would os.RemoveAll.
+	maliciousKey := "../../malicious_yaml_target"
+	targetPath := filepath.Join(dataLoc, "rule_"+maliciousKey)
+	require.NoError(t, os.MkdirAll(targetPath, 0o755))
+	sentinel := filepath.Join(targetPath, "sentinel.txt")
+	require.NoError(t, os.WriteFile(sentinel, []byte("sentinel"), 0o644))
+	defer os.RemoveAll(targetPath)
+
+	yamlContent := []byte(`rules:
+  ../../malicious_yaml_target:
+    sql: SELECT * FROM demo
+    actions:
+      - log: {}
+`)
+	err = importFromByte(yamlContent)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid characters")
+
+	// The sentinel must survive the import attempt: no file deletion occurred.
+	data, statErr := os.ReadFile(sentinel)
+	require.NoError(t, statErr)
+	require.Equal(t, "sentinel", string(data))
+
+	// No malicious rule should have been registered.
+	_, ok := registry.load(maliciousKey)
+	require.False(t, ok)
 }


### PR DESCRIPTION
## Summary
- Validate the rule id with `validate.ValidateID` at the very start of `RuleRegistry.DeleteRule`, before any registry, KV/DB, or filesystem mutation.
- Closes a path-traversal in `deleteRuleData` reachable from YAML import, which passed the rules map key straight to `DeleteRule` without validation.
- Add tests covering invalid ids, file-deletion safety, the YAML import attack vector, and normal delete behavior.

## Why
- YAML rule import (`importRules`) calls `registry.DeleteRule(key)` then `registry.CreateRule(key, ...)` using the rules map key directly, bypassing the interface-level id validation added in PR #3951.
- `DeleteRule` did not validate `name`; `deleteRuleData` joins the unvalidated id onto the data location and calls `os.RemoveAll`, so a malicious map key like `../../target` could delete arbitrary directories under the data location.
- Fix at the unified business boundary (`DeleteRule`) so every caller (REST, RPC, YAML import, internal) is protected without relying on each entry point remembering to validate.

## Changes In This PR

### API and External Behavior Changes

None for external API contracts. REST and RPC already validate the rule id at the interface layer (PR #3951); their responses are unchanged. The change only hardens the internal `DeleteRule` boundary against non-interface callers such as YAML import.

### Internal Implementation Changes

#### `RuleRegistry.DeleteRule` (internal/server/rule_manager.go)
- Added `validate.ValidateID(name)` at the very start of `DeleteRule`, before `rr.delete(name)`, `rs.Delete()`, and `deleteRuleData(name)`, so an invalid id cannot trigger any registry, KV/DB, or filesystem mutation.
- Added the `pkg/validate` import.
- `CreateRule`, `importRules`, REST and RPC handlers are intentionally left unchanged: `CreateRule` already validates via `GetRuleByJson`; `importRules` relies on the now-validated `DeleteRule`/`CreateRule`; interface handlers keep their own validation for early external error responses.
- `path.IsSafeFileComponent` is not restored; `validate.ValidateID` is the single, stricter whitelist standard converged in PR #3951. No filesystem hardening (e.g. `os.Root`) is added in this patch.

#### Tests (internal/server/rule_manager_test.go, internal/server/yaml_import_export_test.go)
- `TestDeleteRuleValidateID`: invalid ids (path traversal, `..`, `/`, `.`, whitespace, empty) are rejected and do not mutate the in-memory registry.
- `TestDeleteRuleMaliciousIDNoSideEffect`: a sentinel file placed at the path `deleteRuleData` would `os.RemoveAll` survives the call, proving no filesystem side effect.
- `TestYamlImportMaliciousRuleID`: imports YAML with a malicious map key (`../../malicious_yaml_target`) via the real `importFromByte` entry point; asserts import fails, the sentinel survives, and no rule is registered.
- `TestDeleteRuleValidID`: valid ids still delete from registry and DB; absent rules keep the original "not found" semantics.

## Notes
- No externally visible API/contract change; REST/RPC already validated, so their responses are unchanged.
- The only semantic change is that `DeleteRule` now returns a validation error for malformed ids instead of `rule <name> not found`; this is the intended security fix.
- Out of scope: `importRules` and `CreateRule` are left unchanged by design (validation lives at `DeleteRule`/`CreateRule`); `os.Root`-based filesystem hardening is a separate hardening effort.

Closes #<issue-number>
