### PR TITLE
fix(window): run WHERE after window

### DIFF
--- a/docs/en_US/guide/sinks/builtin/rest.md
+++ b/docs/en_US/guide/sinks/builtin/rest.md
@@ -44,7 +44,7 @@ will be sent individually.
 
 Example to use oAuth style authentication:
 
-OAuth header templates support only the simple placeholders `{{.access_token}}`, `{{.refresh_token}}`, `{{.token_type}}`, `{{.id_token}}`, and `{{.expires_in}}`. The names must exactly match the JSON fields returned by the token endpoint. Other placeholders, such as `{{.message}}`, `{{.scope}}`, and `{{.custom_token}}`, are evaluated only against the rule output and cannot read fields from the token response. Token endpoints must therefore return the supported field names used by the configured headers. A single header cannot mix an OAuth placeholder with a rule-output template, but different headers may use OAuth and rule-output templates separately.
+OAuth header templates support only the simple placeholders <code v-pre>{{.access_token}}</code>, <code v-pre>{{.refresh_token}}</code>, <code v-pre>{{.token_type}}</code>, <code v-pre>{{.id_token}}</code>, and <code v-pre>{{.expires_in}}</code>. The names must exactly match the JSON fields returned by the token endpoint. Other placeholders, such as <code v-pre>{{.message}}</code>, <code v-pre>{{.scope}}</code>, and <code v-pre>{{.custom_token}}</code>, are evaluated only against the rule output and cannot read fields from the token response. Token endpoints must therefore return the supported field names used by the configured headers. A single header cannot mix an OAuth placeholder with a rule-output template, but different headers may use OAuth and rule-output templates separately.
 
 ```json
 {

--- a/docs/zh_CN/guide/sinks/builtin/rest.md
+++ b/docs/zh_CN/guide/sinks/builtin/rest.md
@@ -43,7 +43,7 @@ REST 服务通常需要特定的数据格式。 这可以由公共目标属性 `
 
 使用 OAuth 风格鉴权的示例:
 
