### PR TITLE
fix(planner): skip oauth section in findTemplateProps

### DIFF
--- a/internal/topo/planner/planner_sink.go
+++ b/internal/topo/planner/planner_sink.go
@@ -165,7 +165,10 @@ func SinkToComp(tp *topo.Topo, sinkType string, sinkName string, props map[strin
 func findTemplateProps(props map[string]any) []string {
 	var result []string
 	re := regexp.MustCompile(`{{(.*?)}}`)
-	for _, p := range props {
+	for k, p := range props {
+		if k == "oauth" {
+			continue
+		}
 		switch pt := p.(type) {
 		case string:
 			if re.Match([]byte(pt)) {

--- a/internal/topo/planner/planner_sink_test.go
+++ b/internal/topo/planner/planner_sink_test.go
@@ -401,6 +401,23 @@ func TestFindTemplates(t *testing.T) {
 				"mypath/{{.path}}", "{{.ntopic}}", "{{.topic}}",
 			},
 		},
+		{
+			name: "skip oauth",
+			props: map[string]any{
+				"dataTemplate": "{{.data}}",
+				"oauth": map[string]any{
+					"access": map[string]any{
+						"url": "http://auth/token",
+						"headers": map[string]any{
+							"Authorization": "Bearer {{.access_token}}",
+						},
+					},
+				},
+			},
+			result: []string{
+				"{{.data}}",
+			},
+		},
 	}
 
 	for _, tt := range cases {


### PR DESCRIPTION
### Motivation

fix one bug for REST sink with oauth

### Changes

- findTemplateProps was recursively scanning all sink props including the oauth section. This caused `Bearer {{.access_token}}` from OAuth headers to be passed to TransformOp as a data template, where it would be evaluated against message data (which lacks access_token) instead of the token data.

- Skip the oauth key during template scanning so OAuth token templates are resolved only by the auth client, not the transform pipeline.

### Verification

- Unit test added: TestFindTemplates/skip_oauth
