### PR TITLE
fix(rest): separate OAuth and row header templates

### DIFF
--- a/docs/en_US/guide/sinks/builtin/rest.md
+++ b/docs/en_US/guide/sinks/builtin/rest.md
@@ -44,7 +44,7 @@ will be sent individually.
 
 Example to use oAuth style authentication:
 
-OAuth header templates support only the simple placeholders `{{.access_token}}`, `{{.refresh_token}}`, `{{.token_type}}`, `{{.id_token}}`, and `{{.expires_in}}`. The names must exactly match the JSON fields returned by the token endpoint. A single header cannot mix an OAuth placeholder with a rule-output template, but different headers may use OAuth and rule-output templates separately.
+OAuth header templates support only the simple placeholders `{{.access_token}}`, `{{.refresh_token}}`, `{{.token_type}}`, `{{.id_token}}`, and `{{.expires_in}}`. The names must exactly match the JSON fields returned by the token endpoint. Other placeholders, such as `{{.message}}`, `{{.scope}}`, and `{{.custom_token}}`, are evaluated only against the rule output and cannot read fields from the token response. Token endpoints must therefore return the supported field names used by the configured headers. A single header cannot mix an OAuth placeholder with a rule-output template, but different headers may use OAuth and rule-output templates separately.
 
 ```json
 {

--- a/docs/en_US/guide/sinks/builtin/rest.md
+++ b/docs/en_US/guide/sinks/builtin/rest.md
@@ -44,6 +44,8 @@ will be sent individually.
 
 Example to use oAuth style authentication:
 
+OAuth header templates support only the simple placeholders `{{.access_token}}`, `{{.refresh_token}}`, `{{.token_type}}`, `{{.id_token}}`, and `{{.expires_in}}`. The names must exactly match the JSON fields returned by the token endpoint. A single header cannot mix an OAuth placeholder with a rule-output template, but different headers may use OAuth and rule-output templates separately.
+
 ```json
 {
   "id": "ruleFollowBack",

--- a/docs/zh_CN/guide/sinks/builtin/rest.md
+++ b/docs/zh_CN/guide/sinks/builtin/rest.md
@@ -43,7 +43,7 @@ REST 服务通常需要特定的数据格式。 这可以由公共目标属性 `
 
 使用 OAuth 风格鉴权的示例:
 
-OAuth Header 模板仅支持简单占位符 `{{.access_token}}`、`{{.refresh_token}}`、`{{.token_type}}`、`{{.id_token}}` 和 `{{.expires_in}}`，字段名必须与 token 接口返回的 JSON 字段完全一致。单个 Header 不能同时包含 OAuth 占位符和规则输出模板，但不同 Header 可以分别使用 OAuth 和规则输出模板。
+OAuth Header 模板仅支持简单占位符 `{{.access_token}}`、`{{.refresh_token}}`、`{{.token_type}}`、`{{.id_token}}` 和 `{{.expires_in}}`，字段名必须与 token 接口返回的 JSON 字段完全一致。其他占位符，例如 `{{.message}}`、`{{.scope}}` 和 `{{.custom_token}}`，只会根据规则输出求值，不能读取 token 响应字段。因此，token 接口必须返回 Header 配置所使用的受支持字段名。单个 Header 不能同时包含 OAuth 占位符和规则输出模板，但不同 Header 可以分别使用 OAuth 和规则输出模板。
 
 ```json
 {

--- a/docs/zh_CN/guide/sinks/builtin/rest.md
+++ b/docs/zh_CN/guide/sinks/builtin/rest.md
@@ -43,6 +43,8 @@ REST 服务通常需要特定的数据格式。 这可以由公共目标属性 `
 
 使用 OAuth 风格鉴权的示例:
 
+OAuth Header 模板仅支持简单占位符 `{{.access_token}}`、`{{.refresh_token}}`、`{{.token_type}}`、`{{.id_token}}` 和 `{{.expires_in}}`，字段名必须与 token 接口返回的 JSON 字段完全一致。单个 Header 不能同时包含 OAuth 占位符和规则输出模板，但不同 Header 可以分别使用 OAuth 和规则输出模板。
+
 ```json
 {
   "id": "ruleFollowBack",

--- a/fvt/rule_test.go
+++ b/fvt/rule_test.go
@@ -813,7 +813,6 @@ func (s *RuleTestSuite) TestRestSinkOAuthAndRowHeaderTemplates() {
 	type receivedRequest struct {
 		authorization string
 		rowHeader     string
-		combined      string
 	}
 	received := make(chan receivedRequest, 1)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -828,7 +827,6 @@ func (s *RuleTestSuite) TestRestSinkOAuthAndRowHeaderTemplates() {
 			request := receivedRequest{
 				authorization: r.Header.Get("Authorization"),
 				rowHeader:     r.Header.Get("X-Row"),
-				combined:      r.Header.Get("X-Combined"),
 			}
 			select {
 			case received <- request:
@@ -871,14 +869,12 @@ func (s *RuleTestSuite) TestRestSinkOAuthAndRowHeaderTemplates() {
 		"actions": []map[string]any{
 			{
 				"rest": map[string]any{
-					"url":        ts.URL + "/target",
-					"method":     http.MethodPost,
-					"sendSingle": true,
+					"url":    ts.URL + "/target",
+					"method": http.MethodPost,
 					"headers": map[string]string{
 						"Authorization": "Bearer {{.access_token}}",
 						"Content-Type":  "application/json",
-						"X-Row":         "{{.row_value}}",
-						"X-Combined":    "{{.row_value}}/{{.access_token}}",
+						"X-Row":         `{{index . 0 "row_value"}}`,
 					},
 					"oauth": map[string]any{
 						"access": map[string]any{
@@ -902,7 +898,6 @@ func (s *RuleTestSuite) TestRestSinkOAuthAndRowHeaderTemplates() {
 	case request := <-received:
 		s.Require().Equal("Bearer e2e-token", request.authorization)
 		s.Require().Equal("row-value", request.rowHeader)
-		s.Require().Equal("row-value/e2e-token", request.combined)
 	case <-time.After(10 * time.Second):
 		s.Fail("timed out waiting for the first REST request")
 	}

--- a/fvt/rule_test.go
+++ b/fvt/rule_test.go
@@ -794,6 +794,120 @@ func (s *RuleTestSuite) TestBatchDataTemplateJSON() {
 	}
 }
 
+func (s *RuleTestSuite) TestRestSinkOAuthAndRowHeaderTemplates() {
+	const (
+		streamID = "restOAuthHeaderStream"
+		ruleID   = "restOAuthHeaderRule"
+		confKey  = "restOAuthHeaderSource"
+	)
+	client.DeleteRule(ruleID)
+	client.DeleteStream(streamID)
+	defer client.DeleteRule(ruleID)
+	defer client.DeleteStream(streamID)
+	originalEnablePrivateNet := conf.Config.Basic.EnablePrivateNet
+	conf.Config.Basic.EnablePrivateNet = true
+	defer func() {
+		conf.Config.Basic.EnablePrivateNet = originalEnablePrivateNet
+	}()
+
+	type receivedRequest struct {
+		authorization string
+		rowHeader     string
+		combined      string
+	}
+	received := make(chan receivedRequest, 1)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "e2e-token",
+				"expires_in":   3600,
+			})
+		case "/target":
+			request := receivedRequest{
+				authorization: r.Header.Get("Authorization"),
+				rowHeader:     r.Header.Get("X-Row"),
+				combined:      r.Header.Get("X-Combined"),
+			}
+			select {
+			case received <- request:
+			default:
+			}
+			if request.authorization != "Bearer e2e-token" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	resp, err := client.CreateConf("sources/simulator/confKeys/"+confKey, map[string]any{
+		"data": []map[string]any{
+			{"row_value": "row-value", "number": float64(42)},
+		},
+		"interval": "10ms",
+		"loop":     false,
+	})
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	streamSQL, err := json.Marshal(map[string]string{
+		"sql": fmt.Sprintf(`CREATE STREAM %s() WITH (TYPE="simulator", CONF_KEY="%s")`, streamID, confKey),
+	})
+	s.Require().NoError(err)
+	resp, err = client.CreateStream(string(streamSQL))
+	s.Require().NoError(err)
+	streamResponse, err := GetResponseText(resp)
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusCreated, resp.StatusCode, streamResponse)
+
+	rule, err := json.Marshal(map[string]any{
+		"id":  ruleID,
+		"sql": fmt.Sprintf("SELECT row_value, number FROM %s", streamID),
+		"actions": []map[string]any{
+			{
+				"rest": map[string]any{
+					"url":        ts.URL + "/target",
+					"method":     http.MethodPost,
+					"sendSingle": true,
+					"headers": map[string]string{
+						"Authorization": "Bearer {{.access_token}}",
+						"Content-Type":  "application/json",
+						"X-Row":         "{{.row_value}}",
+						"X-Combined":    "{{.row_value}}/{{.access_token}}",
+					},
+					"oauth": map[string]any{
+						"access": map[string]any{
+							"url":    ts.URL + "/token",
+							"body":   `{"grant_type":"client_credentials"}`,
+							"expire": "3600",
+						},
+					},
+				},
+			},
+		},
+	})
+	s.Require().NoError(err)
+	resp, err = client.CreateRule(string(rule))
+	s.Require().NoError(err)
+	ruleResponse, err := GetResponseText(resp)
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusCreated, resp.StatusCode, ruleResponse)
+
+	select {
+	case request := <-received:
+		s.Require().Equal("Bearer e2e-token", request.authorization)
+		s.Require().Equal("row-value", request.rowHeader)
+		s.Require().Equal("row-value/e2e-token", request.combined)
+	case <-time.After(10 * time.Second):
+		s.Fail("timed out waiting for the first REST request")
+	}
+}
+
 func (s *RuleTestSuite) TestShowScanTableContentWithErrors() {
 	s.Run("testNoJoin", func() {
 		client.DeleteStream("simpleStream")

--- a/go.mod
+++ b/go.mod
@@ -93,6 +93,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	go.uber.org/automaxprocs v1.5.3
+	golang.org/x/sync v0.20.0
 	golang.org/x/text v0.37.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260414002931-afd174a4e478
 	google.golang.org/grpc v1.82.1
@@ -388,7 +389,6 @@ require (
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/time v0.15.0

--- a/internal/io/http/client.go
+++ b/internal/io/http/client.go
@@ -23,12 +23,12 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/lf-edge/ekuiper/contract/v2/api"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/lf-edge/ekuiper/v2/internal/compressor"
 	"github.com/lf-edge/ekuiper/v2/internal/conf"
@@ -55,7 +55,7 @@ type ClientConf struct {
 
 	tokenHeaderTemplates map[string]string
 	requiredTokenFields  map[string]struct{}
-	tokenRefreshMu       sync.Mutex
+	tokenRefreshGroup    singleflight.Group
 	oauthSnapshot        atomic.Value // *oauthRuntimeState
 }
 
@@ -255,23 +255,24 @@ func (cc *ClientConf) tokenRefreshDue(state *oauthRuntimeState) bool {
 }
 
 func (cc *ClientConf) refreshToken(ctx api.StreamContext) {
-	cc.tokenRefreshMu.Lock()
-	defer cc.tokenRefreshMu.Unlock()
-	// Another concurrent request may have refreshed the token while this request
-	// was waiting for the lock.
-	if !cc.tokenRefreshDue(cc.oauthRuntimeState()) {
-		return
-	}
-	ctx.GetLogger().Debugf("Refreshing token for HTTP client")
-	if cc.refreshConf != nil {
-		if err := cc.refresh(ctx); err != nil {
-			ctx.GetLogger().Warnf("Refresh HTTP client token error: %v", err)
+	_, _, _ = cc.tokenRefreshGroup.Do("oauth", func() (any, error) {
+		// Another concurrent request may have refreshed the token before this
+		// shared attempt started.
+		if !cc.tokenRefreshDue(cc.oauthRuntimeState()) {
+			return nil, nil
 		}
-	} else {
-		if err := cc.auth(ctx); err != nil {
-			ctx.GetLogger().Warnf("Authorize HTTP client token error: %v", err)
+		ctx.GetLogger().Debugf("Refreshing token for HTTP client")
+		if cc.refreshConf != nil {
+			if err := cc.refresh(ctx); err != nil {
+				ctx.GetLogger().Warnf("Refresh HTTP client token error: %v", err)
+			}
+		} else {
+			if err := cc.auth(ctx); err != nil {
+				ctx.GetLogger().Warnf("Authorize HTTP client token error: %v", err)
+			}
 		}
-	}
+		return nil, nil
+	})
 }
 
 // initialize the oAuth access token

--- a/internal/io/http/client.go
+++ b/internal/io/http/client.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -52,18 +53,18 @@ type ClientConf struct {
 	accessConf  *AccessTokenConf
 	refreshConf *RefreshTokenConf
 
-	tokenLastUpdateAt    time.Time
-	parsedHeaders        map[string]string
-	parsedBody           string
-	parsedRefreshHeader  map[string]string
-	parsedRefreshBody    string
 	tokenHeaderTemplates map[string]string
 	requiredTokenFields  map[string]struct{}
+	tokenRefreshMu       sync.Mutex
 	oauthSnapshot        atomic.Value // *oauthRuntimeState
 }
 
 type oauthRuntimeState struct {
-	headers map[string]string
+	headers        map[string]string
+	body           string
+	refreshHeaders map[string]string
+	refreshBody    string
+	updatedAt      time.Time
 }
 
 type AccessTokenConf struct {
@@ -242,20 +243,35 @@ func (cc *ClientConf) Conn(ctx api.StreamContext) error {
 func (cc *ClientConf) Send(ctx api.StreamContext, bodyType string, method string, u string, headers map[string]string, formData map[string]string, formFieldName string, v any) (*http.Response, error) {
 	resp, err := httpx.SendWithFormData(ctx.GetLogger(), cc.client, bodyType, method, u, headers, formData, formFieldName, v)
 	// Check token refresh after send
-	if cc.accessConf != nil && cc.accessConf.ExpireInSecond > 0 &&
-		int(timex.GetNow().Sub(cc.tokenLastUpdateAt).Abs().Seconds())*2 > cc.accessConf.ExpireInSecond {
-		ctx.GetLogger().Debugf("Refreshing token for REST sink")
-		if cc.refreshConf != nil {
-			if err := cc.refresh(ctx); err != nil {
-				ctx.GetLogger().Warnf("Refresh REST sink token error: %v", err)
-			}
-		} else {
-			if err := cc.auth(ctx); err != nil {
-				ctx.GetLogger().Warnf("Authorize REST sink token error: %v", err)
-			}
-		}
+	if cc.tokenRefreshDue(cc.oauthRuntimeState()) {
+		cc.refreshToken(ctx)
 	}
 	return resp, err
+}
+
+func (cc *ClientConf) tokenRefreshDue(state *oauthRuntimeState) bool {
+	return cc.accessConf != nil && cc.accessConf.ExpireInSecond > 0 && state != nil &&
+		int(timex.GetNow().Sub(state.updatedAt).Abs().Seconds())*2 > cc.accessConf.ExpireInSecond
+}
+
+func (cc *ClientConf) refreshToken(ctx api.StreamContext) {
+	cc.tokenRefreshMu.Lock()
+	defer cc.tokenRefreshMu.Unlock()
+	// Another concurrent request may have refreshed the token while this request
+	// was waiting for the lock.
+	if !cc.tokenRefreshDue(cc.oauthRuntimeState()) {
+		return
+	}
+	ctx.GetLogger().Debugf("Refreshing token for HTTP client")
+	if cc.refreshConf != nil {
+		if err := cc.refresh(ctx); err != nil {
+			ctx.GetLogger().Warnf("Refresh HTTP client token error: %v", err)
+		}
+	} else {
+		if err := cc.auth(ctx); err != nil {
+			ctx.GetLogger().Warnf("Authorize HTTP client token error: %v", err)
+		}
+	}
 }
 
 // initialize the oAuth access token
@@ -286,7 +302,11 @@ func parseHeaders(ctx api.StreamContext, oHeaders map[string]string, data map[st
 
 func (cc *ClientConf) refresh(ctx api.StreamContext) error {
 	if cc.refreshConf != nil {
-		resp, err := httpx.Send(conf.Log, cc.client, "json", http.MethodPost, cc.refreshConf.Url, cc.parsedRefreshHeader, cc.parsedRefreshBody)
+		state := cc.oauthRuntimeState()
+		if state == nil {
+			return fmt.Errorf("OAuth token is not initialized")
+		}
+		resp, err := httpx.Send(conf.Log, cc.client, "json", http.MethodPost, cc.refreshConf.Url, state.refreshHeaders, state.refreshBody)
 		if err != nil {
 			return fmt.Errorf("fail to get refresh token: %v", err)
 		}
@@ -302,7 +322,6 @@ func (cc *ClientConf) refresh(ctx api.StreamContext) error {
 }
 
 func (cc *ClientConf) updateToken(ctx api.StreamContext, tk map[string]interface{}) error {
-	cc.tokenLastUpdateAt = timex.GetNow()
 	var err error
 	ctx.GetLogger().Infof("Got access token %v", replace.HidePassword(tk))
 	for field := range cc.requiredTokenFields {
@@ -314,14 +333,16 @@ func (cc *ClientConf) updateToken(ctx api.StreamContext, tk map[string]interface
 	if cc.tokenHeaderTemplates != nil {
 		headerTemplates = cc.tokenHeaderTemplates
 	}
-	cc.parsedHeaders, err = parseHeaders(ctx, headerTemplates, tk)
+	parsedHeaders, err := parseHeaders(ctx, headerTemplates, tk)
 	if err != nil {
 		return fmt.Errorf("fail to parse header with access token: %v", err)
 	}
-	cc.parsedBody, err = ctx.ParseTemplate(cc.config.Body, tk)
+	parsedBody, err := ctx.ParseTemplate(cc.config.Body, tk)
 	if err != nil {
 		return fmt.Errorf("fail to parse body with access token: %v", err)
 	}
+	var parsedRefreshHeaders map[string]string
+	var parsedRefreshBody string
 	if cc.refreshConf != nil {
 		headers := make(map[string]string, len(cc.refreshConf.Headers))
 		for k, v := range cc.refreshConf.Headers {
@@ -330,15 +351,19 @@ func (cc *ClientConf) updateToken(ctx api.StreamContext, tk map[string]interface
 				return fmt.Errorf("fail to parse the header for refresh token request %s: %v", k, err)
 			}
 		}
-		cc.parsedRefreshHeader = headers
+		parsedRefreshHeaders = headers
 		pb, err := ctx.ParseTemplate(cc.refreshConf.Body, tk)
 		if err != nil {
 			return fmt.Errorf("fail to parse body with refresh token request: %v", err)
 		}
-		cc.parsedRefreshBody = pb
+		parsedRefreshBody = pb
 	}
 	cc.oauthSnapshot.Store(&oauthRuntimeState{
-		headers: cc.parsedHeaders,
+		headers:        parsedHeaders,
+		body:           parsedBody,
+		refreshHeaders: parsedRefreshHeaders,
+		refreshBody:    parsedRefreshBody,
+		updatedAt:      timex.GetNow(),
 	})
 	return nil
 }

--- a/internal/io/http/client.go
+++ b/internal/io/http/client.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/lf-edge/ekuiper/contract/v2/api"
@@ -56,6 +57,12 @@ type ClientConf struct {
 	parsedBody          string
 	parsedRefreshHeader map[string]string
 	parsedRefreshBody   string
+	oauthSnapshot       atomic.Value // *oauthRuntimeState
+}
+
+type oauthRuntimeState struct {
+	tokens  map[string]string
+	headers map[string]string
 }
 
 type AccessTokenConf struct {
@@ -319,6 +326,21 @@ func (cc *ClientConf) updateToken(ctx api.StreamContext, tk map[string]interface
 			return fmt.Errorf("fail to parse body with refresh token request: %v", err)
 		}
 		cc.parsedRefreshBody = pb
+	}
+	tokens := make(map[string]string, len(tk))
+	for k, v := range tk {
+		tokens[k] = fmt.Sprint(v)
+	}
+	cc.oauthSnapshot.Store(&oauthRuntimeState{
+		tokens:  tokens,
+		headers: cc.parsedHeaders,
+	})
+	return nil
+}
+
+func (cc *ClientConf) oauthRuntimeState() *oauthRuntimeState {
+	if state := cc.oauthSnapshot.Load(); state != nil {
+		return state.(*oauthRuntimeState)
 	}
 	return nil
 }

--- a/internal/io/http/client.go
+++ b/internal/io/http/client.go
@@ -52,16 +52,17 @@ type ClientConf struct {
 	accessConf  *AccessTokenConf
 	refreshConf *RefreshTokenConf
 
-	tokenLastUpdateAt   time.Time
-	parsedHeaders       map[string]string
-	parsedBody          string
-	parsedRefreshHeader map[string]string
-	parsedRefreshBody   string
-	oauthSnapshot       atomic.Value // *oauthRuntimeState
+	tokenLastUpdateAt    time.Time
+	parsedHeaders        map[string]string
+	parsedBody           string
+	parsedRefreshHeader  map[string]string
+	parsedRefreshBody    string
+	tokenHeaderTemplates map[string]string
+	requiredTokenFields  map[string]struct{}
+	oauthSnapshot        atomic.Value // *oauthRuntimeState
 }
 
 type oauthRuntimeState struct {
-	tokens  map[string]string
 	headers map[string]string
 }
 
@@ -304,7 +305,16 @@ func (cc *ClientConf) updateToken(ctx api.StreamContext, tk map[string]interface
 	cc.tokenLastUpdateAt = timex.GetNow()
 	var err error
 	ctx.GetLogger().Infof("Got access token %v", replace.HidePassword(tk))
-	cc.parsedHeaders, err = cc.parseHeaders(ctx, tk)
+	for field := range cc.requiredTokenFields {
+		if _, ok := tk[field]; !ok {
+			return fmt.Errorf("OAuth response does not contain required field %q", field)
+		}
+	}
+	headerTemplates := cc.config.Headers
+	if cc.tokenHeaderTemplates != nil {
+		headerTemplates = cc.tokenHeaderTemplates
+	}
+	cc.parsedHeaders, err = parseHeaders(ctx, headerTemplates, tk)
 	if err != nil {
 		return fmt.Errorf("fail to parse header with access token: %v", err)
 	}
@@ -327,12 +337,7 @@ func (cc *ClientConf) updateToken(ctx api.StreamContext, tk map[string]interface
 		}
 		cc.parsedRefreshBody = pb
 	}
-	tokens := make(map[string]string, len(tk))
-	for k, v := range tk {
-		tokens[k] = fmt.Sprint(v)
-	}
 	cc.oauthSnapshot.Store(&oauthRuntimeState{
-		tokens:  tokens,
 		headers: cc.parsedHeaders,
 	})
 	return nil

--- a/internal/io/http/client_test.go
+++ b/internal/io/http/client_test.go
@@ -294,7 +294,9 @@ func TestOAuthClientCredentials(t *testing.T) {
 
 	// 4. Send Data (Verifies Token Usage)
 	data, _ := json.Marshal(map[string]interface{}{"data": 123})
-	resp, err := c.Send(ctx, "json", "POST", c.config.Url, c.parsedHeaders, nil, "", data)
+	state := c.oauthRuntimeState()
+	require.NotNil(t, state)
+	resp, err := c.Send(ctx, "json", "POST", c.config.Url, state.headers, nil, "", data)
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)

--- a/internal/io/http/httppull_source.go
+++ b/internal/io/http/httppull_source.go
@@ -15,6 +15,7 @@
 package http
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/lf-edge/ekuiper/contract/v2/api"
@@ -100,12 +101,14 @@ func (hps *HttpPullSource) doPull(ctx api.StreamContext) ([]map[string]any, erro
 func (hps *HttpPullSource) doPullInternal(ctx api.StreamContext, c *ClientConf, lastMD5 string) ([]map[string]any, string, error) {
 	// if auth is set, the auth is handled by the client connect
 	headers := c.config.Headers
-	if c.accessConf != nil {
-		headers = c.parsedHeaders
-	}
 	newBody := c.config.Body
 	if c.accessConf != nil {
-		newBody = c.parsedBody
+		state := c.oauthRuntimeState()
+		if state == nil {
+			return nil, "", fmt.Errorf("OAuth token is not initialized")
+		}
+		headers = state.headers
+		newBody = state.body
 	}
 	var err error
 	newUrl := c.config.Url

--- a/internal/io/http/httppull_source_test.go
+++ b/internal/io/http/httppull_source_test.go
@@ -29,8 +29,9 @@ import (
 )
 
 type Response struct {
-	Message string `json:"message"`
-	Code    int    `json:"code"`
+	Message     string `json:"message"`
+	Code        int    `json:"code"`
+	AccessToken string `json:"access_token,omitempty"`
 }
 
 func handleCodeErr(w http.ResponseWriter, r *http.Request) {
@@ -87,8 +88,9 @@ func handleErr(w http.ResponseWriter, r *http.Request) {
 
 func handleAuth(w http.ResponseWriter, r *http.Request) {
 	resp := Response{
-		Message: "auth",
-		Code:    200,
+		Message:     "auth",
+		Code:        200,
+		AccessToken: "auth",
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
@@ -97,8 +99,9 @@ func handleAuth(w http.ResponseWriter, r *http.Request) {
 
 func handleRefresh(w http.ResponseWriter, r *http.Request) {
 	resp := Response{
-		Message: "refresh",
-		Code:    200,
+		Message:     "refresh",
+		Code:        200,
+		AccessToken: "refresh",
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)

--- a/internal/io/http/lookup_source.go
+++ b/internal/io/http/lookup_source.go
@@ -15,6 +15,8 @@
 package http
 
 import (
+	"fmt"
+
 	"github.com/lf-edge/ekuiper/contract/v2/api"
 
 	"github.com/lf-edge/ekuiper/v2/pkg/cast"
@@ -40,6 +42,9 @@ func (hls *HttpLookupSource) Close(ctx api.StreamContext) error {
 }
 
 func (hls *HttpLookupSource) Connect(ctx api.StreamContext, sch api.StatusChangeHandler) error {
+	if err := hls.Conn(ctx); err != nil {
+		return err
+	}
 	sch(api.ConnectionConnected, "")
 	return nil
 }
@@ -99,12 +104,14 @@ var _ api.LookupSource = &HttpLookupSource{}
 
 func doPull(ctx api.StreamContext, c *ClientConf, lastMD5 string) ([]map[string]any, string, error) {
 	headers := c.config.Headers
-	if c.accessConf != nil {
-		headers = c.parsedHeaders
-	}
 	newBody := c.config.Body
 	if c.accessConf != nil {
-		newBody = c.parsedBody
+		state := c.oauthRuntimeState()
+		if state == nil {
+			return nil, "", fmt.Errorf("OAuth token is not initialized")
+		}
+		headers = state.headers
+		newBody = state.body
 	}
 	resp, err := c.Send(ctx, c.config.BodyType, c.config.Method, c.config.Url, headers, nil, "", []byte(newBody))
 	if err != nil {

--- a/internal/io/http/lookup_source_test.go
+++ b/internal/io/http/lookup_source_test.go
@@ -15,11 +15,19 @@
 package http
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	mockContext "github.com/lf-edge/ekuiper/v2/pkg/mock/context"
+	"github.com/lf-edge/ekuiper/v2/pkg/timex"
 )
 
 func TestLookup(t *testing.T) {
@@ -45,4 +53,76 @@ func TestLookup(t *testing.T) {
 		},
 	}, got)
 	require.NoError(t, hls.Close(ctx))
+}
+
+func TestLookupOAuthConcurrentRefresh(t *testing.T) {
+	var tokenRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			token := fmt.Sprintf("token-%d", tokenRequests.Add(1))
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(map[string]any{
+				"access_token": token,
+				"expires_in":   2,
+			}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		case "/data":
+			if r.Header.Get("Authorization") == "" {
+				http.Error(w, "missing authorization", http.StatusUnauthorized)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(map[string]any{"code": 200}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	timex.Set(1000)
+	ctx := mockContext.NewMockContext("lookupOAuth", "op")
+	hls := &HttpLookupSource{}
+	require.NoError(t, hls.Provision(ctx, map[string]any{
+		"url":        server.URL,
+		"datasource": "/data",
+		"method":     "get",
+		"headers": map[string]any{
+			"Authorization": "Bearer {{.access_token}}",
+		},
+		"oauth": map[string]any{
+			"access": map[string]any{
+				"url":    server.URL + "/token",
+				"expire": "2",
+			},
+		},
+	}))
+	require.NoError(t, hls.Connect(ctx, func(status string, message string) {}))
+	require.Equal(t, int32(1), tokenRequests.Load())
+
+	timex.Add(2 * time.Second)
+	const workers = 16
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			_, err := hls.Lookup(ctx, []string{"code"}, []string{"code"}, []any{float64(200)})
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, int32(2), tokenRequests.Load(), "concurrent lookups must share one token refresh")
+	state := hls.oauthRuntimeState()
+	require.NotNil(t, state)
+	require.Equal(t, "Bearer token-2", state.headers["Authorization"])
 }

--- a/internal/io/http/lookup_source_test.go
+++ b/internal/io/http/lookup_source_test.go
@@ -126,3 +126,94 @@ func TestLookupOAuthConcurrentRefresh(t *testing.T) {
 	require.NotNil(t, state)
 	require.Equal(t, "Bearer token-2", state.headers["Authorization"])
 }
+
+func TestLookupOAuthConcurrentRefreshFailure(t *testing.T) {
+	const workers = 16
+	var tokenRequests atomic.Int32
+	var dataRequests atomic.Int32
+	allDataRequests := make(chan struct{})
+	refreshStarted := make(chan struct{})
+	releaseRefresh := make(chan struct{})
+	var allDataOnce sync.Once
+	var refreshOnce sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/token":
+			if tokenRequests.Add(1) == 1 {
+				w.Header().Set("Content-Type", "application/json")
+				if err := json.NewEncoder(w).Encode(map[string]any{
+					"access_token": "initial-token",
+					"expires_in":   2,
+				}); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
+				return
+			}
+			refreshOnce.Do(func() { close(refreshStarted) })
+			<-releaseRefresh
+			http.Error(w, "token service unavailable", http.StatusServiceUnavailable)
+		case "/data":
+			if dataRequests.Add(1) == workers {
+				allDataOnce.Do(func() { close(allDataRequests) })
+			}
+			<-allDataRequests
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(map[string]any{"code": 200}); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	timex.Set(1000)
+	ctx := mockContext.NewMockContext("lookupOAuthFailure", "op")
+	hls := &HttpLookupSource{}
+	require.NoError(t, hls.Provision(ctx, map[string]any{
+		"url":        server.URL,
+		"datasource": "/data",
+		"method":     "get",
+		"headers": map[string]any{
+			"Authorization": "Bearer {{.access_token}}",
+		},
+		"oauth": map[string]any{
+			"access": map[string]any{
+				"url":    server.URL + "/token",
+				"expire": "2",
+			},
+		},
+	}))
+	require.NoError(t, hls.Connect(ctx, func(status string, message string) {}))
+	timex.Add(2 * time.Second)
+
+	errs := make(chan error, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			_, err := hls.Lookup(ctx, []string{"code"}, []string{"code"}, []any{float64(200)})
+			errs <- err
+		}()
+	}
+	select {
+	case <-refreshStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the shared refresh attempt")
+	}
+	// Give all requests released by the data endpoint time to join the same
+	// in-flight refresh before completing it with an error.
+	time.Sleep(100 * time.Millisecond)
+	close(releaseRefresh)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, int32(2), tokenRequests.Load(), "a failed concurrent refresh must make only one token request")
+	state := hls.oauthRuntimeState()
+	require.NotNil(t, state)
+	require.Equal(t, "Bearer initial-token", state.headers["Authorization"], "a failed refresh must retain the previous token state")
+}

--- a/internal/io/http/rest_sink.go
+++ b/internal/io/http/rest_sink.go
@@ -35,19 +35,22 @@ type RestSink struct {
 }
 
 type restHeaderTemplate struct {
-	value             string
-	dynamic           bool
-	tokenReplacements []tokenReplacement
+	value        string
+	plannerValue string
+	kind         restHeaderKind
 }
 
-type tokenReplacement struct {
-	target string
-	field  string
-}
+type restHeaderKind uint8
+
+const (
+	restHeaderStatic restHeaderKind = iota
+	restHeaderOAuth
+	restHeaderSQL
+)
 
 var (
-	oauthTemplatePattern  = regexp.MustCompile(`{{\s*\.(access_token|refresh_token|token_type|id_token|expires_in)\s*}}`)
-	simpleTemplatePattern = regexp.MustCompile(`{{\s*\.([[:word:]]+)\s*}}`)
+	oauthTemplatePattern       = regexp.MustCompile(`{{\s*\.(access_token|refresh_token|token_type|id_token|expires_in)\s*}}`)
+	oauthFieldReferencePattern = regexp.MustCompile(`{{[^{}]*\b(access_token|refresh_token|token_type|id_token|expires_in)\b[^{}]*}}`)
 )
 
 const oauthTemplateMarkerPrefix = "__ekuiper_oauth_"
@@ -70,16 +73,34 @@ func (r *RestSink) Provision(ctx api.StreamContext, configs map[string]any) erro
 		return fmt.Errorf("format must be %s if bodyType is %s", rf, r.ClientConf.config.BodyType)
 	}
 	r.headerTemplates = make(map[string]restHeaderTemplate, len(r.config.Headers))
+	if r.accessConf != nil {
+		r.tokenHeaderTemplates = make(map[string]string, len(r.config.Headers))
+		r.requiredTokenFields = make(map[string]struct{})
+	}
 	for k, v := range r.config.Headers {
 		if r.accessConf != nil {
-			r.headerTemplates[k] = newOAuthHeaderTemplate(v)
+			h, fields, err := newOAuthHeaderTemplate(k, v)
+			if err != nil {
+				return err
+			}
+			r.headerTemplates[k] = h
+			if h.kind != restHeaderSQL {
+				r.tokenHeaderTemplates[k] = v
+			}
+			for _, field := range fields {
+				r.requiredTokenFields[field] = struct{}{}
+			}
 		} else {
-			h := restHeaderTemplate{value: v, dynamic: strings.Contains(v, "{{")}
+			kind := restHeaderStatic
+			if strings.Contains(v, "{{") {
+				kind = restHeaderSQL
+			}
+			h := restHeaderTemplate{value: v, plannerValue: v, kind: kind}
 			r.headerTemplates[k] = h
 		}
-		if h := r.headerTemplates[k]; h.dynamic || len(h.tokenReplacements) > 0 {
+		if h := r.headerTemplates[k]; h.kind != restHeaderStatic {
 			r.hasHeaderTemplates = true
-			if h.dynamic {
+			if h.kind == restHeaderSQL {
 				r.hasDynamicHeaders = true
 			}
 		}
@@ -99,13 +120,13 @@ func (r *RestSink) Consume(props map[string]any) {
 				case map[string]any:
 					maskedHeaders := make(map[string]any, len(headers))
 					for k := range headers {
-						maskedHeaders[k] = r.headerTemplates[k].value
+						maskedHeaders[k] = r.headerTemplates[k].plannerValue
 					}
 					props[key] = maskedHeaders
 				case map[string]string:
 					maskedHeaders := make(map[string]string, len(headers))
 					for k := range headers {
-						maskedHeaders[k] = r.headerTemplates[k].value
+						maskedHeaders[k] = r.headerTemplates[k].plannerValue
 					}
 					props[key] = maskedHeaders
 				}
@@ -114,31 +135,29 @@ func (r *RestSink) Consume(props map[string]any) {
 	}
 }
 
-func maskOAuthTemplates(value string) string {
-	return oauthTemplatePattern.ReplaceAllString(value, oauthTemplateMarkerPrefix+"${1}__")
-}
-
-func newOAuthHeaderTemplate(value string) restHeaderTemplate {
-	masked := maskOAuthTemplates(value)
-	h := restHeaderTemplate{value: masked, dynamic: strings.Contains(masked, "{{")}
-	for _, match := range simpleTemplatePattern.FindAllStringSubmatch(value, -1) {
-		target := match[0]
-		field := match[1]
-		if oauthTemplatePattern.MatchString(target) {
-			target = oauthTemplateMarkerPrefix + field + "__"
-		}
-		h.tokenReplacements = append(h.tokenReplacements, tokenReplacement{target: target, field: field})
+func newOAuthHeaderTemplate(name, value string) (restHeaderTemplate, []string, error) {
+	matches := oauthTemplatePattern.FindAllStringSubmatch(value, -1)
+	withoutOAuth := oauthTemplatePattern.ReplaceAllString(value, "")
+	if oauthFieldReferencePattern.MatchString(withoutOAuth) {
+		return restHeaderTemplate{}, nil, fmt.Errorf("header %q uses an unsupported OAuth template; only simple placeholders such as {{.access_token}} are supported", name)
 	}
-	return h
-}
-
-func resolveOAuthTemplates(value string, tokens map[string]string, replacements []tokenReplacement) string {
-	for _, replacement := range replacements {
-		if token, ok := tokens[replacement.field]; ok {
-			value = strings.ReplaceAll(value, replacement.target, token)
-		}
+	hasOAuth := len(matches) > 0
+	hasSQL := strings.Contains(withoutOAuth, "{{")
+	if hasOAuth && hasSQL {
+		return restHeaderTemplate{}, nil, fmt.Errorf("header %q cannot mix OAuth and SQL templates", name)
 	}
-	return value
+	h := restHeaderTemplate{value: value, plannerValue: value, kind: restHeaderStatic}
+	fields := make([]string, 0, len(matches))
+	if hasOAuth {
+		h.kind = restHeaderOAuth
+		h.plannerValue = oauthTemplateMarkerPrefix + name
+		for _, match := range matches {
+			fields = append(fields, match[1])
+		}
+	} else if hasSQL {
+		h.kind = restHeaderSQL
+	}
+	return h, fields, nil
 }
 
 func deletePropFold(props map[string]any, name string) {
@@ -274,24 +293,17 @@ func (r *RestSink) prepareHeaders(item api.RawTuple) map[string]string {
 	headers := make(map[string]string, len(r.headerTemplates))
 	dp, hasDynamicProps := item.(api.HasDynamicProps)
 	for k, headerTemplate := range r.headerTemplates {
-		if !headerTemplate.dynamic && oauthState != nil {
+		if headerTemplate.kind != restHeaderSQL && oauthState != nil {
 			if resolved, ok := oauthState.headers[k]; ok {
 				headers[k] = resolved
 				continue
 			}
 		}
 		value := headerTemplate.value
-		if headerTemplate.dynamic && hasDynamicProps {
+		if headerTemplate.kind == restHeaderSQL && hasDynamicProps {
 			if dynamicValue, ok := dp.DynamicProps(headerTemplate.value); ok {
 				value = dynamicValue
 			}
-		}
-		if len(headerTemplate.tokenReplacements) > 0 {
-			var tokens map[string]string
-			if oauthState != nil {
-				tokens = oauthState.tokens
-			}
-			value = resolveOAuthTemplates(value, tokens, headerTemplate.tokenReplacements)
 		}
 		headers[k] = value
 	}

--- a/internal/io/http/rest_sink.go
+++ b/internal/io/http/rest_sink.go
@@ -17,6 +17,7 @@ package http
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/lf-edge/ekuiper/contract/v2/api"
@@ -27,9 +28,29 @@ import (
 
 type RestSink struct {
 	*ClientConf
-	noHeaderTemplate   bool
 	noFormdataTemplate bool
+	headerTemplates    map[string]restHeaderTemplate
+	hasHeaderTemplates bool
+	hasDynamicHeaders  bool
 }
+
+type restHeaderTemplate struct {
+	value             string
+	dynamic           bool
+	tokenReplacements []tokenReplacement
+}
+
+type tokenReplacement struct {
+	target string
+	field  string
+}
+
+var (
+	oauthTemplatePattern  = regexp.MustCompile(`{{\s*\.(access_token|refresh_token|token_type|id_token|expires_in)\s*}}`)
+	simpleTemplatePattern = regexp.MustCompile(`{{\s*\.([[:word:]]+)\s*}}`)
+)
+
+const oauthTemplateMarkerPrefix = "__ekuiper_oauth_"
 
 var bodyTypeFormat = map[string]string{
 	"json": "json",
@@ -48,7 +69,84 @@ func (r *RestSink) Provision(ctx api.StreamContext, configs map[string]any) erro
 	if rf, ok := bodyTypeFormat[r.ClientConf.config.BodyType]; ok && r.ClientConf.config.Format != rf {
 		return fmt.Errorf("format must be %s if bodyType is %s", rf, r.ClientConf.config.BodyType)
 	}
+	r.headerTemplates = make(map[string]restHeaderTemplate, len(r.config.Headers))
+	for k, v := range r.config.Headers {
+		if r.accessConf != nil {
+			r.headerTemplates[k] = newOAuthHeaderTemplate(v)
+		} else {
+			h := restHeaderTemplate{value: v, dynamic: strings.Contains(v, "{{")}
+			r.headerTemplates[k] = h
+		}
+		if h := r.headerTemplates[k]; h.dynamic || len(h.tokenReplacements) > 0 {
+			r.hasHeaderTemplates = true
+			if h.dynamic {
+				r.hasDynamicHeaders = true
+			}
+		}
+	}
 	return nil
+}
+
+// Consume separates OAuth response fields from templates that are evaluated
+// against rule output by the common sink transform operator.
+func (r *RestSink) Consume(props map[string]any) {
+	deletePropFold(props, "oauth")
+	if r.accessConf != nil {
+		deletePropFold(props, "body")
+		for key, value := range props {
+			if strings.EqualFold(key, "headers") {
+				switch headers := value.(type) {
+				case map[string]any:
+					maskedHeaders := make(map[string]any, len(headers))
+					for k := range headers {
+						maskedHeaders[k] = r.headerTemplates[k].value
+					}
+					props[key] = maskedHeaders
+				case map[string]string:
+					maskedHeaders := make(map[string]string, len(headers))
+					for k := range headers {
+						maskedHeaders[k] = r.headerTemplates[k].value
+					}
+					props[key] = maskedHeaders
+				}
+			}
+		}
+	}
+}
+
+func maskOAuthTemplates(value string) string {
+	return oauthTemplatePattern.ReplaceAllString(value, oauthTemplateMarkerPrefix+"${1}__")
+}
+
+func newOAuthHeaderTemplate(value string) restHeaderTemplate {
+	masked := maskOAuthTemplates(value)
+	h := restHeaderTemplate{value: masked, dynamic: strings.Contains(masked, "{{")}
+	for _, match := range simpleTemplatePattern.FindAllStringSubmatch(value, -1) {
+		target := match[0]
+		field := match[1]
+		if oauthTemplatePattern.MatchString(target) {
+			target = oauthTemplateMarkerPrefix + field + "__"
+		}
+		h.tokenReplacements = append(h.tokenReplacements, tokenReplacement{target: target, field: field})
+	}
+	return h
+}
+
+func resolveOAuthTemplates(value string, tokens map[string]string, replacements []tokenReplacement) string {
+	for _, replacement := range replacements {
+		if token, ok := tokens[replacement.field]; ok {
+			value = strings.ReplaceAll(value, replacement.target, token)
+		}
+	}
+	return value
+}
+
+func deletePropFold(props map[string]any, name string) {
+	for key := range props {
+		if strings.EqualFold(key, name) {
+			delete(props, key)
+		}
+	}
 }
 
 func (r *RestSink) Close(ctx api.StreamContext) error {
@@ -69,27 +167,11 @@ func (r *RestSink) Collect(ctx api.StreamContext, item api.RawTuple) error {
 	bodyType := r.config.BodyType
 	method := r.config.Method
 	u := r.config.Url
-	// if auth is set, the auth is handled by the client connect
-	headers := r.config.Headers
-	if r.accessConf != nil {
-		headers = r.parsedHeaders
-	}
+	headers := r.prepareHeaders(item)
 	formData := r.config.FormData
 
-	if dp, ok := item.(api.HasDynamicProps); ok {
-		if !r.noHeaderTemplate {
-			r.noHeaderTemplate = true
-			headers = make(map[string]string, len(r.parsedHeaders))
-			for k, v := range r.parsedHeaders {
-				nv, ok := dp.DynamicProps(v)
-				if ok {
-					r.noHeaderTemplate = false
-					headers[k] = nv
-				} else {
-					headers[k] = v
-				}
-			}
-		}
+	dp, hasDynamicProps := item.(api.HasDynamicProps)
+	if hasDynamicProps {
 		nb, ok := dp.DynamicProps(bodyType)
 		if ok {
 			bodyType = nb
@@ -176,6 +258,52 @@ func (r *RestSink) Collect(ctx api.StreamContext, item api.RawTuple) error {
 		}
 	}
 	return nil
+}
+
+func (r *RestSink) prepareHeaders(item api.RawTuple) map[string]string {
+	if !r.hasHeaderTemplates {
+		if r.config.Compression != "" {
+			return cloneHeaders(r.config.Headers)
+		}
+		return r.config.Headers
+	}
+	oauthState := r.oauthRuntimeState()
+	if r.accessConf != nil && !r.hasDynamicHeaders && oauthState != nil && r.config.Compression == "" {
+		return oauthState.headers
+	}
+	headers := make(map[string]string, len(r.headerTemplates))
+	dp, hasDynamicProps := item.(api.HasDynamicProps)
+	for k, headerTemplate := range r.headerTemplates {
+		if !headerTemplate.dynamic && oauthState != nil {
+			if resolved, ok := oauthState.headers[k]; ok {
+				headers[k] = resolved
+				continue
+			}
+		}
+		value := headerTemplate.value
+		if headerTemplate.dynamic && hasDynamicProps {
+			if dynamicValue, ok := dp.DynamicProps(headerTemplate.value); ok {
+				value = dynamicValue
+			}
+		}
+		if len(headerTemplate.tokenReplacements) > 0 {
+			var tokens map[string]string
+			if oauthState != nil {
+				tokens = oauthState.tokens
+			}
+			value = resolveOAuthTemplates(value, tokens, headerTemplate.tokenReplacements)
+		}
+		headers[k] = value
+	}
+	return headers
+}
+
+func cloneHeaders(headers map[string]string) map[string]string {
+	result := make(map[string]string, len(headers))
+	for k, v := range headers {
+		result[k] = v
+	}
+	return result
 }
 
 func GetSink() api.Sink {

--- a/internal/io/http/rest_sink_test.go
+++ b/internal/io/http/rest_sink_test.go
@@ -473,6 +473,10 @@ func TestRestSinkOAuthClientCredentials(t *testing.T) {
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			}
+			if r.Header.Get("X-Row") != "row-value" || r.Header.Get("X-Combined") != "row-value/mock_access_token" {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`{"status":"ok"}`))
 			return
@@ -490,6 +494,8 @@ func TestRestSinkOAuthClientCredentials(t *testing.T) {
 		"method": "POST",
 		"headers": map[string]interface{}{
 			"Authorization": "Bearer {{.access_token}}",
+			"X-Row":         "{{.row_value}}",
+			"X-Combined":    "{{.row_value}}/{{.access_token}}",
 		},
 		"oauth": map[string]interface{}{
 			"access": map[string]interface{}{
@@ -515,10 +521,65 @@ func TestRestSinkOAuthClientCredentials(t *testing.T) {
 	// 4. Collect (Send Data verifying token)
 	data := &xsql.RawTuple{
 		Rawdata: []byte(`{"data":123}`),
+		Props: map[string]string{
+			s.headerTemplates["X-Row"].value:      "row-value",
+			s.headerTemplates["X-Combined"].value: "row-value/__ekuiper_oauth_access_token__",
+		},
 	}
 	err = s.Collect(ctx, data)
 	require.NoError(t, err)
 
 	err = s.Close(ctx)
 	require.NoError(t, err)
+}
+
+func TestRestSinkStaticHeadersFastPath(t *testing.T) {
+	ctx := mockContext.NewMockContext("staticHeaders", "op")
+	s := &RestSink{}
+	require.NoError(t, s.Provision(ctx, map[string]interface{}{
+		"url": "http://localhost/data",
+		"headers": map[string]interface{}{
+			"Content-Type": "application/json",
+			"X-Static":     "constant",
+		},
+	}))
+	require.False(t, s.hasHeaderTemplates)
+
+	data := &xsql.RawTuple{Rawdata: []byte(`{"value":1}`)}
+	require.Zero(t, testing.AllocsPerRun(1000, func() {
+		_ = s.prepareHeaders(data)
+	}))
+	require.Equal(t, s.config.Headers, s.prepareHeaders(data))
+}
+
+func TestRestSinkOAuthHeadersFastPath(t *testing.T) {
+	ctx := mockContext.NewMockContext("oauthHeaders", "op")
+	s := &RestSink{}
+	require.NoError(t, s.Provision(ctx, map[string]interface{}{
+		"url": "http://localhost/data",
+		"headers": map[string]interface{}{
+			"Authorization": "Bearer {{.access_token}}",
+			"Content-Type":  "application/json",
+		},
+		"oauth": map[string]interface{}{
+			"access": map[string]interface{}{
+				"url":    "http://localhost/token",
+				"expire": "3600",
+			},
+		},
+	}))
+	require.False(t, s.hasDynamicHeaders)
+	require.NoError(t, s.updateToken(ctx, map[string]interface{}{"access_token": "token-one"}))
+
+	data := &xsql.RawTuple{Rawdata: []byte(`{"value":1}`)}
+	require.Zero(t, testing.AllocsPerRun(1000, func() {
+		_ = s.prepareHeaders(data)
+	}))
+	first := s.prepareHeaders(data)
+	require.Equal(t, "Bearer token-one", first["Authorization"])
+
+	require.NoError(t, s.updateToken(ctx, map[string]interface{}{"access_token": "token-two"}))
+	second := s.prepareHeaders(data)
+	require.Equal(t, "Bearer token-one", first["Authorization"])
+	require.Equal(t, "Bearer token-two", second["Authorization"])
 }

--- a/internal/io/http/rest_sink_test.go
+++ b/internal/io/http/rest_sink_test.go
@@ -413,7 +413,7 @@ func TestRestSinkAuth(t *testing.T) {
 				"method":    "get",
 				"debugResp": true,
 				"headers": map[string]interface{}{
-					"token": "{{.message}}",
+					"token": "{{.access_token}}",
 				},
 				"oauth": tt.authSetting,
 			}))
@@ -473,7 +473,7 @@ func TestRestSinkOAuthClientCredentials(t *testing.T) {
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			}
-			if r.Header.Get("X-Row") != "row-value" || r.Header.Get("X-Combined") != "row-value/mock_access_token" {
+			if r.Header.Get("X-Row") != "row-value" {
 				w.WriteHeader(http.StatusBadRequest)
 				return
 			}
@@ -494,8 +494,7 @@ func TestRestSinkOAuthClientCredentials(t *testing.T) {
 		"method": "POST",
 		"headers": map[string]interface{}{
 			"Authorization": "Bearer {{.access_token}}",
-			"X-Row":         "{{.row_value}}",
-			"X-Combined":    "{{.row_value}}/{{.access_token}}",
+			"X-Row":         `{{index . 0 "row_value"}}`,
 		},
 		"oauth": map[string]interface{}{
 			"access": map[string]interface{}{
@@ -522,8 +521,7 @@ func TestRestSinkOAuthClientCredentials(t *testing.T) {
 	data := &xsql.RawTuple{
 		Rawdata: []byte(`{"data":123}`),
 		Props: map[string]string{
-			s.headerTemplates["X-Row"].value:      "row-value",
-			s.headerTemplates["X-Combined"].value: "row-value/__ekuiper_oauth_access_token__",
+			s.headerTemplates["X-Row"].value: "row-value",
 		},
 	}
 	err = s.Collect(ctx, data)
@@ -531,6 +529,51 @@ func TestRestSinkOAuthClientCredentials(t *testing.T) {
 
 	err = s.Close(ctx)
 	require.NoError(t, err)
+}
+
+func TestRestSinkRejectsMixedOAuthAndSQLHeader(t *testing.T) {
+	ctx := mockContext.NewMockContext("mixedOAuthHeader", "op")
+	s := &RestSink{}
+	err := s.Provision(ctx, map[string]interface{}{
+		"url": "http://localhost/data",
+		"headers": map[string]interface{}{
+			"X-Combined": `{{index . 0 "row_value"}}/{{.access_token}}`,
+		},
+		"oauth": map[string]interface{}{
+			"access": map[string]interface{}{"url": "http://localhost/token", "expire": "3600"},
+		},
+	})
+	require.EqualError(t, err, `header "X-Combined" cannot mix OAuth and SQL templates`)
+}
+
+func TestRestSinkRejectsUnsupportedOAuthTemplateSyntax(t *testing.T) {
+	ctx := mockContext.NewMockContext("unsupportedOAuthHeader", "op")
+	s := &RestSink{}
+	err := s.Provision(ctx, map[string]interface{}{
+		"url": "http://localhost/data",
+		"headers": map[string]interface{}{
+			"Authorization": `Bearer {{printf "%s" .access_token}}`,
+		},
+		"oauth": map[string]interface{}{
+			"access": map[string]interface{}{"url": "http://localhost/token", "expire": "3600"},
+		},
+	})
+	require.ErrorContains(t, err, "only simple placeholders such as {{.access_token}} are supported")
+}
+
+func TestRestSinkRejectsMissingOAuthResponseField(t *testing.T) {
+	ctx := mockContext.NewMockContext("missingOAuthField", "op")
+	s := &RestSink{}
+	require.NoError(t, s.Provision(ctx, map[string]interface{}{
+		"url": "http://localhost/data",
+		"headers": map[string]interface{}{
+			"Authorization": "Bearer {{.access_token}}",
+		},
+		"oauth": map[string]interface{}{
+			"access": map[string]interface{}{"url": "http://localhost/token", "expire": "3600"},
+		},
+	}))
+	require.EqualError(t, s.updateToken(ctx, map[string]interface{}{"accesstoken": "token"}), `OAuth response does not contain required field "access_token"`)
 }
 
 func TestRestSinkStaticHeadersFastPath(t *testing.T) {

--- a/internal/io/http/rest_sink_test.go
+++ b/internal/io/http/rest_sink_test.go
@@ -583,3 +583,37 @@ func TestRestSinkOAuthHeadersFastPath(t *testing.T) {
 	require.Equal(t, "Bearer token-one", first["Authorization"])
 	require.Equal(t, "Bearer token-two", second["Authorization"])
 }
+
+func TestRestSinkStaticHeadersFromFirstCollect(t *testing.T) {
+	var requestCount int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if r.Header.Get("Authorization") != "Bearer fixed-token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	ctx := mockContext.NewMockContext("staticAuth", "op")
+	s := &RestSink{}
+	require.NoError(t, s.Provision(ctx, map[string]interface{}{
+		"url":    ts.URL,
+		"method": "POST",
+		"headers": map[string]interface{}{
+			"Authorization": "Bearer fixed-token",
+			"Content-Type":  "application/json",
+		},
+		"oauth": map[string]interface{}{
+			"access":  map[string]interface{}{},
+			"refresh": map[string]interface{}{},
+		},
+	}))
+	require.NoError(t, s.Connect(ctx, func(string, string) {}))
+
+	data := &xsql.RawTuple{Rawdata: []byte(`{"value":1}`)}
+	require.NoError(t, s.Collect(ctx, data), "the first request must retain static headers")
+	require.NoError(t, s.Collect(ctx, data), "subsequent requests must retain static headers")
+	require.Equal(t, 2, requestCount)
+}

--- a/internal/topo/planner/planner_sink.go
+++ b/internal/topo/planner/planner_sink.go
@@ -92,6 +92,10 @@ func SinkToComp(tp *topo.Topo, sinkType string, sinkName string, props map[strin
 	if err := s.Provision(tp.GetContext(), props); err != nil {
 		return nil, err
 	}
+	// Some sinks consume sink-specific properties before the common transform
+	// planning below. Keep the complete configuration for a possible resend
+	// sink, which must be provisioned exactly like the primary sink.
+	resendProps := copyProps(props)
 	tp.GetContext().GetLogger().Infof("provision sink %s with props %+v", sinkName, props)
 	// consume common conf in sink itself, swallow and not pass it to common conf
 	if pc, ok := s.(model.PropsConsumer); ok {
@@ -131,12 +135,12 @@ func SinkToComp(tp *topo.Topo, sinkType string, sinkName string, props map[strin
 		s, _ := io.Sink(sinkType)
 		// TODO currently, the destination prop must be named topic
 		if commonConf.ResendDestination != "" {
-			props["topic"] = commonConf.ResendDestination
+			resendProps["topic"] = commonConf.ResendDestination
 		}
-		if err = s.Provision(tp.GetContext(), props); err != nil {
+		if err = s.Provision(tp.GetContext(), resendProps); err != nil {
 			return nil, err
 		}
-		tp.GetContext().GetLogger().Infof("provision sink %s with props %+v", sinkName, props)
+		tp.GetContext().GetLogger().Infof("provision sink %s with props %+v", sinkName, resendProps)
 
 		cacheOp, err := node.NewCacheOp(tp.GetContext(), fmt.Sprintf("%s_cache", sinkName), rule.Options, &commonConf.SinkConf)
 		if err != nil {

--- a/internal/topo/planner/planner_sink_test.go
+++ b/internal/topo/planner/planner_sink_test.go
@@ -422,7 +422,6 @@ func TestRestOAuthAndRuleOutputHeaderTemplates(t *testing.T) {
 		"headers": map[string]any{
 			"Authorization": "Bearer {{.access_token}}",
 			"X-Row":         `{{index . 0 "row_value"}}`,
-			"X-Combined":    `{{index . 0 "row_value"}}/{{.access_token}}`,
 		},
 		"oAuth": map[string]any{
 			"access": map[string]any{
@@ -452,9 +451,6 @@ func TestRestOAuthAndRuleOutputHeaderTemplates(t *testing.T) {
 	rowValue, ok := dynamicProps.DynamicProps(`{{index . 0 "row_value"}}`)
 	require.True(t, ok)
 	require.Equal(t, "row-value", rowValue)
-	combined, ok := dynamicProps.DynamicProps(`{{index . 0 "row_value"}}/__ekuiper_oauth_access_token__`)
-	require.True(t, ok)
-	require.Equal(t, "row-value/__ekuiper_oauth_access_token__", combined)
 }
 
 func TestSinkSchema(t *testing.T) {

--- a/internal/topo/planner/planner_sink_test.go
+++ b/internal/topo/planner/planner_sink_test.go
@@ -412,6 +412,51 @@ func TestFindTemplates(t *testing.T) {
 	}
 }
 
+func TestRestOAuthAndRuleOutputHeaderTemplates(t *testing.T) {
+	tp, err := topo.NewWithNameAndOptions("test", defaultOption)
+	require.NoError(t, err)
+
+	props := map[string]any{
+		"url":    "http://localhost/data",
+		"method": "POST",
+		"headers": map[string]any{
+			"Authorization": "Bearer {{.access_token}}",
+			"X-Row":         `{{index . 0 "row_value"}}`,
+			"X-Combined":    `{{index . 0 "row_value"}}/{{.access_token}}`,
+		},
+		"oAuth": map[string]any{
+			"access": map[string]any{
+				"url":    "http://localhost/token",
+				"expire": "3600",
+			},
+			"refresh": map[string]any{
+				"url":  "http://localhost/refresh",
+				"body": `{"refresh_token":"{{.refresh_token}}"}`,
+			},
+		},
+	}
+	comp, err := SinkToComp(tp, "rest", "rest_0", props, &def.Rule{Options: defaultOption}, 1, nil)
+	require.NoError(t, err)
+
+	transformOp, ok := comp.Nodes()[0].(*node.TransformOp)
+	require.True(t, ok)
+	result := transformOp.Worker(tp.GetContext(), &xsql.Tuple{Message: map[string]any{
+		"row_value": "row-value",
+		"number":    42,
+	}})
+	require.Len(t, result, 1)
+	_, isError := result[0].(error)
+	require.False(t, isError, "OAuth templates must be evaluated from the token response, not rule output: %v", result[0])
+	dynamicProps, ok := result[0].(api.HasDynamicProps)
+	require.True(t, ok)
+	rowValue, ok := dynamicProps.DynamicProps(`{{index . 0 "row_value"}}`)
+	require.True(t, ok)
+	require.Equal(t, "row-value", rowValue)
+	combined, ok := dynamicProps.DynamicProps(`{{index . 0 "row_value"}}/__ekuiper_oauth_access_token__`)
+	require.True(t, ok)
+	require.Equal(t, "row-value/__ekuiper_oauth_access_token__", combined)
+}
+
 func TestSinkSchema(t *testing.T) {
 	tc := []struct {
 		name string


### PR DESCRIPTION
## What changed

- Classify each REST sink header as static, OAuth-only, or rule-output-only.
- Allow OAuth and rule-output templates in different headers, while rejecting a single header that combines both kinds.
- Restrict OAuth header templates to the simple placeholders `{{.access_token}}`, `{{.refresh_token}}`, `{{.token_type}}`, `{{.id_token}}`, and `{{.expires_in}}`.
- Publish the complete immutable OAuth runtime state atomically for REST sinks, HTTP pull sources, and shared HTTP lookup sources.
- Coalesce concurrent token refresh attempts, including failed attempts, within each HTTP client.
- Make HTTP lookup acquire its initial token during connection.
- Preserve static REST headers from the first request when OAuth access configuration is empty.
- Preserve the complete sink configuration when provisioning a resend sink.
- Add service-level FVT coverage for the complete rule-to-OAuth-to-REST flow in the default batch mode.

## Root cause

The sink planner recursively treated every template in REST and OAuth configuration as a SQL row template. As a result, token fields could be evaluated against a row collection. Separately, the old header-template shortcut rebuilt the first request from an empty parsed-header map when static authorization was used, dropping authorization only on the first record.

OAuth headers, bodies, refresh templates, and update timestamps were also stored in separate mutable fields on the shared HTTP client configuration. HTTP lookup tables can be attached by multiple rules, so concurrent lookups and token refreshes could read and write that state without synchronization. A mutex serialized refreshes but caused every waiter to retry sequentially when a refresh failed.

## Template contract

Each header has one template data source:

- OAuth-only headers may use the five supported simple OAuth placeholders.
- Rule-output-only headers may use SQL row templates.
- Static headers contain no template.
- A single header that mixes OAuth and rule-output placeholders is rejected during provisioning.

Other simple placeholders, including `{{.message}}`, `{{.scope}}`, and extension response fields, are rule-output templates and do not read the OAuth token response. Token endpoints must return the supported OAuth field names used by the configured headers.

## Impact

REST sinks can use OAuth token fields and SQL row fields in separate headers. OAuth headers are resolved when the token is acquired or refreshed, while SQL headers are evaluated only after rule output is available. Static authorization is retained on the first request.

REST sinks, HTTP pull sources, and shared HTTP lookup sources now read one immutable OAuth state generation containing request headers/body, refresh headers/body, and the update timestamp. Concurrent requests using the same `ClientConf` share one in-flight refresh attempt whether it succeeds or fails, preventing failure latency from growing linearly with the number of lookup callers. Separate REST sink instances still own separate HTTP clients and token states.

Configurations that previously relied on arbitrary token-response fields in REST headers must use one of the documented OAuth response field names. Combined OAuth/row templates within one header are intentionally unsupported.

## Validation

- `go test ./internal/io/http -skip "^TestRestSinkRecoverErr$" -count=1`
- `go test -race ./internal/io/http -skip "^TestRestSinkRecoverErr$" -count=1`
- `go test ./internal/io/http -run "^TestLookupOAuthConcurrentRefresh(Failure)?$" -count=20`
- `go test -race ./internal/io/http -run "^TestLookupOAuthConcurrentRefresh(Failure)?$" -count=5`
- `go test ./internal/topo/planner -count=1`
- `go test ./fvt -run "^TestRuleSuite/TestRestSinkOAuthAndRowHeaderTemplates$" -count=1`
- `git diff --check`