-OAuth Header 模板仅支持简单占位符 `{{.access_token}}`、`{{.refresh_token}}`、`{{.token_type}}`、`{{.id_token}}` 和 `{{.expires_in}}`，字段名必须与 token 接口返回的 JSON 字段完全一致。其他占位符，例如 `{{.message}}`、`{{.scope}}` 和 `{{.custom_token}}`，只会根据规则输出求值，不能读取 token 响应字段。因此，token 接口必须返回 Header 配置所使用的受支持字段名。单个 Header 不能同时包含 OAuth 占位符和规则输出模板，但不同 Header 可以分别使用 OAuth 和规则输出模板。
+OAuth Header 模板仅支持简单占位符 <code v-pre>{{.access_token}}</code>、<code v-pre>{{.refresh_token}}</code>、<code v-pre>{{.token_type}}</code>、<code v-pre>{{.id_token}}</code> 和 <code v-pre>{{.expires_in}}</code>，字段名必须与 token 接口返回的 JSON 字段完全一致。其他占位符，例如 <code v-pre>{{.message}}</code>、<code v-pre>{{.scope}}</code> 和 <code v-pre>{{.custom_token}}</code>，只会根据规则输出求值，不能读取 token 响应字段。因此，token 接口必须返回 Header 配置所使用的受支持字段名。单个 Header 不能同时包含 OAuth 占位符和规则输出模板，但不同 Header 可以分别使用 OAuth 和规则输出模板。
 
 ```json
 {

--- a/internal/topo/planner/statewindow_where_test.go
+++ b/internal/topo/planner/statewindow_where_test.go
@@ -1,0 +1,200 @@
+// Copyright 2025 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package planner
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
+	"github.com/lf-edge/ekuiper/v2/internal/pkg/store"
+	"github.com/lf-edge/ekuiper/v2/internal/topo/node"
+	"github.com/lf-edge/ekuiper/v2/internal/topo/operator"
+	"github.com/lf-edge/ekuiper/v2/internal/xsql"
+	"github.com/lf-edge/ekuiper/v2/pkg/ast"
+	mockContext "github.com/lf-edge/ekuiper/v2/pkg/mock/context"
+)
+
+func findWindowPlan(p LogicalPlan) *WindowPlan {
+	if w, ok := p.(*WindowPlan); ok {
+		return w
+	}
+	for _, c := range p.Children() {
+		if r := findWindowPlan(c); r != nil {
+			return r
+		}
+	}
+	return nil
+}
+
+func findFilterPlan(p LogicalPlan) *FilterPlan {
+	if fp, ok := p.(*FilterPlan); ok {
+		return fp
+	}
+	for _, c := range p.Children() {
+		if r := findFilterPlan(c); r != nil {
+			return r
+		}
+	}
+	return nil
+}
+
+func setupVehicleStatusStream(t *testing.T) {
+	kv, err := store.GetKV("stream")
+	require.NoError(t, err)
+	s, err := json.Marshal(&xsql.StreamInfo{
+		StreamType: ast.TypeStream,
+		Statement:  `CREATE STREAM vehicle_status (soc BIGINT, charge_status string) WITH (DATASOURCE="vehicle_status", FORMAT="json");`,
+	})
+	require.NoError(t, err)
+	require.NoError(t, kv.Set("vehicle_status", string(s)))
+}
+
+// TestStateWindowWhereNotPushedDown verifies that a WHERE clause on a state
+// window is NOT pushed below the window. The FilterPlan must sit above the
+// WindowPlan (so the filter runs after the window emits), and the WindowPlan
+// must not carry the WHERE as its own condition (which would create a
+// windowFilter operator before the window).
+func TestStateWindowWhereNotPushedDown(t *testing.T) {
+	setupVehicleStatusStream(t)
+
+	sql := `SELECT collect(*) AS charge_data FROM vehicle_status WHERE soc % 10 = 0 AND changed_col(true, soc % 10 = 0) GROUP BY statewindow(charge_status = 'charging', charge_status = 'discharging')`
+	stmt, err := xsql.GetStatementFromSql(sql)
+	require.NoError(t, err)
+
+	kv, err := store.GetKV("stream")
+	require.NoError(t, err)
+	p, err := CreateLogicalPlan(stmt, &def.RuleOption{BufferLength: 1024}, kv)
+	require.NoError(t, err)
+
+	explain, err := ExplainFromLogicalPlan(p, "charge_monitor")
+	require.NoError(t, err)
+	fmt.Println("==== EXPLAIN ====\n" + explain)
+
+	// Root is Project; its direct child must be the FilterPlan (WHERE after window).
+	root := p
+	require.IsType(t, &ProjectPlan{}, root)
+	var filterAbove *FilterPlan
+	for _, c := range root.Children() {
+		if fp, ok := c.(*FilterPlan); ok {
+			filterAbove = fp
+		}
+	}
+	require.NotNil(t, filterAbove, "expected FilterPlan directly under Project (WHERE after window)")
+
+	w := findWindowPlan(p)
+	require.NotNil(t, w)
+	require.Nil(t, w.condition, "state window should not carry the WHERE condition")
+
+	// No FilterPlan may live below the window (the old windowFilter placement).
+	var hasFilterBelow func(LogicalPlan) bool
+	hasFilterBelow = func(n LogicalPlan) bool {
+		if _, ok := n.(*FilterPlan); ok {
+			return true
+		}
+		for _, c := range n.Children() {
+			if hasFilterBelow(c) {
+				return true
+			}
+		}
+		return false
+	}
+	require.False(t, hasFilterBelow(w), "state window should not have a FilterPlan descendant")
+}
+
+// TestStateWindowWhereAfterRuntime verifies end-to-end that the WHERE clause
+// is evaluated AFTER the state window emits.
+//
+// The begin/emit rows deliberately have soc % 10 != 0 so that, under the old
+// WHERE-before-window behavior, the discharging row would be filtered out and
+// the window would never emit.
+//
+//	t1 soc=5  charge_status=charging     -> begin window
+//	t2 soc=10 charge_status=charging     -> collected
+//	t3 soc=15 charge_status=discharging  -> emit window
+//
+// Expected (WHERE after window): the window emits [soc=5, soc=10, soc=15] and
+// the filter keeps only the row with soc % 10 == 0, i.e. [soc=10].
+func TestStateWindowWhereAfterRuntime(t *testing.T) {
+	setupVehicleStatusStream(t)
+
+	sql := `SELECT collect(*) AS charge_data FROM vehicle_status WHERE soc % 10 = 0 GROUP BY statewindow(charge_status = 'charging', charge_status = 'discharging')`
+	stmt, err := xsql.GetStatementFromSql(sql)
+	require.NoError(t, err)
+
+	o := &def.RuleOption{BufferLength: 1024}
+	kv, err := store.GetKV("stream")
+	require.NoError(t, err)
+	p, err := CreateLogicalPlan(stmt, o, kv)
+	require.NoError(t, err)
+
+	wp := findWindowPlan(p)
+	require.NotNil(t, wp)
+	fp := findFilterPlan(p)
+	require.NotNil(t, fp)
+	require.Nil(t, wp.condition)
+
+	winOp, err := node.NewWindowV2Op("window", node.WindowConfig{
+		Type:           wp.WindowType(),
+		BeginCondition: wp.GetBeginCondition(),
+		EmitCondition:  wp.GetEmitCondition(),
+	}, o)
+	require.NoError(t, err)
+
+	fp.ExtractStateFunc()
+	filterOp := Transform(&operator.FilterOp{
+		Condition:  fp.condition,
+		StateFuncs: fp.stateFuncs,
+	}, "filter", o)
+
+	filterInput, _ := filterOp.GetInput()
+	require.NoError(t, winOp.AddOutput(filterInput, "to_filter"))
+	output := make(chan any, 10)
+	require.NoError(t, filterOp.AddOutput(output, "output"))
+
+	ctx, cancel := mockContext.NewMockContext("1", "2").WithCancel()
+	errCh := make(chan error, 10)
+	winOp.Exec(ctx, errCh)
+	filterOp.Exec(ctx, errCh)
+	time.Sleep(50 * time.Millisecond)
+
+	now := time.Now()
+	winIn, _ := winOp.GetInput()
+	winIn <- &xsql.Tuple{Message: map[string]any{"soc": int64(5), "charge_status": "charging"}, Timestamp: now}
+	winIn <- &xsql.Tuple{Message: map[string]any{"soc": int64(10), "charge_status": "charging"}, Timestamp: now.Add(1 * time.Second)}
+	winIn <- &xsql.Tuple{Message: map[string]any{"soc": int64(15), "charge_status": "discharging"}, Timestamp: now.Add(2 * time.Second)}
+	time.Sleep(100 * time.Millisecond)
+
+	select {
+	case got := <-output:
+		wt, ok := got.(*xsql.WindowTuples)
+		require.True(t, ok, "expected *xsql.WindowTuples, got %T", got)
+		maps := wt.ToMaps()
+		require.Equal(t, []map[string]any{
+			{"soc": int64(10), "charge_status": "charging"},
+		}, maps)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for window output")
+	}
+
+	cancel()
+	time.Sleep(50 * time.Millisecond)
+	winOp.Close()
+	filterOp.Close()
+}

--- a/internal/topo/planner/windowPlan.go
+++ b/internal/topo/planner/windowPlan.go
@@ -90,8 +90,12 @@ func (p *WindowPlan) BuildExplainInfo() {
 }
 
 func (p *WindowPlan) PushDownPredicate(condition ast.Expr) (ast.Expr, LogicalPlan) {
-	// not time window depends on the event, so should not filter any
-	if p.wtype == ast.COUNT_WINDOW || p.wtype == ast.SLIDING_WINDOW {
+	// not time window depends on the event, so should not filter any.
+	// state window also needs to see every row to detect state transitions
+	// (begin/emit), so the WHERE filter must run after the window rather than
+	// before it; otherwise rows that trigger a state change could be filtered
+	// out and the window would never open/close.
+	if p.wtype == ast.COUNT_WINDOW || p.wtype == ast.SLIDING_WINDOW || p.wtype == ast.STATE_WINDOW {
 		return condition, p
 	} else if p.isEventTime {
 		// TODO event time filter, need event window op support


### PR DESCRIPTION
## Summary
- State windows now run the `WHERE` clause **after** the window instead of before, matching `COUNT_WINDOW` and `SLIDING_WINDOW` behavior.
- A row that flips `charge_status` no longer gets dropped before the window sees it, so begin/emit transitions are never missed.

## Why
- A state window opens on a `begin` condition and closes on an `emit` condition, both evaluated **per input row**. When `WHERE` was pushed below the window, the rows that carry a state transition (e.g. `charge_status='discharging'`) could be filtered out, and the window would get stuck open forever or never open at all.
- This made rules like the following unusable in practice:

  ```sql
  SELECT collect(*) AS charge_data
  FROM vehicle_status
  WHERE soc % 10 = 0
  GROUP BY statewindow(charge_status = 'charging', charge_status = 'discharging')
  ```

  Most of the time `soc % 10 = 0` is false, so the `discharging` transition row was discarded and the window never emitted.
- The fix treats `STATE_WINDOW` the same as `COUNT_WINDOW` / `SLIDING_WINDOW` in `WindowPlan.PushDownPredicate`, which already "should not filter any" because their semantics depend on the events themselves.

## Changes In This PR
- `internal/topo/planner/windowPlan.go`: added `ast.STATE_WINDOW` to the no-push-down branch of `WindowPlan.PushDownPredicate`, so the `FilterPlan` stays above the `WindowPlan` and is evaluated on the emitted `WindowTuples`.
- No new operator was needed: `FilterOp.Apply` already handles `xsql.Collection` (which `WindowTuples` implements) by keeping only the matching rows.
- `FILTER(WHERE)` semantics are unchanged — it still sets `WindowPlan.condition` and runs before the window, so explicit input filtering still works as documented.
- `internal/topo/planner/statewindow_where_test.go`: added two tests:
  - `TestStateWindowWhereNotPushedDown`: asserts the explain plan has `FilterPlan` above `WindowPlan` and that the window carries no condition.
  - `TestStateWindowWhereAfterRuntime`: runs a `window -> filter` pipeline end-to-end and verifies the window emits all collected rows while the filter keeps only `soc % 10 = 0`.

## Notes
- This is a behavior change for `STATE_WINDOW`: rules that relied on `WHERE` filtering rows *before* they reach the window will now see all rows enter the window and the filter applied to the emitted result. In practice the old behavior was a correctness bug (windows could not open/close), so the new behavior is the intended one.
- `FILTER(WHERE)` remains the supported way to filter window inputs; `OVER WHEN` is still ignored at runtime by `StateWindowOp` (pre-existing limitation, out of scope here).
