### PR TITLE
refactor(conf): harden default security

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -145,7 +145,10 @@ jobs:
         file: deploy/docker/Dockerfile${{ matrix.suffix }}
     - name: Test docker image
       run: |
-        docker run -d --name ekuiper docker.io/lfedge/ekuiper
+        # REST API binds to 127.0.0.1 by default for security.
+        # Expose it on all interfaces for the smoke test, which reaches it
+        # from the host via the container's bridge network address.
+        docker run -d -e KUIPER__BASIC__RESTIP=0.0.0.0 --name ekuiper docker.io/lfedge/ekuiper
         ip_address=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ekuiper)
         sleep 5
         if ! curl ${ip_address}:9081  >/dev/null 2>&1; then
@@ -259,7 +262,10 @@ jobs:
           plugin_type=$(echo ${PLUGIN%%/*})
           plugin_name=$(echo ${PLUGIN##*/})
           
-          container_id=$(docker run -u 0 -e KUIPER__BASIC__ALLOWEXTERNALFILEACCESS=true -d -v $(pwd)/_plugins:/var/plugins docker.io/lfedge/ekuiper-${{ matrix.os[0] }})
+          # REST API binds to 127.0.0.1 by default for security.
+          # Expose it on all interfaces for the test, which reaches it from
+          # the host via the container's bridge network address.
+          container_id=$(docker run -u 0 -e KUIPER__BASIC__RESTIP=0.0.0.0 -e KUIPER__BASIC__ALLOWEXTERNALFILEACCESS=true -d -v $(pwd)/_plugins:/var/plugins docker.io/lfedge/ekuiper-${{ matrix.os[0] }})
           ip_address=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $container_id)
           os=$(docker exec -i ${container_id} sh -c "sed -n '/^ID=/p' /etc/os-release | sed -r 's/ID=(.*)/\1/g'" )
           sleep 5

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,15 @@
+# Release Notes
+
+## Security hardening
+
+- REST API now binds to localhost by default.
+- CLI service now binds to localhost by default.
+- HTTP data ingestion server now binds to localhost by default.
+- External file access is disabled by default.
+- Production deployments exposing REST API should enable authentication.
+
+> **Behavior change:** By default the REST management API, the CLI service,
+> and the HTTP data ingestion server now listen on `127.0.0.1` only.
+> Remote devices pushing data over HTTP, and remote CLI/REST clients, will no
+> longer be able to connect unless operators explicitly set the relevant bind
+> address (e.g. `0.0.0.0`) and enable authentication where appropriate.

--- a/etc/kuiper.yaml
+++ b/etc/kuiper.yaml
@@ -31,16 +31,20 @@ basic:
   # Maximum log file count
   rotateCount: 3
   # CLI ip
-  ip: 0.0.0.0
+  ip: 127.0.0.1
   # CLI port
   port: 20498
   # REST service ip
-  restIp: 0.0.0.0
+  restIp: 127.0.0.1
   # REST service port
   restPort: 9081
   # The global time zone from the IANA time zone database, or Local if not set.
   timezone: Local
-  # true|false, when true, will check the RSA jwt token for rest api
+  # true|false, when true, will check the RSA JWT token for REST API.
+  #
+  # For local development, authentication can remain disabled.
+  # For production deployments, especially when REST API is exposed
+  # beyond localhost, authentication should be enabled.
   authentication: false
   #  restTls:
   #    certfile: /var/https-server.crt
@@ -79,7 +83,11 @@ basic:
   enableRestAuditLog: false
   # If it is enabled, the rule functions can access the private network.
   enablePrivateNet: false
-  allowExternalFileAccess: true
+  # Allow rule functions to access files outside the eKuiper upload directory.
+  #
+  # For security reasons, this is disabled by default.
+  # Enable only when trusted external file paths are required.
+  allowExternalFileAccess: false
 
 # The default options for all rules. Each rule can override this setting by defining its own option
 rule:
@@ -114,7 +122,7 @@ sink:
 source:
   ## Configurations for the global http data server for httppush source
   # HTTP data service ip
-  httpServerIp: 0.0.0.0
+  httpServerIp: 127.0.0.1
   # HTTP data service port
   httpServerPort: 10081
   # httpServerTls:


### PR DESCRIPTION
## Summary
- Bind all default network listeners to `127.0.0.1`: the REST management API (`restIp`), the CLI service (`basic.ip`), and the HTTP data ingestion server (`httpServerIp`).
- Disable external file access by default (`allowExternalFileAccess: false`), restricting file access to the eKuiper upload directory unless explicitly enabled.
- Expand the `authentication` comment to give clear production guidance (value unchanged, kept `false` for local/edge compatibility).

## Why
- Improve eKuiper's secure-by-default posture. By binding management and ingestion endpoints only to localhost, the API/CLI/HTTP-push services are not exposed on shared or cloud hosts unless an operator explicitly opts in, at which point they should also enable authentication.
- `allowExternalFileAccess: true` previously let rule functions access arbitrary external file paths (e.g. `file:///external/path`), which is a path-traversal exposure. The safer default restricts file access to eKuiper-managed locations.
- Driven by the implementation plan to harden `etc/kuiper.yaml` defaults without changing Go code.

## Changes In This PR

### API and External Behavior Changes

#### `etc/kuiper.yaml` - default network bind addresses
- `basic.ip` (CLI service): `0.0.0.0` -> `127.0.0.1`. Remote CLI clients can no longer connect by default; set `ip: 0.0.0.0` to restore remote CLI access.
- `basic.restIp` (REST management API): `0.0.0.0` -> `127.0.0.1`. Remote REST clients can no longer connect by default; set `restIp: 0.0.0.0` and enable `authentication` to expose the API remotely.
- `source.httpServerIp` (HTTP data ingestion / httppush source): `0.0.0.0` -> `127.0.0.1`. Remote devices pushing HTTP data can no longer reach the server by default; set `httpServerIp: 0.0.0.0` to restore remote HTTP-push ingestion.
- This is a behavior change for deployments relying on remote CLI, remote REST, or remote HTTP-push access.

#### `etc/kuiper.yaml` - external file access default
- `basic.allowExternalFileAccess`: `true` -> `false`. File access APIs (e.g. `file://` URLs in plugins/schemas) are now restricted to the `data/uploads` directory by default. Set to `true` only when trusted external file paths are required.

#### `etc/kuiper.yaml` - authentication comment (no value change)
- `basic.authentication` remains `false`. Comment rewritten to state that for local development authentication can stay disabled, but production deployments exposing the REST API beyond localhost should enable it.

### Internal Implementation Changes

#### Configuration only
- No Go source code changes. Only default values and comments in `etc/kuiper.yaml` are modified; no types, functions, or data-flow changes.
- No new tests added (no code behavior to test); the YAML continues to parse as valid and no existing config keys were renamed or removed.

## Notes
- **Breaking change (network defaults):** All three listeners (CLI, REST, HTTP-push) now bind to `127.0.0.1` by default. Operators needing remote access must explicitly set the relevant bind address to `0.0.0.0` (or another interface) and, for the REST API, enable `authentication`. This is documented in `RELEASE_NOTES.md`.
- **Breaking change (file access):** Deployments relying on `file:///external/path` access must set `allowExternalFileAccess: true` after reviewing trust of those paths.
- `pprofIp` (`127.0.0.1`), `prometheus` (`false`), `enablePrivateNet` (`false`), and `enableRestAuditLog` (`false`) are intentionally left unchanged.
- Out of scope: enabling authentication by default, changing `basic.aesKey` defaults, and any Go-level enforcement changes.

