### PR TITLE
fix(log): check correct error variable

### DIFF
--- a/internal/io/file/file_writer.go
+++ b/internal/io/file/file_writer.go
@@ -129,7 +129,7 @@ func (fw *fileWriter) Close(ctx api.StreamContext) error {
 		if w, ok := fw.Writer.(io.Closer); ok {
 			e := w.Close()
 			if e != nil {
-				ctx.GetLogger().Errorf("file sink fails to close compress/encrypt writer with error %s.", err)
+				ctx.GetLogger().Errorf("file sink fails to close compress/encrypt writer with error %s.", e)
 			}
 		}
 		err = fw.fileBuffer.Flush()

--- a/pkg/cert/cert.go
+++ b/pkg/cert/cert.go
@@ -136,6 +136,9 @@ func buildCert(ctx api.StreamContext, opts *model.TlsConfigurationOptions, keys 
 	)
 	if len(opts.CertFile) > 0 || len(opts.KeyFile) > 0 {
 		cpb, kpb, err = certLoader(ctx, opts.CertFile, opts.KeyFile)
+		if err != nil {
+			return tls.Certificate{}, err
+		}
 	} else {
 		cpb, kpb = keys.RawCertBytes, keys.RawKeyBytes
 	}
@@ -152,12 +155,12 @@ func buildCert(ctx api.StreamContext, opts *model.TlsConfigurationOptions, keys 
 			return tls.Certificate{}, e
 		}
 		cpb, e = decryptor.Decrypt(cpb)
-		if err != nil {
-			return tls.Certificate{}, e
+		if e != nil {
+			return tls.Certificate{}, fmt.Errorf("decrypt certificate failed: %w", e)
 		}
 		kpb, e = decryptor.Decrypt(kpb)
 		if e != nil {
-			return tls.Certificate{}, e
+			return tls.Certificate{}, fmt.Errorf("decrypt private key failed: %w", e)
 		}
 	}
 	return tls.X509KeyPair(cpb, kpb)

--- a/pkg/cert/cert_test.go
+++ b/pkg/cert/cert_test.go
@@ -15,7 +15,9 @@
 package cert
 
 import (
+	"bytes"
 	"crypto/tls"
+	"encoding/base64"
 	"fmt"
 	"testing"
 
@@ -220,4 +222,35 @@ func TestGenOptions(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, tc.options, opt)
 	}
+}
+
+// TestBuildCertDecryptError is a regression test for a bug where the error
+// returned by decryptor.Decrypt(cpb) was checked against the stale `err`
+// variable instead of `e`, causing decryption failures to be silently
+// ignored. The undecrypted bytes were then passed to tls.X509KeyPair,
+// surfacing as a misleading "private key does not match" error.
+func TestBuildCertDecryptError(t *testing.T) {
+	ctx := mockContext.NewMockContext("gentls", "op1")
+
+	// valid 32-byte AES-256 key so that the decryptor is constructed and we
+	// actually reach decryptor.Decrypt (rather than failing at GetDecryptorWithKey)
+	keyB64 := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0x01}, 32))
+
+	// short garbage cert/key bytes: AES-GCM Decrypt rejects them with
+	// "ciphertext too short" (nonce is 12 bytes).
+	certB64 := base64.StdEncoding.EncodeToString([]byte("short"))
+
+	props := map[string]any{
+		"certificationRaw": certB64,
+		"privateKeyRaw":    certB64,
+		"decrypt": map[string]any{
+			"algorithm": "aes",
+			"key":       keyB64,
+		},
+	}
+
+	_, err := GenTLSConfig(ctx, props)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decrypt certificate failed",
+		"decryption failure must be surfaced, not masked by a later X509KeyPair error")
 }


### PR DESCRIPTION
## Summary
- Fix error variable shadow in  function that caused certificate decryption failures to be silently ignored

## Why
- When using  with encrypted certificates (via  config), if certificate decryption fails, the error was not caught
- This caused corrupted certificate bytes to be passed to , resulting in misleading "private key does not match public key" error
- The bug was at  where  (from ) was checked instead of  (from )

## Changes

### 
- Line 139-141: Added error check after  call to properly handle file loading errors
- Line 158: Changed  to  to correctly check the error from 
- Lines 159, 163: Improved error messages with  wrapping for better debugging

### 
- Line 132: Fixed incorrect error variable in log message (used  instead of )

### 
- Added  regression test to verify decryption errors are properly surfaced

## Testing
- All existing tests pass
- New regression test  passes