### PR TITLE
docs(rest): escape OAuth template placeholders

### DIFF
--- a/docs/en_US/guide/sinks/builtin/rest.md
+++ b/docs/en_US/guide/sinks/builtin/rest.md
@@ -44,7 +44,7 @@ will be sent individually.
 
 Example to use oAuth style authentication:
 
-OAuth header templates support only the simple placeholders `{{.access_token}}`, `{{.refresh_token}}`, `{{.token_type}}`, `{{.id_token}}`, and `{{.expires_in}}`. The names must exactly match the JSON fields returned by the token endpoint. Other placeholders, such as `{{.message}}`, `{{.scope}}`, and `{{.custom_token}}`, are evaluated only against the rule output and cannot read fields from the token response. Token endpoints must therefore return the supported field names used by the configured headers. A single header cannot mix an OAuth placeholder with a rule-output template, but different headers may use OAuth and rule-output templates separately.
+OAuth header templates support only the simple placeholders <code v-pre>{{.access_token}}</code>, <code v-pre>{{.refresh_token}}</code>, <code v-pre>{{.token_type}}</code>, <code v-pre>{{.id_token}}</code>, and <code v-pre>{{.expires_in}}</code>. The names must exactly match the JSON fields returned by the token endpoint. Other placeholders, such as <code v-pre>{{.message}}</code>, <code v-pre>{{.scope}}</code>, and <code v-pre>{{.custom_token}}</code>, are evaluated only against the rule output and cannot read fields from the token response. Token endpoints must therefore return the supported field names used by the configured headers. A single header cannot mix an OAuth placeholder with a rule-output template, but different headers may use OAuth and rule-output templates separately.
 
 ```json
 {

--- a/docs/zh_CN/guide/sinks/builtin/rest.md
+++ b/docs/zh_CN/guide/sinks/builtin/rest.md
@@ -43,7 +43,7 @@ REST 服务通常需要特定的数据格式。 这可以由公共目标属性 `
 
 使用 OAuth 风格鉴权的示例:
 
-OAuth Header 模板仅支持简单占位符 `{{.access_token}}`、`{{.refresh_token}}`、`{{.token_type}}`、`{{.id_token}}` 和 `{{.expires_in}}`，字段名必须与 token 接口返回的 JSON 字段完全一致。其他占位符，例如 `{{.message}}`、`{{.scope}}` 和 `{{.custom_token}}`，只会根据规则输出求值，不能读取 token 响应字段。因此，token 接口必须返回 Header 配置所使用的受支持字段名。单个 Header 不能同时包含 OAuth 占位符和规则输出模板，但不同 Header 可以分别使用 OAuth 和规则输出模板。
+OAuth Header 模板仅支持简单占位符 <code v-pre>{{.access_token}}</code>、<code v-pre>{{.refresh_token}}</code>、<code v-pre>{{.token_type}}</code>、<code v-pre>{{.id_token}}</code> 和 <code v-pre>{{.expires_in}}</code>，字段名必须与 token 接口返回的 JSON 字段完全一致。其他占位符，例如 <code v-pre>{{.message}}</code>、<code v-pre>{{.scope}}</code> 和 <code v-pre>{{.custom_token}}</code>，只会根据规则输出求值，不能读取 token 响应字段。因此，token 接口必须返回 Header 配置所使用的受支持字段名。单个 Header 不能同时包含 OAuth 占位符和规则输出模板，但不同 Header 可以分别使用 OAuth 和规则输出模板。
 
 ```json
 {


### PR DESCRIPTION
## Summary

- Prevent Vue from evaluating REST OAuth template placeholders in the generated documentation.
- Apply the same fix to the English and Chinese REST sink pages.

## Root cause

The OAuth placeholders added by #4094 used ordinary Markdown inline code. After Markdown rendering, Vue still interpreted values such as `{{.access_token}}` as template expressions and failed because `.access_token` is not a valid standalone JavaScript expression.

## Fix

Render the placeholders with `<code v-pre>` so they remain visible as literal eKuiper templates and are skipped by the Vue compiler.

## Validation

- Markdown lint passed for both modified files.
- `@vue/compiler-dom` 3.3.11 reproduces the failure without `v-pre` and compiles the corrected markup successfully.
- The full documentation frontend could not be built locally because `emqx/emqx-io-docs-frontend` is not accessible with the current GitHub credentials.
