### PR TITLE
feat(sink): add IoTDB predefined sink plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ PLUGINS_IN_FULL := \
 	extensions/sinks/kafka \
 	extensions/sinks/image \
 	extensions/sinks/sql   \
+	extensions/sinks/iotdb \
 	extensions/sinks/zmq \
 	extensions/sinks/tdengine3 \
 	extensions/sources/random \

--- a/docs/directory.json
+++ b/docs/directory.json
@@ -338,6 +338,10 @@
                   "path": "guide/sinks/plugin/influx2"
                 },
                 {
+                  "title": "IoTDB Sink",
+                  "path": "guide/sinks/plugin/iotdb"
+                },
+                {
                   "title": "Image Sink",
                   "path": "guide/sinks/plugin/image"
                 },
@@ -1112,6 +1116,10 @@
                 {
                   "title": "InfluxDBV2 Sink",
                   "path": "guide/sinks/plugin/influx2"
+                },
+                {
+                  "title": "IoTDB Sink",
+                  "path": "guide/sinks/plugin/iotdb"
                 },
                 {
                   "title": "Image Sink",

--- a/docs/en_US/guide/sinks/overview.md
+++ b/docs/en_US/guide/sinks/overview.md
@@ -30,6 +30,7 @@ The list of predefined sink plugins:
 - [Image sink](./plugin/image.md): sink to an image file. Only used to handle binary results.
 - [Zero MQ sink](./plugin/zmq.md): sink to Zero MQ.
 - [Kafka sink](./plugin/kafka.md): sink to Kafka.
+- [IoTDB sink](./plugin/iotdb.md): sink to Apache IoTDB, supporting both tree and table models.
 
 ## Updatable Sink
 

--- a/docs/en_US/guide/sinks/plugin/iotdb.md
+++ b/docs/en_US/guide/sinks/plugin/iotdb.md
@@ -1,0 +1,137 @@
+# IoTDB Sink
+
+The sink writes data into Apache IoTDB using the native Thrift RPC client. It supports both the tree model and the table model.
+
+## Compile the plugins
+
+In eKuiper source code root path, run the below command:
+
+```shell
+go build -trimpath --buildmode=plugin -o plugins/sinks/Iotdb.so extensions/sinks/iotdb/*.go
+```
+
+## Properties
+
+Connection properties:
+
+| Property name | Optional | Default value  | Description                                                    |
+|---------------|----------|----------------|----------------------------------------------------------------|
+| addr          | false    | 127.0.0.1:6667 | IoTDB server address in `host:port` format.                    |
+| username      | true     | root           | The username for authentication.                               |
+| password      | true     | root           | The password for authentication.                               |
+| nodeUrls      | true     | []             | Cluster node URLs. When set, it overrides the `addr` property. |
+| timeout       | true     | 5000           | Connection timeout in milliseconds.                            |
+| poolSize      | true     | 3              | The size of the connection pool.                               |
+
+Model selection:
+
+| Property name | Optional | Default value | Description                               |
+|---------------|----------|---------------|-------------------------------------------|
+| model         | false    | tree          | The data model to use: `tree` or `table`. |
+
+Tree model properties (used when `model=tree`):
+
+| Property name | Optional | Default value | Description                                                     |
+|---------------|----------|---------------|-----------------------------------------------------------------|
+| device        | true     | ""            | The device path, e.g. `root.sg1.dev1`. Required for tree model. |
+| isAligned     | true     | false         | Whether to use aligned time series.                             |
+
+Table model properties (used when `model=table`):
+
+| Property name    | Optional | Default value | Description                                                                                              |
+|------------------|----------|---------------|----------------------------------------------------------------------------------------------------------|
+| database         | true     | ""            | The database name (without the `root.` prefix; it is automatically stripped). Required for table model.   |
+| table            | true     | ""            | The target table name. Required for table model.                                                         |
+| columnCategories | true     | []            | Column categories corresponding to `measurements` one-to-one: `TAG`, `FIELD`, or `ATTRIBUTE`. Required for table model. |
+
+Data mapping properties:
+
+| Property name | Optional | Default value | Description                                                                                                              |
+|---------------|----------|---------------|--------------------------------------------------------------------------------------------------------------------------|
+| measurements  | false    | []            | List of measurement / column names.                                                                                      |
+| dataTypes     | false    | []            | IoTDB data types corresponding to `measurements` one-to-one: `INT32`, `INT64`, `FLOAT`, `DOUBLE`, `BOOLEAN`, `TEXT`, `STRING`, `TIMESTAMP`. |
+| tsFieldName   | true     | ""            | The field name of the timestamp (in milliseconds). If not set, the current time will be used.                            |
+| batchSize     | true     | 10            | The number of rows per tablet write.                                                                                     |
+
+Other common sink properties including batch settings are supported. Please refer to
+the [sink common properties](../overview.md#common-properties) for more information.
+
+## Sample usage
+
+### Tree model example
+
+Below is a sample rule for selecting temperature greater than 50 and writing into IoTDB using the tree model.
+
+```json
+{
+  "id": "iotdb_tree",
+  "sql": "SELECT * from demo_stream where temperature > 50",
+  "actions": [
+    {
+      "log": {},
+      "iotdb": {
+        "addr": "127.0.0.1:6667",
+        "username": "root",
+        "password": "root",
+        "model": "tree",
+        "device": "root.sg1.d1",
+        "measurements": ["temperature", "humidity"],
+        "dataTypes": ["FLOAT", "FLOAT"],
+        "tsFieldName": "ts",
+        "batchSize": 10
+      }
+    }
+  ]
+}
+```
+
+### Table model example
+
+Below is a sample rule for selecting temperature greater than 50 and writing into IoTDB using the table model.
+
+```json
+{
+  "id": "iotdb_table",
+  "sql": "SELECT * from demo_stream where temperature > 50",
+  "actions": [
+    {
+      "log": {},
+      "iotdb": {
+        "addr": "127.0.0.1:6667",
+        "username": "root",
+        "password": "root",
+        "model": "table",
+        "database": "iot_data",
+        "table": "sensor_data",
+        "measurements": ["device_id", "temperature", "humidity"],
+        "dataTypes": ["STRING", "FLOAT", "FLOAT"],
+        "columnCategories": ["TAG", "FIELD", "FIELD"],
+        "tsFieldName": "ts",
+        "batchSize": 10
+      }
+    }
+  ]
+}
+```
+
+## Data Types
+
+The following IoTDB data types are supported in the `dataTypes` property:
+
+| Data type  | Description                     |
+|------------|---------------------------------|
+| INT32      | 32-bit signed integer           |
+| INT64      | 64-bit signed integer           |
+| FLOAT      | Single-precision floating point |
+| DOUBLE     | Double-precision floating point |
+| BOOLEAN    | Boolean value (true / false)    |
+| TEXT       | Text string (IoTDB legacy type) |
+| STRING     | String value                    |
+| TIMESTAMP  | Timestamp value                 |
+
+## Notes
+
+- IoTDB uses Thrift RPC protocol on port 6667 by default.
+- For table model, the database is automatically created if it does not exist.
+- The `root.` prefix in the `database` field is automatically stripped for table model.
+- Missing fields in the data will be written as null values to IoTDB.

--- a/docs/en_US/guide/sinks/plugin/iotdb.md
+++ b/docs/en_US/guide/sinks/plugin/iotdb.md
@@ -50,7 +50,7 @@ Data mapping properties:
 |---------------|----------|---------------|--------------------------------------------------------------------------------------------------------------------------|
 | measurements  | false    | []            | List of measurement / column names.                                                                                      |
 | dataTypes     | false    | []            | IoTDB data types corresponding to `measurements` one-to-one: `INT32`, `INT64`, `FLOAT`, `DOUBLE`, `BOOLEAN`, `TEXT`, `STRING`, `TIMESTAMP`. |
-| tsFieldName   | true     | ""            | The field name of the timestamp (in milliseconds). If not set, the current time will be used.                            |
+| tsFieldName   | true     | ""            | The field name of the timestamp (in milliseconds). If not set, the current time will be used; when set, every row must contain this field. |
 | batchSize     | true     | 10            | The number of rows per tablet write.                                                                                     |
 
 Other common sink properties including batch settings are supported. Please refer to

--- a/docs/zh_CN/guide/sinks/overview.md
+++ b/docs/zh_CN/guide/sinks/overview.md
@@ -31,6 +31,7 @@
 - [Image sink](./plugin/image.md)：写入一个图像文件。仅用于处理二进制结果。
 - [ZeroMQ sink](./plugin/zmq.md)：输出到 ZeroMQ。
 - [Kafka sink](./plugin/kafka.md)：输出到 Kafka。
+- [IoTDB sink](./plugin/iotdb.md)：写入 Apache IoTDB，同时支持树模型和表模型。
 
 ## 更新
 

--- a/docs/zh_CN/guide/sinks/plugin/iotdb.md
+++ b/docs/zh_CN/guide/sinks/plugin/iotdb.md
@@ -1,0 +1,136 @@
+# IoTDB 目标（Sink）
+
+该插件通过原生 Thrift RPC 客户端将分析结果写入 Apache IoTDB，同时支持树模型和表模型。
+
+## 编译插件
+
+在 eKuiper 项目主目录运行如下命令：
+
+```shell
+go build -trimpath --buildmode=plugin -o plugins/sinks/Iotdb.so extensions/sinks/iotdb/*.go
+```
+
+## 属性
+
+连接属性：
+
+| 属性名称   | 是否可选 | 默认值          | 说明                                              |
+|------------|----------|-----------------|---------------------------------------------------|
+| addr       | 否       | 127.0.0.1:6667  | IoTDB 服务端地址，格式为 `host:port`。            |
+| username   | 是       | root            | 用户名。                                          |
+| password   | 是       | root            | 密码。                                            |
+| nodeUrls   | 是       | []              | 集群节点列表，设置后覆盖 `addr`。                 |
+| timeout    | 是       | 5000            | 连接超时时间，单位毫秒。                          |
+| poolSize   | 是       | 3               | 连接池大小。                                      |
+
+模型选择：
+
+| 属性名称 | 是否可选 | 默认值 | 说明                                      |
+|----------|----------|--------|-------------------------------------------|
+| model    | 否       | tree   | 数据模型：`tree` 树模型，`table` 表模型。 |
+
+树模型属性（当 `model=tree` 时使用）：
+
+| 属性名称   | 是否可选 | 默认值 | 说明                                                 |
+|------------|----------|--------|------------------------------------------------------|
+| device     | 是       | ""     | 设备路径，例如 `root.sg1.dev1`。树模型必填。         |
+| isAligned  | 是       | false  | 是否使用对齐时间序列。                               |
+
+表模型属性（当 `model=table` 时使用）：
+
+| 属性名称         | 是否可选 | 默认值 | 说明                                                                                   |
+|------------------|----------|--------|----------------------------------------------------------------------------------------|
+| database         | 是       | ""     | 数据库名（不带 `root.` 前缀，自动去除）。表模型必填。                                  |
+| table            | 是       | ""     | 目标表名。表模型必填。                                                                 |
+| columnCategories | 是       | []     | 列类别列表，与 `measurements` 一一对应：`TAG`、`FIELD`、`ATTRIBUTE`。表模型必填。      |
+
+数据映射属性：
+
+| 属性名称     | 是否可选 | 默认值 | 说明                                                                                                           |
+|--------------|----------|--------|----------------------------------------------------------------------------------------------------------------|
+| measurements | 否       | []     | 测点/列名列表。                                                                                                |
+| dataTypes    | 否       | []     | 与 `measurements` 一一对应的数据类型列表：`INT32`、`INT64`、`FLOAT`、`DOUBLE`、`BOOLEAN`、`TEXT`、`STRING`、`TIMESTAMP`。 |
+| tsFieldName  | 是       | ""     | 时间戳字段名（毫秒级）。若为空则使用当前时间。                                                                 |
+| batchSize    | 是       | 10     | 单次 tablet 写入行数。                                                                                         |
+
+其他通用的 sink 属性也支持，包括批量设置等，请参阅[公共属性](../overview.md#公共属性)。
+
+## 示例用法
+
+### 树模型示例
+
+下面是选择温度大于 50 度并使用树模型写入 IoTDB 的示例规则。
+
+```json
+{
+  "id": "iotdb_tree",
+  "sql": "SELECT * from demo_stream where temperature > 50",
+  "actions": [
+    {
+      "log": {},
+      "iotdb": {
+        "addr": "127.0.0.1:6667",
+        "username": "root",
+        "password": "root",
+        "model": "tree",
+        "device": "root.sg1.d1",
+        "measurements": ["temperature", "humidity"],
+        "dataTypes": ["FLOAT", "FLOAT"],
+        "tsFieldName": "ts",
+        "batchSize": 10
+      }
+    }
+  ]
+}
+```
+
+### 表模型示例
+
+下面是选择温度大于 50 度并使用表模型写入 IoTDB 的示例规则。
+
+```json
+{
+  "id": "iotdb_table",
+  "sql": "SELECT * from demo_stream where temperature > 50",
+  "actions": [
+    {
+      "log": {},
+      "iotdb": {
+        "addr": "127.0.0.1:6667",
+        "username": "root",
+        "password": "root",
+        "model": "table",
+        "database": "iot_data",
+        "table": "sensor_data",
+        "measurements": ["device_id", "temperature", "humidity"],
+        "dataTypes": ["STRING", "FLOAT", "FLOAT"],
+        "columnCategories": ["TAG", "FIELD", "FIELD"],
+        "tsFieldName": "ts",
+        "batchSize": 10
+      }
+    }
+  ]
+}
+```
+
+## 数据类型
+
+`dataTypes` 属性支持以下 IoTDB 数据类型：
+
+| 数据类型   | 说明              |
+|------------|-------------------|
+| INT32      | 32 位有符号整数   |
+| INT64      | 64 位有符号整数   |
+| FLOAT      | 单精度浮点数      |
+| DOUBLE     | 双精度浮点数      |
+| BOOLEAN    | 布尔值            |
+| TEXT       | 文本（IoTDB 传统类型） |
+| STRING     | 字符串            |
+| TIMESTAMP  | 时间戳            |
+
+## 注意事项
+
+- IoTDB 默认使用 Thrift RPC 协议，端口为 6667。
+- 表模型下，如果数据库不存在会自动创建。
+- 表模型的 `database` 字段会自动去除 `root.` 前缀。
+- 数据中缺失的字段将作为 null 值写入 IoTDB。

--- a/docs/zh_CN/guide/sinks/plugin/iotdb.md
+++ b/docs/zh_CN/guide/sinks/plugin/iotdb.md
@@ -50,7 +50,7 @@ go build -trimpath --buildmode=plugin -o plugins/sinks/Iotdb.so extensions/sinks
 |--------------|----------|--------|----------------------------------------------------------------------------------------------------------------|
 | measurements | 否       | []     | 测点/列名列表。                                                                                                |
 | dataTypes    | 否       | []     | 与 `measurements` 一一对应的数据类型列表：`INT32`、`INT64`、`FLOAT`、`DOUBLE`、`BOOLEAN`、`TEXT`、`STRING`、`TIMESTAMP`。 |
-| tsFieldName  | 是       | ""     | 时间戳字段名（毫秒级）。若为空则使用当前时间。                                                                 |
+| tsFieldName  | 是       | ""     | 时间戳字段名（毫秒级）。若为空则使用当前时间；配置后每一行都必须包含该字段。                                      |
 | batchSize    | 是       | 10     | 单次 tablet 写入行数。                                                                                         |
 
 其他通用的 sink 属性也支持，包括批量设置等，请参阅[公共属性](../overview.md#公共属性)。

--- a/extensions/impl/iotdb/config.go
+++ b/extensions/impl/iotdb/config.go
@@ -146,7 +146,6 @@ func (c *iotdbConfig) validate() error {
 		if c.Database == "" {
 			return fmt.Errorf("database is required when model is %q", modelTable)
 		}
-		// 表模型的 database 不需要 root. 前缀，自动去除
 		c.Database = strings.TrimPrefix(strings.TrimSpace(c.Database), "root.")
 		if c.Database == "" {
 			return fmt.Errorf("database name cannot be empty after stripping 'root.' prefix")
@@ -174,12 +173,12 @@ func (c *iotdbConfig) validate() error {
 
 // newPoolConfig builds the common client pool configuration. In cluster mode,
 // NodeUrls is authoritative and Addr does not need to be parsed.
-func (c *iotdbConfig) newPoolConfig() (*client.PoolConfig, error) {
+func (c *iotdbConfig) newPoolConfig(database string) (*client.PoolConfig, error) {
 	conf := &client.PoolConfig{
 		NodeUrls: c.NodeUrls,
 		UserName: c.Username,
 		Password: c.Password,
-		Database: c.Database,
+		Database: database,
 	}
 	if len(c.NodeUrls) > 0 {
 		return conf, nil

--- a/extensions/impl/iotdb/config.go
+++ b/extensions/impl/iotdb/config.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Timecho Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iotdb
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	modelTree  = "tree"
+	modelTable = "table"
+
+	categoryTag       = "TAG"
+	categoryField     = "FIELD"
+	categoryAttribute = "ATTRIBUTE"
+)
+
+// supportedDataTypes lists all valid IoTDB data type strings.
+var supportedDataTypes = map[string]struct{}{
+	"INT32":     {},
+	"INT64":     {},
+	"FLOAT":     {},
+	"DOUBLE":    {},
+	"BOOLEAN":   {},
+	"TEXT":      {},
+	"STRING":    {},
+	"TIMESTAMP": {},
+}
+
+// supportedCategories lists all valid IoTDB column category strings.
+var supportedCategories = map[string]struct{}{
+	categoryTag:       {},
+	categoryField:     {},
+	categoryAttribute: {},
+}
+
+// iotdbConfig is the configuration for the IoTDB sink.
+type iotdbConfig struct {
+	// connection parameters
+	Addr     string `json:"addr"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+
+	// model selection: "tree" or "table"
+	Model string `json:"model"`
+
+	// tree model parameters
+	Device    string `json:"device"`
+	IsAligned bool   `json:"isAligned"`
+
+	// table model parameters
+	Database         string   `json:"database"`
+	Table            string   `json:"table"`
+	ColumnCategories []string `json:"columnCategories"`
+
+	// common data mapping
+	Measurements []string `json:"measurements"`
+	DataTypes    []string `json:"dataTypes"`
+
+	// common write parameters
+	TsFieldName string `json:"tsFieldName"`
+	BatchSize   int    `json:"batchSize"`
+	Timeout     int64  `json:"timeout"`
+	PoolSize    int    `json:"poolSize"`
+
+	// cluster mode (optional)
+	NodeUrls []string `json:"nodeUrls"`
+}
+
+// applyDefaults fills in default values for unset fields.
+func (c *iotdbConfig) applyDefaults() {
+	if c.Addr == "" {
+		c.Addr = "127.0.0.1:6667"
+	}
+	if c.Username == "" {
+		c.Username = "root"
+	}
+	if c.Password == "" {
+		c.Password = "root"
+	}
+	if c.BatchSize <= 0 {
+		c.BatchSize = 10
+	}
+	if c.Timeout <= 0 {
+		c.Timeout = 5000
+	}
+	if c.PoolSize <= 0 {
+		c.PoolSize = 3
+	}
+}
+
+// validate checks the configuration for required fields and consistency.
+func (c *iotdbConfig) validate() error {
+	// normalize model
+	c.Model = strings.ToLower(strings.TrimSpace(c.Model))
+	if c.Model != modelTree && c.Model != modelTable {
+		return fmt.Errorf("model must be either %q or %q", modelTree, modelTable)
+	}
+
+	if len(c.Measurements) == 0 {
+		return fmt.Errorf("measurements is required")
+	}
+	if len(c.DataTypes) == 0 {
+		return fmt.Errorf("dataTypes is required")
+	}
+	if len(c.Measurements) != len(c.DataTypes) {
+		return fmt.Errorf("measurements (%d) and dataTypes (%d) must have the same length",
+			len(c.Measurements), len(c.DataTypes))
+	}
+	for i, dt := range c.DataTypes {
+		up := strings.ToUpper(strings.TrimSpace(dt))
+		if _, ok := supportedDataTypes[up]; !ok {
+			return fmt.Errorf("dataTypes[%d]=%q is not a supported IoTDB data type", i, dt)
+		}
+		c.DataTypes[i] = up
+	}
+
+	switch c.Model {
+	case modelTree:
+		if c.Device == "" {
+			return fmt.Errorf("device is required when model is %q", modelTree)
+		}
+	case modelTable:
+		if c.Database == "" {
+			return fmt.Errorf("database is required when model is %q", modelTable)
+		}
+		// 表模型的 database 不需要 root. 前缀，自动去除
+		c.Database = strings.TrimPrefix(strings.TrimSpace(c.Database), "root.")
+		if c.Database == "" {
+			return fmt.Errorf("database name cannot be empty after stripping 'root.' prefix")
+		}
+		if c.Table == "" {
+			return fmt.Errorf("table is required when model is %q", modelTable)
+		}
+		if len(c.ColumnCategories) != len(c.Measurements) {
+			return fmt.Errorf("columnCategories (%d) must have the same length as measurements (%d)",
+				len(c.ColumnCategories), len(c.Measurements))
+		}
+		for i, cat := range c.ColumnCategories {
+			up := strings.ToUpper(strings.TrimSpace(cat))
+			if _, ok := supportedCategories[up]; !ok {
+				return fmt.Errorf("columnCategories[%d]=%q is not a supported column category (TAG/FIELD/ATTRIBUTE)", i, cat)
+			}
+			c.ColumnCategories[i] = up
+		}
+	}
+	return nil
+}
+
+// splitAddr parses an "host:port" string into its parts.
+func splitAddr(addr string) (host string, port string, err error) {
+	parts := strings.Split(addr, ":")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid addr %q, expected host:port", addr)
+	}
+	return parts[0], parts[1], nil
+}

--- a/extensions/impl/iotdb/config.go
+++ b/extensions/impl/iotdb/config.go
@@ -17,7 +17,10 @@ package iotdb
 import (
 	"fmt"
 	"net"
+	"regexp"
 	"strings"
+
+	"github.com/apache/iotdb-client-go/v2/client"
 )
 
 const (
@@ -47,6 +50,8 @@ var supportedCategories = map[string]struct{}{
 	categoryField:     {},
 	categoryAttribute: {},
 }
+
+var iotdbIdentifierPattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 // iotdbConfig is the configuration for the IoTDB sink.
 type iotdbConfig struct {
@@ -91,6 +96,9 @@ func (c *iotdbConfig) applyDefaults() {
 	}
 	if c.Password == "" {
 		c.Password = "root"
+	}
+	if c.Model == "" {
+		c.Model = modelTree
 	}
 	if c.BatchSize <= 0 {
 		c.BatchSize = 10
@@ -143,6 +151,9 @@ func (c *iotdbConfig) validate() error {
 		if c.Database == "" {
 			return fmt.Errorf("database name cannot be empty after stripping 'root.' prefix")
 		}
+		if !iotdbIdentifierPattern.MatchString(c.Database) {
+			return fmt.Errorf("database %q is not a valid identifier; expected [A-Za-z_][A-Za-z0-9_]*", c.Database)
+		}
 		if c.Table == "" {
 			return fmt.Errorf("table is required when model is %q", modelTable)
 		}
@@ -159,6 +170,28 @@ func (c *iotdbConfig) validate() error {
 		}
 	}
 	return nil
+}
+
+// newPoolConfig builds the common client pool configuration. In cluster mode,
+// NodeUrls is authoritative and Addr does not need to be parsed.
+func (c *iotdbConfig) newPoolConfig() (*client.PoolConfig, error) {
+	conf := &client.PoolConfig{
+		NodeUrls: c.NodeUrls,
+		UserName: c.Username,
+		Password: c.Password,
+		Database: c.Database,
+	}
+	if len(c.NodeUrls) > 0 {
+		return conf, nil
+	}
+
+	host, port, err := splitAddr(c.Addr)
+	if err != nil {
+		return nil, err
+	}
+	conf.Host = host
+	conf.Port = port
+	return conf, nil
 }
 
 // splitAddr parses an "host:port" string into its parts. It uses

--- a/extensions/impl/iotdb/config.go
+++ b/extensions/impl/iotdb/config.go
@@ -16,6 +16,7 @@ package iotdb
 
 import (
 	"fmt"
+	"net"
 	"strings"
 )
 
@@ -160,11 +161,15 @@ func (c *iotdbConfig) validate() error {
 	return nil
 }
 
-// splitAddr parses an "host:port" string into its parts.
+// splitAddr parses an "host:port" string into its parts. It uses
+// net.SplitHostPort so IPv6 literals such as "[::1]:6667" are handled correctly.
 func splitAddr(addr string) (host string, port string, err error) {
-	parts := strings.Split(addr, ":")
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+	host, port, err = net.SplitHostPort(addr)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid addr %q, expected host:port: %w", addr, err)
+	}
+	if host == "" || port == "" {
 		return "", "", fmt.Errorf("invalid addr %q, expected host:port", addr)
 	}
-	return parts[0], parts[1], nil
+	return host, port, nil
 }

--- a/extensions/impl/iotdb/iotdb.go
+++ b/extensions/impl/iotdb/iotdb.go
@@ -20,7 +20,6 @@ import (
 	"github.com/lf-edge/ekuiper/contract/v2/api"
 
 	"github.com/lf-edge/ekuiper/v2/pkg/cast"
-	"github.com/lf-edge/ekuiper/v2/pkg/errorx"
 	"github.com/lf-edge/ekuiper/v2/pkg/model"
 )
 
@@ -86,7 +85,7 @@ func (s *iotdbSink) collect(ctx api.StreamContext, data any) error {
 	}
 	if err := s.writer.write(ctx, maps); err != nil {
 		ctx.GetLogger().Errorf("iotdb sink write error: %v", err)
-		return errorx.NewIOErr(fmt.Sprintf("iotdb sink fails to send out the data: %v", err))
+		return err
 	}
 	ctx.GetLogger().Debug("insert data into iotdb success")
 	return nil

--- a/extensions/impl/iotdb/iotdb.go
+++ b/extensions/impl/iotdb/iotdb.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Timecho Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iotdb
+
+import (
+	"fmt"
+
+	"github.com/lf-edge/ekuiper/contract/v2/api"
+
+	"github.com/lf-edge/ekuiper/v2/pkg/cast"
+	"github.com/lf-edge/ekuiper/v2/pkg/errorx"
+	"github.com/lf-edge/ekuiper/v2/pkg/model"
+)
+
+// writer is the strategy interface implemented by tree/table specific writers.
+type writer interface {
+	connect(ctx api.StreamContext, conf *iotdbConfig) error
+	write(ctx api.StreamContext, data []map[string]any) error
+	close() error
+}
+
+// iotdbSink is the IoTDB sink that delegates writes to a model-specific writer.
+type iotdbSink struct {
+	conf   iotdbConfig
+	writer writer
+}
+
+func (s *iotdbSink) Provision(ctx api.StreamContext, props map[string]any) error {
+	s.conf = iotdbConfig{}
+	if err := cast.MapToStruct(props, &s.conf); err != nil {
+		return fmt.Errorf("error configuring iotdb sink: %s", err)
+	}
+	s.conf.applyDefaults()
+	if err := s.conf.validate(); err != nil {
+		return err
+	}
+	switch s.conf.Model {
+	case modelTree:
+		s.writer = &treeWriter{}
+	case modelTable:
+		s.writer = &tableWriter{}
+	default:
+		// unreachable: validate already rejected other values
+		return fmt.Errorf("unsupported model %q", s.conf.Model)
+	}
+	return nil
+}
+
+func (s *iotdbSink) Connect(ctx api.StreamContext, sch api.StatusChangeHandler) error {
+	err := s.writer.connect(ctx, &s.conf)
+	if err != nil {
+		sch(api.ConnectionDisconnected, err.Error())
+		return err
+	}
+	sch(api.ConnectionConnected, "")
+	return nil
+}
+
+func (s *iotdbSink) Collect(ctx api.StreamContext, item api.MessageTuple) error {
+	return s.collect(ctx, item.ToMap())
+}
+
+func (s *iotdbSink) CollectList(ctx api.StreamContext, items api.MessageTupleList) error {
+	return s.collect(ctx, items.ToMaps())
+}
+
+func (s *iotdbSink) collect(ctx api.StreamContext, data any) error {
+	maps, err := toMapList(data)
+	if err != nil {
+		return err
+	}
+	if len(maps) == 0 {
+		return nil
+	}
+	if err := s.writer.write(ctx, maps); err != nil {
+		ctx.GetLogger().Errorf("iotdb sink write error: %v", err)
+		return errorx.NewIOErr(fmt.Sprintf("iotdb sink fails to send out the data: %v", err))
+	}
+	ctx.GetLogger().Debug("insert data into iotdb success")
+	return nil
+}
+
+func (s *iotdbSink) Close(ctx api.StreamContext) error {
+	ctx.GetLogger().Infof("iotdb sink close")
+	if s.writer != nil {
+		return s.writer.close()
+	}
+	return nil
+}
+
+// toMapList normalizes data into []map[string]any.
+func toMapList(data any) ([]map[string]any, error) {
+	switch dd := data.(type) {
+	case map[string]any:
+		return []map[string]any{dd}, nil
+	case []map[string]any:
+		return dd, nil
+	default:
+		return nil, fmt.Errorf("iotdb sink needs map or []map, but received unsupported data %T", dd)
+	}
+}
+
+// GetSink returns a new IoTDB sink instance.
+func GetSink() api.Sink {
+	return &iotdbSink{}
+}
+
+// Info implements model.SinkInfoNode to declare sink capabilities.
+func (s *iotdbSink) Info() model.SinkInfo {
+	return model.SinkInfo{
+		HasFields: true,
+	}
+}
+
+// interface compliance check
+var (
+	_ api.TupleCollector  = &iotdbSink{}
+	_ model.SinkInfoNode = &iotdbSink{}
+)

--- a/extensions/impl/iotdb/iotdb.go
+++ b/extensions/impl/iotdb/iotdb.go
@@ -126,6 +126,6 @@ func (s *iotdbSink) Info() model.SinkInfo {
 
 // interface compliance check
 var (
-	_ api.TupleCollector  = &iotdbSink{}
+	_ api.TupleCollector = &iotdbSink{}
 	_ model.SinkInfoNode = &iotdbSink{}
 )

--- a/extensions/impl/iotdb/iotdb_test.go
+++ b/extensions/impl/iotdb/iotdb_test.go
@@ -435,6 +435,7 @@ func TestConvertValue(t *testing.T) {
 		{"int to TIMESTAMP", 1700000000000, "TIMESTAMP", int64(1700000000000), false},
 		{"unsupported type", 1, "UNKNOWN", nil, true},
 		{"invalid bool source", "notabool", "BOOLEAN", nil, true},
+		{"int32 overflow errors", int64(1) << 40, "INT32", nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -519,4 +520,37 @@ func TestGetSink(t *testing.T) {
 	assert.NotNil(t, sink)
 	_, ok := sink.(*iotdbSink)
 	assert.True(t, ok)
+}
+
+func TestWriterCloseWithoutConnect(t *testing.T) {
+	// close() before a successful connect() must not panic even though the
+	// underlying session pool was never initialized.
+	assert.NotPanics(t, func() {
+		tw := &treeWriter{}
+		assert.NoError(t, tw.close())
+	})
+	assert.NotPanics(t, func() {
+		tbw := &tableWriter{}
+		assert.NoError(t, tbw.close())
+	})
+}
+
+func TestNextTimestamp(t *testing.T) {
+	// explicit timestamps are used verbatim and do not advance the auto cursor
+	var last int64
+	ts, err := nextTimestamp(map[string]any{"ts": 100}, "ts", &last)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(100), ts)
+	assert.Equal(t, int64(0), last)
+
+	// auto timestamps strictly increase within a batch even within the same millisecond
+	last = 0
+	t1, err := nextTimestamp(map[string]any{}, "", &last)
+	assert.NoError(t, err)
+	t2, err := nextTimestamp(map[string]any{}, "", &last)
+	assert.NoError(t, err)
+	t3, err := nextTimestamp(map[string]any{}, "", &last)
+	assert.NoError(t, err)
+	assert.Greater(t, t2, t1)
+	assert.Greater(t, t3, t2)
 }

--- a/extensions/impl/iotdb/iotdb_test.go
+++ b/extensions/impl/iotdb/iotdb_test.go
@@ -15,10 +15,13 @@
 package iotdb
 
 import (
+	"encoding/binary"
+	"math"
 	"testing"
 
 	"github.com/apache/iotdb-client-go/v2/client"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	mockContext "github.com/lf-edge/ekuiper/v2/pkg/mock/context"
 )
@@ -33,7 +36,6 @@ func TestConfig(t *testing.T) {
 		{
 			name: "valid tree model with defaults",
 			conf: map[string]interface{}{
-				"model":        "tree",
 				"device":       "root.sg.d1",
 				"measurements": []interface{}{"temperature", "humidity"},
 				"dataTypes":    []interface{}{"FLOAT", "INT32"},
@@ -106,11 +108,6 @@ func TestConfig(t *testing.T) {
 				Timeout:      3000,
 				PoolSize:     5,
 			},
-		},
-		{
-			name:  "model missing",
-			conf:  map[string]interface{}{},
-			error: `model must be either "tree" or "table"`,
 		},
 		{
 			name: "invalid model value",
@@ -253,6 +250,18 @@ func TestConfig(t *testing.T) {
 			error: "database name cannot be empty after stripping 'root.' prefix",
 		},
 		{
+			name: "table model rejects unsafe database identifier",
+			conf: map[string]interface{}{
+				"model":            "table",
+				"database":         "db1; DROP DATABASE db2",
+				"table":            "t1",
+				"measurements":     []interface{}{"v"},
+				"dataTypes":        []interface{}{"INT32"},
+				"columnCategories": []interface{}{"FIELD"},
+			},
+			error: `database "db1; DROP DATABASE db2" is not a valid identifier; expected [A-Za-z_][A-Za-z0-9_]*`,
+		},
+		{
 			name: "unmarshal error",
 			conf: map[string]interface{}{
 				"addr": 12,
@@ -324,6 +333,7 @@ func TestApplyDefaults(t *testing.T) {
 	assert.Equal(t, "127.0.0.1:6667", c.Addr)
 	assert.Equal(t, "root", c.Username)
 	assert.Equal(t, "root", c.Password)
+	assert.Equal(t, modelTree, c.Model)
 	assert.Equal(t, 10, c.BatchSize)
 	assert.Equal(t, int64(5000), c.Timeout)
 	assert.Equal(t, 3, c.PoolSize)
@@ -333,6 +343,7 @@ func TestApplyDefaults(t *testing.T) {
 		Addr:      "1.2.3.4:6667",
 		Username:  "u",
 		Password:  "p",
+		Model:     modelTable,
 		BatchSize: 50,
 		Timeout:   1000,
 		PoolSize:  10,
@@ -341,6 +352,7 @@ func TestApplyDefaults(t *testing.T) {
 	assert.Equal(t, "1.2.3.4:6667", c2.Addr)
 	assert.Equal(t, "u", c2.Username)
 	assert.Equal(t, "p", c2.Password)
+	assert.Equal(t, modelTable, c2.Model)
 	assert.Equal(t, 50, c2.BatchSize)
 	assert.Equal(t, int64(1000), c2.Timeout)
 	assert.Equal(t, 10, c2.PoolSize)
@@ -352,6 +364,11 @@ func TestSplitAddr(t *testing.T) {
 	assert.Equal(t, "192.168.1.1", host)
 	assert.Equal(t, "6667", port)
 
+	host, port, err = splitAddr("[::1]:6667")
+	assert.NoError(t, err)
+	assert.Equal(t, "::1", host)
+	assert.Equal(t, "6667", port)
+
 	_, _, err = splitAddr("invalid")
 	assert.Error(t, err)
 
@@ -360,6 +377,28 @@ func TestSplitAddr(t *testing.T) {
 
 	_, _, err = splitAddr("host:")
 	assert.Error(t, err)
+}
+
+func TestNewPoolConfig(t *testing.T) {
+	t.Run("single node parses addr", func(t *testing.T) {
+		conf := &iotdbConfig{Addr: "[::1]:6667", Username: "u", Password: "p", Database: "db1"}
+		got, err := conf.newPoolConfig()
+		require.NoError(t, err)
+		assert.Equal(t, "::1", got.Host)
+		assert.Equal(t, "6667", got.Port)
+		assert.Equal(t, "u", got.UserName)
+		assert.Equal(t, "p", got.Password)
+		assert.Equal(t, "db1", got.Database)
+	})
+
+	t.Run("nodeUrls overrides invalid addr", func(t *testing.T) {
+		conf := &iotdbConfig{Addr: "not-an-address", NodeUrls: []string{"node1:6667", "node2:6667"}}
+		got, err := conf.newPoolConfig()
+		require.NoError(t, err)
+		assert.Empty(t, got.Host)
+		assert.Empty(t, got.Port)
+		assert.Equal(t, conf.NodeUrls, got.NodeUrls)
+	})
 }
 
 func TestToTSDataType(t *testing.T) {
@@ -436,6 +475,9 @@ func TestConvertValue(t *testing.T) {
 		{"unsupported type", 1, "UNKNOWN", nil, true},
 		{"invalid bool source", "notabool", "BOOLEAN", nil, true},
 		{"int32 overflow errors", int64(1) << 40, "INT32", nil, true},
+		{"finite float overflow errors", math.MaxFloat64, "FLOAT", nil, true},
+		{"positive infinity errors", math.Inf(1), "FLOAT", nil, true},
+		{"negative infinity errors", math.Inf(-1), "FLOAT", nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -553,4 +595,51 @@ func TestNextTimestamp(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Greater(t, t2, t1)
 	assert.Greater(t, t3, t2)
+}
+
+func TestFillTablet(t *testing.T) {
+	conf := &iotdbConfig{
+		Measurements: []string{"temperature", "count", "label"},
+		DataTypes:    []string{"FLOAT", "INT32", "TEXT"},
+		TsFieldName:  "ts",
+	}
+	schemas, err := buildMeasurementSchemas(conf.Measurements, conf.DataTypes)
+	require.NoError(t, err)
+
+	rows := []map[string]any{
+		{"ts": 1000, "temperature": "1.5", "count": "2", "label": "first"},
+		{"count": 3, "label": "second"},
+		{"temperature": 4.5},
+	}
+	tablet, err := client.NewTablet("root.sg.d1", schemas, len(rows))
+	require.NoError(t, err)
+
+	lastAuto := int64(1 << 62)
+	autoStart := lastAuto
+	require.NoError(t, fillTablet(tablet, rows, conf, &lastAuto))
+
+	assert.Equal(t, len(rows), tablet.RowSize)
+	assert.Equal(t, []int64{1000, autoStart + 1, autoStart + 2}, decodeTimestamps(tablet.GetTimestampBytes()))
+	assert.Equal(t, autoStart+2, lastAuto)
+
+	expected := [][]any{
+		{float32(1.5), int32(2), "first"},
+		{nil, int32(3), "second"},
+		{float32(4.5), nil, nil},
+	}
+	for rowIdx := range expected {
+		for colIdx := range expected[rowIdx] {
+			got, err := tablet.GetValueAt(colIdx, rowIdx)
+			require.NoError(t, err)
+			assert.Equal(t, expected[rowIdx][colIdx], got)
+		}
+	}
+}
+
+func decodeTimestamps(data []byte) []int64 {
+	timestamps := make([]int64, len(data)/8)
+	for i := range timestamps {
+		timestamps[i] = int64(binary.BigEndian.Uint64(data[i*8 : (i+1)*8]))
+	}
+	return timestamps
 }

--- a/extensions/impl/iotdb/iotdb_test.go
+++ b/extensions/impl/iotdb/iotdb_test.go
@@ -1,0 +1,522 @@
+// Copyright 2026 Timecho Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iotdb
+
+import (
+	"testing"
+
+	"github.com/apache/iotdb-client-go/v2/client"
+	"github.com/stretchr/testify/assert"
+
+	mockContext "github.com/lf-edge/ekuiper/v2/pkg/mock/context"
+)
+
+func TestConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		conf     map[string]interface{}
+		expected iotdbConfig
+		error    string
+	}{
+		{
+			name: "valid tree model with defaults",
+			conf: map[string]interface{}{
+				"model":        "tree",
+				"device":       "root.sg.d1",
+				"measurements": []interface{}{"temperature", "humidity"},
+				"dataTypes":    []interface{}{"FLOAT", "INT32"},
+			},
+			expected: iotdbConfig{
+				Addr:         "127.0.0.1:6667",
+				Username:     "root",
+				Password:     "root",
+				Model:        "tree",
+				Device:       "root.sg.d1",
+				Measurements: []string{"temperature", "humidity"},
+				DataTypes:    []string{"FLOAT", "INT32"},
+				BatchSize:    10,
+				Timeout:      5000,
+				PoolSize:     3,
+			},
+		},
+		{
+			name: "valid table model with defaults",
+			conf: map[string]interface{}{
+				"model":            "table",
+				"database":         "db1",
+				"table":            "t1",
+				"measurements":     []interface{}{"d", "v"},
+				"dataTypes":        []interface{}{"TEXT", "DOUBLE"},
+				"columnCategories": []interface{}{"TAG", "FIELD"},
+			},
+			expected: iotdbConfig{
+				Addr:             "127.0.0.1:6667",
+				Username:         "root",
+				Password:         "root",
+				Model:            "table",
+				Database:         "db1",
+				Table:            "t1",
+				Measurements:     []string{"d", "v"},
+				DataTypes:        []string{"TEXT", "DOUBLE"},
+				ColumnCategories: []string{"TAG", "FIELD"},
+				BatchSize:        10,
+				Timeout:          5000,
+				PoolSize:         3,
+			},
+		},
+		{
+			name: "valid tree model with custom values",
+			conf: map[string]interface{}{
+				"addr":         "192.168.1.10:6668",
+				"username":     "admin",
+				"password":     "secret",
+				"model":        "tree",
+				"device":       "root.sg.d1",
+				"isAligned":    true,
+				"measurements": []interface{}{"v"},
+				"dataTypes":    []interface{}{"int64"},
+				"tsFieldName":  "ts",
+				"batchSize":    100,
+				"timeout":      3000,
+				"poolSize":     5,
+			},
+			expected: iotdbConfig{
+				Addr:         "192.168.1.10:6668",
+				Username:     "admin",
+				Password:     "secret",
+				Model:        "tree",
+				Device:       "root.sg.d1",
+				IsAligned:    true,
+				Measurements: []string{"v"},
+				DataTypes:    []string{"INT64"},
+				TsFieldName:  "ts",
+				BatchSize:    100,
+				Timeout:      3000,
+				PoolSize:     5,
+			},
+		},
+		{
+			name:  "model missing",
+			conf:  map[string]interface{}{},
+			error: `model must be either "tree" or "table"`,
+		},
+		{
+			name: "invalid model value",
+			conf: map[string]interface{}{
+				"model":        "foo",
+				"device":       "root.sg.d1",
+				"measurements": []interface{}{"v"},
+				"dataTypes":    []interface{}{"INT32"},
+			},
+			error: `model must be either "tree" or "table"`,
+		},
+		{
+			name: "tree model missing device",
+			conf: map[string]interface{}{
+				"model":        "tree",
+				"measurements": []interface{}{"v"},
+				"dataTypes":    []interface{}{"INT32"},
+			},
+			error: `device is required when model is "tree"`,
+		},
+		{
+			name: "table model missing database",
+			conf: map[string]interface{}{
+				"model":            "table",
+				"table":            "t1",
+				"measurements":     []interface{}{"v"},
+				"dataTypes":        []interface{}{"INT32"},
+				"columnCategories": []interface{}{"FIELD"},
+			},
+			error: `database is required when model is "table"`,
+		},
+		{
+			name: "table model missing table",
+			conf: map[string]interface{}{
+				"model":            "table",
+				"database":         "db1",
+				"measurements":     []interface{}{"v"},
+				"dataTypes":        []interface{}{"INT32"},
+				"columnCategories": []interface{}{"FIELD"},
+			},
+			error: `table is required when model is "table"`,
+		},
+		{
+			name: "measurements missing",
+			conf: map[string]interface{}{
+				"model":     "tree",
+				"device":    "root.sg.d1",
+				"dataTypes": []interface{}{"INT32"},
+			},
+			error: "measurements is required",
+		},
+		{
+			name: "dataTypes missing",
+			conf: map[string]interface{}{
+				"model":        "tree",
+				"device":       "root.sg.d1",
+				"measurements": []interface{}{"v"},
+			},
+			error: "dataTypes is required",
+		},
+		{
+			name: "measurements and dataTypes length mismatch",
+			conf: map[string]interface{}{
+				"model":        "tree",
+				"device":       "root.sg.d1",
+				"measurements": []interface{}{"a", "b"},
+				"dataTypes":    []interface{}{"INT32"},
+			},
+			error: "measurements (2) and dataTypes (1) must have the same length",
+		},
+		{
+			name: "invalid data type",
+			conf: map[string]interface{}{
+				"model":        "tree",
+				"device":       "root.sg.d1",
+				"measurements": []interface{}{"v"},
+				"dataTypes":    []interface{}{"FOOBAR"},
+			},
+			error: `dataTypes[0]="FOOBAR" is not a supported IoTDB data type`,
+		},
+		{
+			name: "table model columnCategories length mismatch",
+			conf: map[string]interface{}{
+				"model":            "table",
+				"database":         "db1",
+				"table":            "t1",
+				"measurements":     []interface{}{"a", "b"},
+				"dataTypes":        []interface{}{"INT32", "INT64"},
+				"columnCategories": []interface{}{"TAG"},
+			},
+			error: "columnCategories (1) must have the same length as measurements (2)",
+		},
+		{
+			name: "table model invalid column category",
+			conf: map[string]interface{}{
+				"model":            "table",
+				"database":         "db1",
+				"table":            "t1",
+				"measurements":     []interface{}{"a"},
+				"dataTypes":        []interface{}{"INT32"},
+				"columnCategories": []interface{}{"BAD"},
+			},
+			error: `columnCategories[0]="BAD" is not a supported column category (TAG/FIELD/ATTRIBUTE)`,
+		},
+		{
+			name: "table model database root. prefix stripped",
+			conf: map[string]interface{}{
+				"model":            "table",
+				"database":         "root.db1",
+				"table":            "t1",
+				"measurements":     []interface{}{"d", "v"},
+				"dataTypes":        []interface{}{"TEXT", "DOUBLE"},
+				"columnCategories": []interface{}{"TAG", "FIELD"},
+			},
+			expected: iotdbConfig{
+				Addr:             "127.0.0.1:6667",
+				Username:         "root",
+				Password:         "root",
+				Model:            "table",
+				Database:         "db1",
+				Table:            "t1",
+				Measurements:     []string{"d", "v"},
+				DataTypes:        []string{"TEXT", "DOUBLE"},
+				ColumnCategories: []string{"TAG", "FIELD"},
+				BatchSize:        10,
+				Timeout:          5000,
+				PoolSize:         3,
+			},
+		},
+		{
+			name: "table model database empty after stripping root. prefix",
+			conf: map[string]interface{}{
+				"model":            "table",
+				"database":         "root.",
+				"table":            "t1",
+				"measurements":     []interface{}{"v"},
+				"dataTypes":        []interface{}{"INT32"},
+				"columnCategories": []interface{}{"FIELD"},
+			},
+			error: "database name cannot be empty after stripping 'root.' prefix",
+		},
+		{
+			name: "unmarshal error",
+			conf: map[string]interface{}{
+				"addr": 12,
+			},
+			error: "error configuring iotdb sink: 1 error(s) decoding:\n\n* 'addr' expected type 'string', got unconvertible type 'int', value: '12'",
+		},
+	}
+
+	ctx := mockContext.NewMockContext("testconfig", "op")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := &iotdbSink{}
+			err := s.Provision(ctx, test.conf)
+			if test.error == "" {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expected, s.conf)
+				assert.NotNil(t, s.writer)
+			} else {
+				assert.Error(t, err)
+				assert.Equal(t, test.error, err.Error())
+			}
+		})
+	}
+}
+
+func TestProvisionWriterSelection(t *testing.T) {
+	ctx := mockContext.NewMockContext("rule", "op")
+
+	t.Run("tree model selects treeWriter", func(t *testing.T) {
+		s := &iotdbSink{}
+		err := s.Provision(ctx, map[string]interface{}{
+			"model":        "tree",
+			"device":       "root.sg.d1",
+			"measurements": []interface{}{"v"},
+			"dataTypes":    []interface{}{"INT32"},
+		})
+		assert.NoError(t, err)
+		_, ok := s.writer.(*treeWriter)
+		assert.True(t, ok, "expected *treeWriter")
+	})
+
+	t.Run("table model selects tableWriter", func(t *testing.T) {
+		s := &iotdbSink{}
+		err := s.Provision(ctx, map[string]interface{}{
+			"model":            "table",
+			"database":         "db1",
+			"table":            "t1",
+			"measurements":     []interface{}{"v"},
+			"dataTypes":        []interface{}{"INT64"},
+			"columnCategories": []interface{}{"FIELD"},
+		})
+		assert.NoError(t, err)
+		_, ok := s.writer.(*tableWriter)
+		assert.True(t, ok, "expected *tableWriter")
+	})
+
+	t.Run("invalid configuration returns error", func(t *testing.T) {
+		s := &iotdbSink{}
+		err := s.Provision(ctx, map[string]interface{}{
+			"model": "invalid",
+		})
+		assert.Error(t, err)
+	})
+}
+
+func TestApplyDefaults(t *testing.T) {
+	c := iotdbConfig{}
+	c.applyDefaults()
+	assert.Equal(t, "127.0.0.1:6667", c.Addr)
+	assert.Equal(t, "root", c.Username)
+	assert.Equal(t, "root", c.Password)
+	assert.Equal(t, 10, c.BatchSize)
+	assert.Equal(t, int64(5000), c.Timeout)
+	assert.Equal(t, 3, c.PoolSize)
+
+	// existing values are preserved
+	c2 := iotdbConfig{
+		Addr:      "1.2.3.4:6667",
+		Username:  "u",
+		Password:  "p",
+		BatchSize: 50,
+		Timeout:   1000,
+		PoolSize:  10,
+	}
+	c2.applyDefaults()
+	assert.Equal(t, "1.2.3.4:6667", c2.Addr)
+	assert.Equal(t, "u", c2.Username)
+	assert.Equal(t, "p", c2.Password)
+	assert.Equal(t, 50, c2.BatchSize)
+	assert.Equal(t, int64(1000), c2.Timeout)
+	assert.Equal(t, 10, c2.PoolSize)
+}
+
+func TestSplitAddr(t *testing.T) {
+	host, port, err := splitAddr("192.168.1.1:6667")
+	assert.NoError(t, err)
+	assert.Equal(t, "192.168.1.1", host)
+	assert.Equal(t, "6667", port)
+
+	_, _, err = splitAddr("invalid")
+	assert.Error(t, err)
+
+	_, _, err = splitAddr(":6667")
+	assert.Error(t, err)
+
+	_, _, err = splitAddr("host:")
+	assert.Error(t, err)
+}
+
+func TestToTSDataType(t *testing.T) {
+	tests := []struct {
+		in       string
+		expected client.TSDataType
+		hasErr   bool
+	}{
+		{"INT32", client.INT32, false},
+		{"INT64", client.INT64, false},
+		{"FLOAT", client.FLOAT, false},
+		{"DOUBLE", client.DOUBLE, false},
+		{"BOOLEAN", client.BOOLEAN, false},
+		{"TEXT", client.TEXT, false},
+		{"STRING", client.STRING, false},
+		{"TIMESTAMP", client.TIMESTAMP, false},
+		{"BAD", client.UNKNOWN, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := toTSDataType(tt.in)
+			if tt.hasErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestToColumnCategory(t *testing.T) {
+	tests := []struct {
+		in       string
+		expected client.ColumnCategory
+		hasErr   bool
+	}{
+		{"TAG", client.TAG, false},
+		{"FIELD", client.FIELD, false},
+		{"ATTRIBUTE", client.ATTRIBUTE, false},
+		{"BAD", 0, true},
+		{"", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := toColumnCategory(tt.in)
+			if tt.hasErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestConvertValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       any
+		dt       string
+		expected any
+		hasErr   bool
+	}{
+		{"nil returns nil", nil, "INT32", nil, false},
+		{"int to INT32", 10, "INT32", int32(10), false},
+		{"int64 to INT64", int64(123), "INT64", int64(123), false},
+		{"float to FLOAT", 1.5, "FLOAT", float32(1.5), false},
+		{"float to DOUBLE", 2.5, "DOUBLE", float64(2.5), false},
+		{"bool to BOOLEAN", true, "BOOLEAN", true, false},
+		{"string to TEXT", "hello", "TEXT", "hello", false},
+		{"string to STRING", "world", "STRING", "world", false},
+		{"int to TIMESTAMP", 1700000000000, "TIMESTAMP", int64(1700000000000), false},
+		{"unsupported type", 1, "UNKNOWN", nil, true},
+		{"invalid bool source", "notabool", "BOOLEAN", nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := convertValue(tt.in, tt.dt)
+			if tt.hasErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestBuildMeasurementSchemas(t *testing.T) {
+	schemas, err := buildMeasurementSchemas(
+		[]string{"a", "b"},
+		[]string{"INT32", "DOUBLE"},
+	)
+	assert.NoError(t, err)
+	assert.Len(t, schemas, 2)
+	assert.Equal(t, "a", schemas[0].Measurement)
+	assert.Equal(t, client.INT32, schemas[0].DataType)
+	assert.Equal(t, "b", schemas[1].Measurement)
+	assert.Equal(t, client.DOUBLE, schemas[1].DataType)
+
+	_, err = buildMeasurementSchemas(
+		[]string{"a"},
+		[]string{"BAD"},
+	)
+	assert.Error(t, err)
+}
+
+func TestExtractTimestamp(t *testing.T) {
+	// when tsFieldName is empty, returns current time (>0)
+	ts, err := extractTimestamp(map[string]any{}, "")
+	assert.NoError(t, err)
+	assert.Greater(t, ts, int64(0))
+
+	// when tsFieldName is set and value exists, returns the value
+	ts, err = extractTimestamp(map[string]any{"ts": 12345}, "ts")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(12345), ts)
+
+	// when tsFieldName is set but missing, falls back to current time
+	ts, err = extractTimestamp(map[string]any{}, "ts")
+	assert.NoError(t, err)
+	assert.Greater(t, ts, int64(0))
+
+	// when ts value is invalid, returns error
+	_, err = extractTimestamp(map[string]any{"ts": "not-a-number"}, "ts")
+	assert.Error(t, err)
+}
+
+func TestToMapList(t *testing.T) {
+	// single map
+	got, err := toMapList(map[string]any{"a": 1})
+	assert.NoError(t, err)
+	assert.Equal(t, []map[string]any{{"a": 1}}, got)
+
+	// list of maps
+	in := []map[string]any{{"a": 1}, {"b": 2}}
+	got, err = toMapList(in)
+	assert.NoError(t, err)
+	assert.Equal(t, in, got)
+
+	// unsupported type
+	_, err = toMapList([]byte{1, 2, 3})
+	assert.Error(t, err)
+}
+
+func TestSinkClose(t *testing.T) {
+	// close on a sink without writer should not panic
+	s := &iotdbSink{}
+	ctx := mockContext.NewMockContext("rule", "op")
+	err := s.Close(ctx)
+	assert.NoError(t, err)
+}
+
+func TestGetSink(t *testing.T) {
+	sink := GetSink()
+	assert.NotNil(t, sink)
+	_, ok := sink.(*iotdbSink)
+	assert.True(t, ok)
+}

--- a/extensions/impl/iotdb/iotdb_test.go
+++ b/extensions/impl/iotdb/iotdb_test.go
@@ -16,15 +16,87 @@ package iotdb
 
 import (
 	"encoding/binary"
+	"errors"
 	"math"
 	"testing"
 
 	"github.com/apache/iotdb-client-go/v2/client"
+	"github.com/lf-edge/ekuiper/contract/v2/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/lf-edge/ekuiper/v2/pkg/errorx"
 	mockContext "github.com/lf-edge/ekuiper/v2/pkg/mock/context"
 )
+
+type fakeWriter struct {
+	connectErr   error
+	writeErr     error
+	closeErr     error
+	connectCalls int
+	writeCalls   int
+	closeCalls   int
+	written      []map[string]any
+}
+
+func (w *fakeWriter) connect(api.StreamContext, *iotdbConfig) error {
+	w.connectCalls++
+	return w.connectErr
+}
+
+func (w *fakeWriter) write(_ api.StreamContext, data []map[string]any) error {
+	w.writeCalls++
+	w.written = data
+	return w.writeErr
+}
+
+func (w *fakeWriter) close() error {
+	w.closeCalls++
+	return w.closeErr
+}
+
+type fakeTableSessionPool struct {
+	session  client.ITableSession
+	getErr   error
+	getCalls int
+	closed   bool
+}
+
+func (p *fakeTableSessionPool) GetSession() (client.ITableSession, error) {
+	p.getCalls++
+	return p.session, p.getErr
+}
+
+func (p *fakeTableSessionPool) Close() {
+	p.closed = true
+}
+
+type fakeTableSession struct {
+	insertErr  error
+	executeErr error
+	inserted   *client.Tablet
+	statements []string
+	closeCalls int
+}
+
+func (s *fakeTableSession) Insert(tablet *client.Tablet) error {
+	s.inserted = tablet
+	return s.insertErr
+}
+
+func (s *fakeTableSession) ExecuteNonQueryStatement(statement string) error {
+	s.statements = append(s.statements, statement)
+	return s.executeErr
+}
+
+func (s *fakeTableSession) ExecuteQueryStatement(string, *int64) (*client.SessionDataSet, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *fakeTableSession) Close() error {
+	s.closeCalls++
+	return nil
+}
 
 func TestConfig(t *testing.T) {
 	tests := []struct {
@@ -382,22 +454,95 @@ func TestSplitAddr(t *testing.T) {
 func TestNewPoolConfig(t *testing.T) {
 	t.Run("single node parses addr", func(t *testing.T) {
 		conf := &iotdbConfig{Addr: "[::1]:6667", Username: "u", Password: "p", Database: "db1"}
-		got, err := conf.newPoolConfig()
+		got, err := conf.newPoolConfig(conf.Database)
 		require.NoError(t, err)
 		assert.Equal(t, "::1", got.Host)
 		assert.Equal(t, "6667", got.Port)
 		assert.Equal(t, "u", got.UserName)
 		assert.Equal(t, "p", got.Password)
 		assert.Equal(t, "db1", got.Database)
+
+		bootstrap, err := conf.newPoolConfig("")
+		require.NoError(t, err)
+		assert.Empty(t, bootstrap.Database)
 	})
 
 	t.Run("nodeUrls overrides invalid addr", func(t *testing.T) {
 		conf := &iotdbConfig{Addr: "not-an-address", NodeUrls: []string{"node1:6667", "node2:6667"}}
-		got, err := conf.newPoolConfig()
+		got, err := conf.newPoolConfig("")
 		require.NoError(t, err)
 		assert.Empty(t, got.Host)
 		assert.Empty(t, got.Port)
 		assert.Equal(t, conf.NodeUrls, got.NodeUrls)
+	})
+}
+
+func TestSinkConnect(t *testing.T) {
+	ctx := mockContext.NewMockContext("rule", "op")
+
+	t.Run("success", func(t *testing.T) {
+		w := &fakeWriter{}
+		s := &iotdbSink{writer: w}
+		var status, message string
+		err := s.Connect(ctx, func(gotStatus, gotMessage string) {
+			status, message = gotStatus, gotMessage
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, w.connectCalls)
+		assert.Equal(t, api.ConnectionConnected, status)
+		assert.Empty(t, message)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		connectErr := errors.New("connect failed")
+		w := &fakeWriter{connectErr: connectErr}
+		s := &iotdbSink{writer: w}
+		var status, message string
+		err := s.Connect(ctx, func(gotStatus, gotMessage string) {
+			status, message = gotStatus, gotMessage
+		})
+		assert.ErrorIs(t, err, connectErr)
+		assert.Equal(t, 1, w.connectCalls)
+		assert.Equal(t, api.ConnectionDisconnected, status)
+		assert.Equal(t, connectErr.Error(), message)
+	})
+}
+
+func TestSinkCollectErrorClassification(t *testing.T) {
+	ctx := mockContext.NewMockContext("rule", "op")
+
+	t.Run("empty batch is a no-op", func(t *testing.T) {
+		w := &fakeWriter{}
+		s := &iotdbSink{writer: w}
+		require.NoError(t, s.collect(ctx, []map[string]any{}))
+		assert.Zero(t, w.writeCalls)
+	})
+
+	t.Run("success forwards rows", func(t *testing.T) {
+		w := &fakeWriter{}
+		s := &iotdbSink{writer: w}
+		row := map[string]any{"value": 1}
+		require.NoError(t, s.collect(ctx, row))
+		assert.Equal(t, 1, w.writeCalls)
+		assert.Equal(t, []map[string]any{row}, w.written)
+	})
+
+	t.Run("conversion error remains non-IO", func(t *testing.T) {
+		conversionErr := errors.New("conversion failed")
+		w := &fakeWriter{writeErr: conversionErr}
+		s := &iotdbSink{writer: w}
+		err := s.collect(ctx, map[string]any{"value": "bad"})
+		assert.ErrorIs(t, err, conversionErr)
+		assert.False(t, errorx.IsIOError(err))
+	})
+
+	t.Run("insert error remains IO", func(t *testing.T) {
+		insertErr := errorx.NewIOErr("insert failed")
+		w := &fakeWriter{writeErr: insertErr}
+		s := &iotdbSink{writer: w}
+		err := s.collect(ctx, map[string]any{"value": 1})
+		assert.Equal(t, insertErr, err)
+		assert.True(t, errorx.IsIOError(err))
 	})
 }
 
@@ -511,6 +656,95 @@ func TestBuildMeasurementSchemas(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestEnsureDatabase(t *testing.T) {
+	t.Run("executes create before using target database", func(t *testing.T) {
+		session := &fakeTableSession{}
+		pool := &fakeTableSessionPool{session: session}
+		require.NoError(t, ensureDatabase(pool, "db1"))
+		assert.Equal(t, []string{"CREATE DATABASE IF NOT EXISTS db1"}, session.statements)
+		assert.Equal(t, 1, session.closeCalls)
+	})
+
+	t.Run("get session failure is returned", func(t *testing.T) {
+		pool := &fakeTableSessionPool{getErr: errors.New("dial failed")}
+		err := ensureDatabase(pool, "db1")
+		assert.EqualError(t, err, "failed to get iotdb table session for database creation: dial failed")
+	})
+
+	t.Run("create failure is returned", func(t *testing.T) {
+		session := &fakeTableSession{executeErr: errors.New("permission denied")}
+		pool := &fakeTableSessionPool{session: session}
+		err := ensureDatabase(pool, "db1")
+		assert.EqualError(t, err, `create iotdb database "db1": permission denied`)
+		assert.Equal(t, 1, session.closeCalls)
+	})
+}
+
+func TestInsertRelationalTablet(t *testing.T) {
+	tablet, err := client.NewRelationalTablet(
+		"t1",
+		[]*client.MeasurementSchema{{Measurement: "value", DataType: client.INT32}},
+		[]client.ColumnCategory{client.FIELD},
+		1,
+	)
+	require.NoError(t, err)
+
+	t.Run("success closes session", func(t *testing.T) {
+		session := &fakeTableSession{}
+		pool := &fakeTableSessionPool{session: session}
+		require.NoError(t, insertRelationalTablet(pool, tablet))
+		assert.Same(t, tablet, session.inserted)
+		assert.Equal(t, 1, session.closeCalls)
+	})
+
+	t.Run("get session failure is IO", func(t *testing.T) {
+		pool := &fakeTableSessionPool{getErr: errors.New("pool exhausted")}
+		err := insertRelationalTablet(pool, tablet)
+		assert.True(t, errorx.IsIOError(err))
+		assert.Contains(t, err.Error(), "failed to get iotdb table session")
+	})
+
+	t.Run("insert failure is IO and closes session", func(t *testing.T) {
+		session := &fakeTableSession{insertErr: errors.New("connection reset")}
+		pool := &fakeTableSessionPool{session: session}
+		err := insertRelationalTablet(pool, tablet)
+		assert.True(t, errorx.IsIOError(err))
+		assert.Contains(t, err.Error(), "insert relational tablet")
+		assert.Equal(t, 1, session.closeCalls)
+	})
+}
+
+func TestTableWriterSortsTablet(t *testing.T) {
+	session := &fakeTableSession{}
+	pool := &fakeTableSessionPool{session: session}
+	w := &tableWriter{
+		pool: pool,
+		conf: &iotdbConfig{
+			Database:         "db1",
+			Table:            "t1",
+			Measurements:     []string{"value"},
+			DataTypes:        []string{"INT32"},
+			ColumnCategories: []string{"FIELD"},
+			TsFieldName:      "ts",
+			BatchSize:        10,
+		},
+	}
+	rows := []map[string]any{
+		{"ts": 30, "value": 3},
+		{"ts": 10, "value": 1},
+		{"ts": 20, "value": 2},
+	}
+
+	require.NoError(t, w.write(mockContext.NewMockContext("rule", "op"), rows))
+	require.NotNil(t, session.inserted)
+	assert.Equal(t, []int64{10, 20, 30}, decodeTimestamps(session.inserted.GetTimestampBytes()))
+	for row, expected := range []int32{1, 2, 3} {
+		value, err := session.inserted.GetValueAt(0, row)
+		require.NoError(t, err)
+		assert.Equal(t, expected, value)
+	}
+}
+
 func TestExtractTimestamp(t *testing.T) {
 	// when tsFieldName is empty, returns current time (>0)
 	ts, err := extractTimestamp(map[string]any{}, "")
@@ -522,10 +756,10 @@ func TestExtractTimestamp(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, int64(12345), ts)
 
-	// when tsFieldName is set but missing, falls back to current time
+	// when tsFieldName is set but missing, returns an error
 	ts, err = extractTimestamp(map[string]any{}, "ts")
-	assert.NoError(t, err)
-	assert.Greater(t, ts, int64(0))
+	assert.Error(t, err)
+	assert.Zero(t, ts)
 
 	// when ts value is invalid, returns error
 	_, err = extractTimestamp(map[string]any{"ts": "not-a-number"}, "ts")
@@ -607,20 +841,19 @@ func TestFillTablet(t *testing.T) {
 	require.NoError(t, err)
 
 	rows := []map[string]any{
-		{"ts": 1000, "temperature": "1.5", "count": "2", "label": "first"},
-		{"count": 3, "label": "second"},
-		{"temperature": 4.5},
+		{"ts": 1002, "temperature": "1.5", "count": "2", "label": "first"},
+		{"ts": 1000, "count": 3, "label": "second"},
+		{"ts": 1001, "temperature": 4.5},
 	}
 	tablet, err := client.NewTablet("root.sg.d1", schemas, len(rows))
 	require.NoError(t, err)
 
-	lastAuto := int64(1 << 62)
-	autoStart := lastAuto
+	lastAuto := int64(0)
 	require.NoError(t, fillTablet(tablet, rows, conf, &lastAuto))
 
 	assert.Equal(t, len(rows), tablet.RowSize)
-	assert.Equal(t, []int64{1000, autoStart + 1, autoStart + 2}, decodeTimestamps(tablet.GetTimestampBytes()))
-	assert.Equal(t, autoStart+2, lastAuto)
+	assert.Equal(t, []int64{1002, 1000, 1001}, decodeTimestamps(tablet.GetTimestampBytes()))
+	assert.Equal(t, int64(0), lastAuto)
 
 	expected := [][]any{
 		{float32(1.5), int32(2), "first"},
@@ -634,6 +867,44 @@ func TestFillTablet(t *testing.T) {
 			assert.Equal(t, expected[rowIdx][colIdx], got)
 		}
 	}
+}
+
+func TestFillTabletRejectsMissingTimestamp(t *testing.T) {
+	conf := &iotdbConfig{
+		Measurements: []string{"value"},
+		DataTypes:    []string{"INT32"},
+		TsFieldName:  "ts",
+	}
+	schemas, err := buildMeasurementSchemas(conf.Measurements, conf.DataTypes)
+	require.NoError(t, err)
+	tablet, err := client.NewTablet("root.sg.d1", schemas, 1)
+	require.NoError(t, err)
+
+	err = fillTablet(tablet, []map[string]any{{"value": 1}}, conf, new(int64))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), `timestamp field "ts" is missing`)
+	assert.Zero(t, tablet.RowSize)
+}
+
+func TestFillTabletAutoTimestampsIncrease(t *testing.T) {
+	conf := &iotdbConfig{
+		Measurements: []string{"value"},
+		DataTypes:    []string{"INT32"},
+	}
+	schemas, err := buildMeasurementSchemas(conf.Measurements, conf.DataTypes)
+	require.NoError(t, err)
+	tablet, err := client.NewTablet("root.sg.d1", schemas, 3)
+	require.NoError(t, err)
+
+	var lastAuto int64
+	require.NoError(t, fillTablet(tablet, []map[string]any{
+		{"value": 1}, {"value": 2}, {"value": 3},
+	}, conf, &lastAuto))
+	timestamps := decodeTimestamps(tablet.GetTimestampBytes())
+	assert.Len(t, timestamps, 3)
+	assert.Less(t, timestamps[0], timestamps[1])
+	assert.Less(t, timestamps[1], timestamps[2])
+	assert.Equal(t, timestamps[2], lastAuto)
 }
 
 func decodeTimestamps(data []byte) []int64 {

--- a/extensions/impl/iotdb/table_writer.go
+++ b/extensions/impl/iotdb/table_writer.go
@@ -32,20 +32,9 @@ type tableWriter struct {
 func (w *tableWriter) connect(ctx api.StreamContext, conf *iotdbConfig) error {
 	w.conf = conf
 
-	host, port, err := splitAddr(conf.Addr)
+	poolConfig, err := conf.newPoolConfig()
 	if err != nil {
 		return err
-	}
-
-	poolConfig := &client.PoolConfig{
-		Host:     host,
-		Port:     port,
-		UserName: conf.Username,
-		Password: conf.Password,
-		Database: conf.Database,
-	}
-	if len(conf.NodeUrls) > 0 {
-		poolConfig.NodeUrls = conf.NodeUrls
 	}
 
 	pool := client.NewTableSessionPool(poolConfig, conf.PoolSize, int(conf.Timeout), 60000, false)

--- a/extensions/impl/iotdb/table_writer.go
+++ b/extensions/impl/iotdb/table_writer.go
@@ -25,6 +25,8 @@ import (
 type tableWriter struct {
 	pool *client.TableSessionPool
 	conf *iotdbConfig
+	// lastAuto is the monotonic cursor for auto-generated timestamps.
+	lastAuto int64
 }
 
 func (w *tableWriter) connect(ctx api.StreamContext, conf *iotdbConfig) error {
@@ -56,7 +58,6 @@ func (w *tableWriter) connect(ctx api.StreamContext, conf *iotdbConfig) error {
 	}
 	createDBSQL := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", conf.Database)
 	if err := autoSession.ExecuteNonQueryStatement(createDBSQL); err != nil {
-		autoSession.Close()
 		// 数据库可能已存在，记录 warning 但不阻断连接
 		ctx.GetLogger().Warnf("iotdb table writer: auto-create database %q failed (may already exist): %v", conf.Database, err)
 	} else {
@@ -110,27 +111,8 @@ func (w *tableWriter) write(ctx api.StreamContext, data []map[string]any) error 
 		if err != nil {
 			return fmt.Errorf("failed to create relational tablet: %w", err)
 		}
-
-		for rowIdx, row := range chunk {
-			ts, err := extractTimestamp(row, w.conf.TsFieldName)
-			if err != nil {
-				return err
-			}
-			tablet.SetTimestamp(ts, rowIdx)
-			for colIdx, m := range w.conf.Measurements {
-				raw, ok := row[m]
-				if !ok {
-					raw = nil
-				}
-				val, err := convertValue(raw, w.conf.DataTypes[colIdx])
-				if err != nil {
-					return fmt.Errorf("convert column %q row %d: %w", m, rowIdx, err)
-				}
-				if err := tablet.SetValueAt(val, colIdx, rowIdx); err != nil {
-					return fmt.Errorf("set value at (%d, %d): %w", colIdx, rowIdx, err)
-				}
-			}
-			tablet.RowSize++
+		if err := fillTablet(tablet, chunk, w.conf, &w.lastAuto); err != nil {
+			return err
 		}
 
 		session, err := w.pool.GetSession()

--- a/extensions/impl/iotdb/table_writer.go
+++ b/extensions/impl/iotdb/table_writer.go
@@ -19,11 +19,22 @@ import (
 
 	"github.com/apache/iotdb-client-go/v2/client"
 	"github.com/lf-edge/ekuiper/contract/v2/api"
+
+	"github.com/lf-edge/ekuiper/v2/pkg/errorx"
 )
+
+type tableSessionProvider interface {
+	GetSession() (client.ITableSession, error)
+}
+
+type tableSessionPool interface {
+	tableSessionProvider
+	Close()
+}
 
 // tableWriter writes data using the IoTDB table model via TableSessionPool.
 type tableWriter struct {
-	pool *client.TableSessionPool
+	pool tableSessionPool
 	conf *iotdbConfig
 	// lastAuto is the monotonic cursor for auto-generated timestamps.
 	lastAuto int64
@@ -32,34 +43,33 @@ type tableWriter struct {
 func (w *tableWriter) connect(ctx api.StreamContext, conf *iotdbConfig) error {
 	w.conf = conf
 
-	poolConfig, err := conf.newPoolConfig()
+	// Bootstrap without a database because the client selects PoolConfig.Database
+	// during OpenSession, before CREATE DATABASE can run.
+	bootstrapConfig, err := conf.newPoolConfig("")
 	if err != nil {
 		return err
 	}
+	bootstrapPool := client.NewTableSessionPool(bootstrapConfig, conf.PoolSize, int(conf.Timeout), 60000, false)
+	if err := ensureDatabase(&bootstrapPool, conf.Database); err != nil {
+		bootstrapPool.Close()
+		return err
+	}
+	bootstrapPool.Close()
+	ctx.GetLogger().Infof("iotdb table writer: database %q ensured", conf.Database)
 
+	poolConfig, err := conf.newPoolConfig(conf.Database)
+	if err != nil {
+		return err
+	}
 	pool := client.NewTableSessionPool(poolConfig, conf.PoolSize, int(conf.Timeout), 60000, false)
-	w.pool = &pool
-
-	// 自动创建数据库（table dialect 下的 CREATE DATABASE）
-	autoSession, err := w.pool.GetSession()
+	session, err := pool.GetSession()
 	if err != nil {
-		return fmt.Errorf("failed to get iotdb table session for database creation: %w", err)
-	}
-	createDBSQL := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", conf.Database)
-	if err := autoSession.ExecuteNonQueryStatement(createDBSQL); err != nil {
-		// 数据库可能已存在，记录 warning 但不阻断连接
-		ctx.GetLogger().Warnf("iotdb table writer: auto-create database %q failed (may already exist): %v", conf.Database, err)
-	} else {
-		ctx.GetLogger().Infof("iotdb table writer: database %q ensured", conf.Database)
-	}
-	autoSession.Close()
-
-	// test connection by acquiring and closing a session
-	session, err := w.pool.GetSession()
-	if err != nil {
+		pool.Close()
 		return fmt.Errorf("failed to get iotdb table session: %w", err)
 	}
-	session.Close()
+	// PooledTableSession.Close returns the wrapper's session to the table pool.
+	_ = session.Close()
+	w.pool = &pool
 
 	ctx.GetLogger().Infof("iotdb table writer connected to %s (database=%s)", conf.Addr, conf.Database)
 	return nil
@@ -103,17 +113,39 @@ func (w *tableWriter) write(ctx api.StreamContext, data []map[string]any) error 
 		if err := fillTablet(tablet, chunk, w.conf, &w.lastAuto); err != nil {
 			return err
 		}
-
-		session, err := w.pool.GetSession()
-		if err != nil {
-			return fmt.Errorf("failed to get iotdb table session: %w", err)
+		if err := tablet.Sort(); err != nil {
+			return fmt.Errorf("sort relational tablet: %w", err)
 		}
-		if err := session.Insert(tablet); err != nil {
-			session.Close()
-			return fmt.Errorf("insert relational tablet: %w", err)
+		if err := insertRelationalTablet(w.pool, tablet); err != nil {
+			return err
 		}
-		session.Close()
 		logger.Debugf("iotdb table writer inserted %d rows", tablet.RowSize)
+	}
+	return nil
+}
+
+func ensureDatabase(pool tableSessionProvider, database string) error {
+	session, err := pool.GetSession()
+	if err != nil {
+		return fmt.Errorf("failed to get iotdb table session for database creation: %w", err)
+	}
+	defer session.Close()
+
+	if err := session.ExecuteNonQueryStatement(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", database)); err != nil {
+		return fmt.Errorf("create iotdb database %q: %w", database, err)
+	}
+	return nil
+}
+
+func insertRelationalTablet(pool tableSessionProvider, tablet *client.Tablet) error {
+	session, err := pool.GetSession()
+	if err != nil {
+		return errorx.NewIOErr(fmt.Sprintf("failed to get iotdb table session: %v", err))
+	}
+	defer session.Close()
+
+	if err := session.Insert(tablet); err != nil {
+		return errorx.NewIOErr(fmt.Sprintf("insert relational tablet: %v", err))
 	}
 	return nil
 }

--- a/extensions/impl/iotdb/table_writer.go
+++ b/extensions/impl/iotdb/table_writer.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Timecho Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iotdb
+
+import (
+	"fmt"
+
+	"github.com/apache/iotdb-client-go/v2/client"
+	"github.com/lf-edge/ekuiper/contract/v2/api"
+)
+
+// tableWriter writes data using the IoTDB table model via TableSessionPool.
+type tableWriter struct {
+	pool *client.TableSessionPool
+	conf *iotdbConfig
+}
+
+func (w *tableWriter) connect(ctx api.StreamContext, conf *iotdbConfig) error {
+	w.conf = conf
+
+	host, port, err := splitAddr(conf.Addr)
+	if err != nil {
+		return err
+	}
+
+	poolConfig := &client.PoolConfig{
+		Host:     host,
+		Port:     port,
+		UserName: conf.Username,
+		Password: conf.Password,
+		Database: conf.Database,
+	}
+	if len(conf.NodeUrls) > 0 {
+		poolConfig.NodeUrls = conf.NodeUrls
+	}
+
+	pool := client.NewTableSessionPool(poolConfig, conf.PoolSize, int(conf.Timeout), 60000, false)
+	w.pool = &pool
+
+	// 自动创建数据库（table dialect 下的 CREATE DATABASE）
+	autoSession, err := w.pool.GetSession()
+	if err != nil {
+		return fmt.Errorf("failed to get iotdb table session for database creation: %w", err)
+	}
+	createDBSQL := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", conf.Database)
+	if err := autoSession.ExecuteNonQueryStatement(createDBSQL); err != nil {
+		autoSession.Close()
+		// 数据库可能已存在，记录 warning 但不阻断连接
+		ctx.GetLogger().Warnf("iotdb table writer: auto-create database %q failed (may already exist): %v", conf.Database, err)
+	} else {
+		ctx.GetLogger().Infof("iotdb table writer: database %q ensured", conf.Database)
+	}
+	autoSession.Close()
+
+	// test connection by acquiring and closing a session
+	session, err := w.pool.GetSession()
+	if err != nil {
+		return fmt.Errorf("failed to get iotdb table session: %w", err)
+	}
+	session.Close()
+
+	ctx.GetLogger().Infof("iotdb table writer connected to %s (database=%s)", conf.Addr, conf.Database)
+	return nil
+}
+
+func (w *tableWriter) write(ctx api.StreamContext, data []map[string]any) error {
+	if len(data) == 0 {
+		return nil
+	}
+	logger := ctx.GetLogger()
+
+	schemas, err := buildMeasurementSchemas(w.conf.Measurements, w.conf.DataTypes)
+	if err != nil {
+		return err
+	}
+	categories := make([]client.ColumnCategory, 0, len(w.conf.ColumnCategories))
+	for _, c := range w.conf.ColumnCategories {
+		cc, err := toColumnCategory(c)
+		if err != nil {
+			return err
+		}
+		categories = append(categories, cc)
+	}
+
+	batchSize := w.conf.BatchSize
+	if batchSize <= 0 {
+		batchSize = len(data)
+	}
+
+	for start := 0; start < len(data); start += batchSize {
+		end := start + batchSize
+		if end > len(data) {
+			end = len(data)
+		}
+		chunk := data[start:end]
+
+		tablet, err := client.NewRelationalTablet(w.conf.Table, schemas, categories, len(chunk))
+		if err != nil {
+			return fmt.Errorf("failed to create relational tablet: %w", err)
+		}
+
+		for rowIdx, row := range chunk {
+			ts, err := extractTimestamp(row, w.conf.TsFieldName)
+			if err != nil {
+				return err
+			}
+			tablet.SetTimestamp(ts, rowIdx)
+			for colIdx, m := range w.conf.Measurements {
+				raw, ok := row[m]
+				if !ok {
+					raw = nil
+				}
+				val, err := convertValue(raw, w.conf.DataTypes[colIdx])
+				if err != nil {
+					return fmt.Errorf("convert column %q row %d: %w", m, rowIdx, err)
+				}
+				if err := tablet.SetValueAt(val, colIdx, rowIdx); err != nil {
+					return fmt.Errorf("set value at (%d, %d): %w", colIdx, rowIdx, err)
+				}
+			}
+			tablet.RowSize++
+		}
+
+		session, err := w.pool.GetSession()
+		if err != nil {
+			return fmt.Errorf("failed to get iotdb table session: %w", err)
+		}
+		if err := session.Insert(tablet); err != nil {
+			session.Close()
+			return fmt.Errorf("insert relational tablet: %w", err)
+		}
+		session.Close()
+		logger.Debugf("iotdb table writer inserted %d rows", tablet.RowSize)
+	}
+	return nil
+}
+
+func (w *tableWriter) close() error {
+	if w.pool != nil {
+		w.pool.Close()
+	}
+	return nil
+}

--- a/extensions/impl/iotdb/tree_writer.go
+++ b/extensions/impl/iotdb/tree_writer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/lf-edge/ekuiper/contract/v2/api"
 
 	"github.com/lf-edge/ekuiper/v2/pkg/cast"
+	"github.com/lf-edge/ekuiper/v2/pkg/errorx"
 )
 
 // treeWriter writes data using the IoTDB tree model via SessionPool.
@@ -35,7 +36,7 @@ type treeWriter struct {
 func (w *treeWriter) connect(ctx api.StreamContext, conf *iotdbConfig) error {
 	w.conf = conf
 
-	poolConfig, err := conf.newPoolConfig()
+	poolConfig, err := conf.newPoolConfig("")
 	if err != nil {
 		return err
 	}
@@ -46,9 +47,9 @@ func (w *treeWriter) connect(ctx api.StreamContext, conf *iotdbConfig) error {
 	// test connection by acquiring and releasing a session
 	session, err := w.pool.GetSession()
 	if err != nil {
-		return fmt.Errorf("failed to get iotdb session: %w", err)
+		return errorx.NewIOErr(fmt.Sprintf("failed to get iotdb session: %v", err))
 	}
-	// SessionPool sessions require PutBack; PooledTableSession.Close does this internally.
+	// SessionPool exposes Session values, so PutBack returns this connection to the pool.
 	w.pool.PutBack(session)
 
 	ctx.GetLogger().Infof("iotdb tree writer connected to %s", conf.Addr)
@@ -63,7 +64,7 @@ func (w *treeWriter) write(ctx api.StreamContext, data []map[string]any) error {
 
 	session, err := w.pool.GetSession()
 	if err != nil {
-		return fmt.Errorf("failed to get iotdb session: %w", err)
+		return errorx.NewIOErr(fmt.Sprintf("failed to get iotdb session: %v", err))
 	}
 	defer w.pool.PutBack(session)
 
@@ -95,11 +96,11 @@ func (w *treeWriter) write(ctx api.StreamContext, data []map[string]any) error {
 
 		if w.conf.IsAligned {
 			if err := session.InsertAlignedTablet(tablet, false); err != nil {
-				return fmt.Errorf("insert aligned tablet: %w", err)
+				return errorx.NewIOErr(fmt.Sprintf("insert aligned tablet: %v", err))
 			}
 		} else {
 			if err := session.InsertTablet(tablet, false); err != nil {
-				return fmt.Errorf("insert tablet: %w", err)
+				return errorx.NewIOErr(fmt.Sprintf("insert tablet: %v", err))
 			}
 		}
 
@@ -115,15 +116,15 @@ func (w *treeWriter) close() error {
 	return nil
 }
 
-// extractTimestamp returns the timestamp for the given row. If tsFieldName is
-// empty or missing, the current time in milliseconds is returned.
+// extractTimestamp returns the configured timestamp, or the current time when
+// no timestamp field is configured. A configured but missing field is invalid.
 func extractTimestamp(row map[string]any, tsFieldName string) (int64, error) {
 	if tsFieldName == "" {
 		return time.Now().UnixMilli(), nil
 	}
 	v, ok := row[tsFieldName]
 	if !ok {
-		return time.Now().UnixMilli(), nil
+		return 0, fmt.Errorf("timestamp field %q is missing", tsFieldName)
 	}
 	ts, err := cast.ToInt64(v, cast.CONVERT_ALL)
 	if err != nil {

--- a/extensions/impl/iotdb/tree_writer.go
+++ b/extensions/impl/iotdb/tree_writer.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Timecho Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iotdb
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/apache/iotdb-client-go/v2/client"
+	"github.com/lf-edge/ekuiper/contract/v2/api"
+
+	"github.com/lf-edge/ekuiper/v2/pkg/cast"
+)
+
+// treeWriter writes data using the IoTDB tree model via SessionPool.
+type treeWriter struct {
+	pool client.SessionPool
+	conf *iotdbConfig
+}
+
+func (w *treeWriter) connect(ctx api.StreamContext, conf *iotdbConfig) error {
+	w.conf = conf
+
+	host, port, err := splitAddr(conf.Addr)
+	if err != nil {
+		return err
+	}
+
+	poolConfig := &client.PoolConfig{
+		Host:     host,
+		Port:     port,
+		UserName: conf.Username,
+		Password: conf.Password,
+	}
+	if len(conf.NodeUrls) > 0 {
+		poolConfig.NodeUrls = conf.NodeUrls
+	}
+
+	w.pool = client.NewSessionPool(poolConfig, conf.PoolSize, int(conf.Timeout), 60000, false)
+
+	// test connection by acquiring and releasing a session
+	session, err := w.pool.GetSession()
+	if err != nil {
+		return fmt.Errorf("failed to get iotdb session: %w", err)
+	}
+	w.pool.PutBack(session)
+
+	ctx.GetLogger().Infof("iotdb tree writer connected to %s", conf.Addr)
+	return nil
+}
+
+func (w *treeWriter) write(ctx api.StreamContext, data []map[string]any) error {
+	if len(data) == 0 {
+		return nil
+	}
+	logger := ctx.GetLogger()
+
+	session, err := w.pool.GetSession()
+	if err != nil {
+		return fmt.Errorf("failed to get iotdb session: %w", err)
+	}
+	defer w.pool.PutBack(session)
+
+	schemas, err := buildMeasurementSchemas(w.conf.Measurements, w.conf.DataTypes)
+	if err != nil {
+		return err
+	}
+
+	// write in batches according to the configured BatchSize
+	batchSize := w.conf.BatchSize
+	if batchSize <= 0 {
+		batchSize = len(data)
+	}
+
+	for start := 0; start < len(data); start += batchSize {
+		end := start + batchSize
+		if end > len(data) {
+			end = len(data)
+		}
+		chunk := data[start:end]
+
+		tablet, err := client.NewTablet(w.conf.Device, schemas, len(chunk))
+		if err != nil {
+			return fmt.Errorf("failed to create tablet: %w", err)
+		}
+
+		for rowIdx, row := range chunk {
+			ts, err := extractTimestamp(row, w.conf.TsFieldName)
+			if err != nil {
+				return err
+			}
+			tablet.SetTimestamp(ts, rowIdx)
+			for colIdx, m := range w.conf.Measurements {
+				raw, ok := row[m]
+				if !ok {
+					raw = nil
+				}
+				val, err := convertValue(raw, w.conf.DataTypes[colIdx])
+				if err != nil {
+					return fmt.Errorf("convert column %q row %d: %w", m, rowIdx, err)
+				}
+				if err := tablet.SetValueAt(val, colIdx, rowIdx); err != nil {
+					return fmt.Errorf("set value at (%d, %d): %w", colIdx, rowIdx, err)
+				}
+			}
+			tablet.RowSize++
+		}
+
+		if w.conf.IsAligned {
+			if err := session.InsertAlignedTablet(tablet, false); err != nil {
+				return fmt.Errorf("insert aligned tablet: %w", err)
+			}
+		} else {
+			if err := session.InsertTablet(tablet, false); err != nil {
+				return fmt.Errorf("insert tablet: %w", err)
+			}
+		}
+
+		logger.Debugf("iotdb tree writer inserted %d rows", tablet.RowSize)
+	}
+	return nil
+}
+
+func (w *treeWriter) close() error {
+	w.pool.Close()
+	return nil
+}
+
+// extractTimestamp returns the timestamp for the given row. If tsFieldName is
+// empty or missing, the current time in milliseconds is returned.
+func extractTimestamp(row map[string]any, tsFieldName string) (int64, error) {
+	if tsFieldName == "" {
+		return time.Now().UnixMilli(), nil
+	}
+	v, ok := row[tsFieldName]
+	if !ok {
+		return time.Now().UnixMilli(), nil
+	}
+	ts, err := cast.ToInt64(v, cast.CONVERT_ALL)
+	if err != nil {
+		return 0, fmt.Errorf("invalid timestamp field %q: %v", tsFieldName, err)
+	}
+	return ts, nil
+}

--- a/extensions/impl/iotdb/tree_writer.go
+++ b/extensions/impl/iotdb/tree_writer.go
@@ -26,8 +26,10 @@ import (
 
 // treeWriter writes data using the IoTDB tree model via SessionPool.
 type treeWriter struct {
-	pool client.SessionPool
+	pool *client.SessionPool
 	conf *iotdbConfig
+	// lastAuto is the monotonic cursor for auto-generated timestamps.
+	lastAuto int64
 }
 
 func (w *treeWriter) connect(ctx api.StreamContext, conf *iotdbConfig) error {
@@ -48,7 +50,8 @@ func (w *treeWriter) connect(ctx api.StreamContext, conf *iotdbConfig) error {
 		poolConfig.NodeUrls = conf.NodeUrls
 	}
 
-	w.pool = client.NewSessionPool(poolConfig, conf.PoolSize, int(conf.Timeout), 60000, false)
+	pool := client.NewSessionPool(poolConfig, conf.PoolSize, int(conf.Timeout), 60000, false)
+	w.pool = &pool
 
 	// test connection by acquiring and releasing a session
 	session, err := w.pool.GetSession()
@@ -95,27 +98,8 @@ func (w *treeWriter) write(ctx api.StreamContext, data []map[string]any) error {
 		if err != nil {
 			return fmt.Errorf("failed to create tablet: %w", err)
 		}
-
-		for rowIdx, row := range chunk {
-			ts, err := extractTimestamp(row, w.conf.TsFieldName)
-			if err != nil {
-				return err
-			}
-			tablet.SetTimestamp(ts, rowIdx)
-			for colIdx, m := range w.conf.Measurements {
-				raw, ok := row[m]
-				if !ok {
-					raw = nil
-				}
-				val, err := convertValue(raw, w.conf.DataTypes[colIdx])
-				if err != nil {
-					return fmt.Errorf("convert column %q row %d: %w", m, rowIdx, err)
-				}
-				if err := tablet.SetValueAt(val, colIdx, rowIdx); err != nil {
-					return fmt.Errorf("set value at (%d, %d): %w", colIdx, rowIdx, err)
-				}
-			}
-			tablet.RowSize++
+		if err := fillTablet(tablet, chunk, w.conf, &w.lastAuto); err != nil {
+			return err
 		}
 
 		if w.conf.IsAligned {
@@ -134,7 +118,9 @@ func (w *treeWriter) write(ctx api.StreamContext, data []map[string]any) error {
 }
 
 func (w *treeWriter) close() error {
-	w.pool.Close()
+	if w.pool != nil {
+		w.pool.Close()
+	}
 	return nil
 }
 

--- a/extensions/impl/iotdb/tree_writer.go
+++ b/extensions/impl/iotdb/tree_writer.go
@@ -35,19 +35,9 @@ type treeWriter struct {
 func (w *treeWriter) connect(ctx api.StreamContext, conf *iotdbConfig) error {
 	w.conf = conf
 
-	host, port, err := splitAddr(conf.Addr)
+	poolConfig, err := conf.newPoolConfig()
 	if err != nil {
 		return err
-	}
-
-	poolConfig := &client.PoolConfig{
-		Host:     host,
-		Port:     port,
-		UserName: conf.Username,
-		Password: conf.Password,
-	}
-	if len(conf.NodeUrls) > 0 {
-		poolConfig.NodeUrls = conf.NodeUrls
 	}
 
 	pool := client.NewSessionPool(poolConfig, conf.PoolSize, int(conf.Timeout), 60000, false)
@@ -58,6 +48,7 @@ func (w *treeWriter) connect(ctx api.StreamContext, conf *iotdbConfig) error {
 	if err != nil {
 		return fmt.Errorf("failed to get iotdb session: %w", err)
 	}
+	// SessionPool sessions require PutBack; PooledTableSession.Close does this internally.
 	w.pool.PutBack(session)
 
 	ctx.GetLogger().Infof("iotdb tree writer connected to %s", conf.Addr)

--- a/extensions/impl/iotdb/types.go
+++ b/extensions/impl/iotdb/types.go
@@ -136,20 +136,19 @@ func convertValue(v any, dt string) (any, error) {
 
 // nextTimestamp resolves the timestamp for a single row.
 //
-// An explicit timestamp supplied via tsFieldName is used as-is. An
-// auto-generated timestamp (field absent or tsFieldName empty) is forced to
-// strictly increase within a writer via lastAuto, so that multiple rows in one
-// batch do not collapse onto the same millisecond and overwrite each other in
-// IoTDB (where (device/table, timestamp) is the primary key).
+// An explicit timestamp supplied via tsFieldName is used as-is. When a
+// timestamp field is configured it must be present in every row. An
+// auto-generated timestamp (tsFieldName empty) is forced to strictly increase
+// within a writer via lastAuto, so that multiple rows in one batch do not
+// collapse onto the same millisecond and overwrite each other in IoTDB (where
+// (device/table, timestamp) is the primary key).
 func nextTimestamp(row map[string]any, tsFieldName string, lastAuto *int64) (int64, error) {
-	if tsFieldName != "" {
-		if _, ok := row[tsFieldName]; ok {
-			return extractTimestamp(row, tsFieldName)
-		}
-	}
 	ts, err := extractTimestamp(row, tsFieldName)
 	if err != nil {
 		return 0, err
+	}
+	if tsFieldName != "" {
+		return ts, nil
 	}
 	if ts <= *lastAuto {
 		ts = *lastAuto + 1

--- a/extensions/impl/iotdb/types.go
+++ b/extensions/impl/iotdb/types.go
@@ -1,0 +1,126 @@
+// Copyright 2026 Timecho Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package iotdb
+
+import (
+	"fmt"
+
+	"github.com/apache/iotdb-client-go/v2/client"
+
+	"github.com/lf-edge/ekuiper/v2/pkg/cast"
+)
+
+// toTSDataType maps an IoTDB data type string (already upper-cased and validated)
+// to the corresponding client.TSDataType constant.
+func toTSDataType(s string) (client.TSDataType, error) {
+	switch s {
+	case "INT32":
+		return client.INT32, nil
+	case "INT64":
+		return client.INT64, nil
+	case "FLOAT":
+		return client.FLOAT, nil
+	case "DOUBLE":
+		return client.DOUBLE, nil
+	case "BOOLEAN":
+		return client.BOOLEAN, nil
+	case "TEXT":
+		return client.TEXT, nil
+	case "STRING":
+		return client.STRING, nil
+	case "TIMESTAMP":
+		return client.TIMESTAMP, nil
+	default:
+		return client.UNKNOWN, fmt.Errorf("unsupported IoTDB data type %q", s)
+	}
+}
+
+// toColumnCategory maps a category string to client.ColumnCategory.
+func toColumnCategory(s string) (client.ColumnCategory, error) {
+	switch s {
+	case categoryTag:
+		return client.TAG, nil
+	case categoryField:
+		return client.FIELD, nil
+	case categoryAttribute:
+		return client.ATTRIBUTE, nil
+	default:
+		return 0, fmt.Errorf("unsupported column category %q", s)
+	}
+}
+
+// buildMeasurementSchemas builds a list of *client.MeasurementSchema for given names and types.
+func buildMeasurementSchemas(measurements []string, dataTypes []string) ([]*client.MeasurementSchema, error) {
+	schemas := make([]*client.MeasurementSchema, 0, len(measurements))
+	for i, m := range measurements {
+		dt, err := toTSDataType(dataTypes[i])
+		if err != nil {
+			return nil, err
+		}
+		schemas = append(schemas, &client.MeasurementSchema{
+			Measurement: m,
+			DataType:    dt,
+		})
+	}
+	return schemas, nil
+}
+
+// convertValue casts a Go value to the target IoTDB data type's expected Go type.
+// Returns nil when the input is nil (caller decides how to handle missing values).
+func convertValue(v any, dt string) (any, error) {
+	if v == nil {
+		return nil, nil
+	}
+	switch dt {
+	case "INT32":
+		i, err := cast.ToInt(v, cast.CONVERT_ALL)
+		if err != nil {
+			return nil, err
+		}
+		return int32(i), nil
+	case "INT64", "TIMESTAMP":
+		i, err := cast.ToInt64(v, cast.CONVERT_ALL)
+		if err != nil {
+			return nil, err
+		}
+		return i, nil
+	case "FLOAT":
+		f, err := cast.ToFloat64(v, cast.CONVERT_ALL)
+		if err != nil {
+			return nil, err
+		}
+		return float32(f), nil
+	case "DOUBLE":
+		f, err := cast.ToFloat64(v, cast.CONVERT_ALL)
+		if err != nil {
+			return nil, err
+		}
+		return f, nil
+	case "BOOLEAN":
+		b, err := cast.ToBool(v, cast.CONVERT_ALL)
+		if err != nil {
+			return nil, err
+		}
+		return b, nil
+	case "TEXT", "STRING":
+		s, err := cast.ToString(v, cast.CONVERT_ALL)
+		if err != nil {
+			return nil, err
+		}
+		return s, nil
+	default:
+		return nil, fmt.Errorf("unsupported IoTDB data type %q", dt)
+	}
+}

--- a/extensions/impl/iotdb/types.go
+++ b/extensions/impl/iotdb/types.go
@@ -16,6 +16,7 @@ package iotdb
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/apache/iotdb-client-go/v2/client"
 
@@ -85,9 +86,12 @@ func convertValue(v any, dt string) (any, error) {
 	}
 	switch dt {
 	case "INT32":
-		i, err := cast.ToInt(v, cast.CONVERT_ALL)
+		i, err := cast.ToInt64(v, cast.CONVERT_ALL)
 		if err != nil {
 			return nil, err
+		}
+		if i < math.MinInt32 || i > math.MaxInt32 {
+			return nil, fmt.Errorf("value %d overflows INT32 range", i)
 		}
 		return int32(i), nil
 	case "INT64", "TIMESTAMP":
@@ -100,6 +104,11 @@ func convertValue(v any, dt string) (any, error) {
 		f, err := cast.ToFloat64(v, cast.CONVERT_ALL)
 		if err != nil {
 			return nil, err
+		}
+		// float64 -> float32 silently yields +/-Inf when the magnitude is out of
+		// range; reject that instead of writing a bogus infinity.
+		if !math.IsInf(f, 0) && math.IsInf(float64(float32(f)), 0) {
+			return nil, fmt.Errorf("value %v overflows FLOAT range", f)
 		}
 		return float32(f), nil
 	case "DOUBLE":
@@ -123,4 +132,54 @@ func convertValue(v any, dt string) (any, error) {
 	default:
 		return nil, fmt.Errorf("unsupported IoTDB data type %q", dt)
 	}
+}
+
+// nextTimestamp resolves the timestamp for a single row.
+//
+// An explicit timestamp supplied via tsFieldName is used as-is. An
+// auto-generated timestamp (field absent or tsFieldName empty) is forced to
+// strictly increase within a writer via lastAuto, so that multiple rows in one
+// batch do not collapse onto the same millisecond and overwrite each other in
+// IoTDB (where (device/table, timestamp) is the primary key).
+func nextTimestamp(row map[string]any, tsFieldName string, lastAuto *int64) (int64, error) {
+	if tsFieldName != "" {
+		if _, ok := row[tsFieldName]; ok {
+			return extractTimestamp(row, tsFieldName)
+		}
+	}
+	ts, err := extractTimestamp(row, tsFieldName)
+	if err != nil {
+		return 0, err
+	}
+	if ts <= *lastAuto {
+		ts = *lastAuto + 1
+	}
+	*lastAuto = ts
+	return ts, nil
+}
+
+// fillTablet populates a tablet from a chunk of rows. It is shared by the tree
+// and table writers; only tablet construction and the insert call differ
+// between the two models. lastAuto carries the monotonic auto-timestamp cursor
+// across batches for a single writer.
+func fillTablet(tablet *client.Tablet, chunk []map[string]any, conf *iotdbConfig, lastAuto *int64) error {
+	for rowIdx, row := range chunk {
+		ts, err := nextTimestamp(row, conf.TsFieldName, lastAuto)
+		if err != nil {
+			return err
+		}
+		tablet.SetTimestamp(ts, rowIdx)
+		for colIdx, m := range conf.Measurements {
+			// a missing key yields a nil value, which SetValueAt records as null
+			val, err := convertValue(row[m], conf.DataTypes[colIdx])
+			if err != nil {
+				return fmt.Errorf("convert column %q row %d: %w", m, rowIdx, err)
+			}
+			if err := tablet.SetValueAt(val, colIdx, rowIdx); err != nil {
+				return fmt.Errorf("set value at (%d, %d): %w", colIdx, rowIdx, err)
+			}
+		}
+		tablet.RowSize++
+	}
+	return nil
 }

--- a/extensions/impl/iotdb/types.go
+++ b/extensions/impl/iotdb/types.go
@@ -107,7 +107,7 @@ func convertValue(v any, dt string) (any, error) {
 		}
 		// float64 -> float32 silently yields +/-Inf when the magnitude is out of
 		// range; reject that instead of writing a bogus infinity.
-		if !math.IsInf(f, 0) && math.IsInf(float64(float32(f)), 0) {
+		if math.IsInf(float64(float32(f)), 0) {
 			return nil, fmt.Errorf("value %v overflows FLOAT range", f)
 		}
 		return float32(f), nil

--- a/extensions/sinks/iotdb/iotdb.go
+++ b/extensions/sinks/iotdb/iotdb.go
@@ -1,0 +1,26 @@
+// Copyright 2026 Timecho Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	_ "github.com/apache/iotdb-client-go/v2/client"
+	"github.com/lf-edge/ekuiper/contract/v2/api"
+
+	"github.com/lf-edge/ekuiper/v2/extensions/impl/iotdb"
+)
+
+func Iotdb() api.Sink {
+	return iotdb.GetSink()
+}

--- a/extensions/sinks/iotdb/iotdb.json
+++ b/extensions/sinks/iotdb/iotdb.json
@@ -1,0 +1,276 @@
+{
+  "about": {
+    "trial": true,
+    "author": {
+      "name": "Hawkon",
+      "email": "github@mail.hawkon.tech",
+      "company": "Timecho Limited",
+      "website": "https://github.com/Hawkon"
+    },
+    "helpUrl": {
+      "en_US": "https://ekuiper.org/docs/en/latest/guide/sinks/plugin/iotdb.html",
+      "zh_CN": "https://ekuiper.org/docs/zh/latest/guide/sinks/plugin/iotdb.html"
+    },
+    "description": {
+      "en_US": "This is a sink plugin for Apache IoTDB. It writes data into IoTDB using the native Thrift client, and supports both the tree model and the table model.",
+      "zh_CN": "本插件为 Apache IoTDB 的持久化插件，使用原生 Thrift 客户端将分析结果写入 IoTDB，同时支持树模型（Tree Model）和表模型（Table Model）。"
+    }
+  },
+  "libs": [
+    "github.com/apache/iotdb-client-go/v2@v2.0.8"
+  ],
+  "properties": [
+    {
+      "name": "addr",
+      "default": "127.0.0.1:6667",
+      "optional": false,
+      "control": "text",
+      "type": "string",
+      "hint": {
+        "en_US": "IoTDB server address in host:port format.",
+        "zh_CN": "IoTDB 服务端地址，格式为 host:port。"
+      },
+      "label": {
+        "en_US": "Addr",
+        "zh_CN": "地址"
+      }
+    },
+    {
+      "name": "username",
+      "default": "root",
+      "optional": true,
+      "control": "text",
+      "type": "string",
+      "hint": {
+        "en_US": "IoTDB username.",
+        "zh_CN": "IoTDB 用户名。"
+      },
+      "label": {
+        "en_US": "Username",
+        "zh_CN": "用户名"
+      }
+    },
+    {
+      "name": "password",
+      "default": "root",
+      "optional": true,
+      "control": "text",
+      "type": "string",
+      "hint": {
+        "en_US": "IoTDB password.",
+        "zh_CN": "IoTDB 密码。"
+      },
+      "label": {
+        "en_US": "Password",
+        "zh_CN": "密码"
+      }
+    },
+    {
+      "name": "model",
+      "default": "tree",
+      "optional": false,
+      "control": "select",
+      "type": "string",
+      "values": [
+        "tree",
+        "table"
+      ],
+      "hint": {
+        "en_US": "Data model used by IoTDB. Choose 'tree' for the traditional tree model, or 'table' for the relational table model.",
+        "zh_CN": "IoTDB 使用的数据模型。选择 'tree' 表示传统树模型；选择 'table' 表示关系表模型。"
+      },
+      "label": {
+        "en_US": "Model",
+        "zh_CN": "数据模型"
+      }
+    },
+    {
+      "name": "device",
+      "default": "",
+      "optional": true,
+      "control": "text",
+      "type": "string",
+      "hint": {
+        "en_US": "Required when model is 'tree'. The device path, e.g. root.sg1.dev1.",
+        "zh_CN": "当 model 为 'tree' 时必填。设备路径，例如 root.sg1.dev1。"
+      },
+      "label": {
+        "en_US": "Device",
+        "zh_CN": "设备路径"
+      }
+    },
+    {
+      "name": "isAligned",
+      "default": false,
+      "optional": true,
+      "control": "radio",
+      "type": "bool",
+      "hint": {
+        "en_US": "Whether to use aligned timeseries when model is 'tree'.",
+        "zh_CN": "当 model 为 'tree' 时是否使用对齐时间序列。"
+      },
+      "label": {
+        "en_US": "Is Aligned",
+        "zh_CN": "对齐时间序列"
+      }
+    },
+    {
+      "name": "database",
+      "default": "",
+      "optional": true,
+      "control": "text",
+      "type": "string",
+      "hint": {
+        "en_US": "The database name for table model (without root. prefix, e.g. iot_data). The 'root.' prefix is automatically stripped if provided.",
+        "zh_CN": "表模型的数据库名称（不需要 root. 前缀，如 iot_data）。如果提供了 'root.' 前缀会被自动去除。"
+      },
+      "label": {
+        "en_US": "Database",
+        "zh_CN": "数据库"
+      }
+    },
+    {
+      "name": "table",
+      "default": "",
+      "optional": true,
+      "control": "text",
+      "type": "string",
+      "hint": {
+        "en_US": "Required when model is 'table'. The target table name.",
+        "zh_CN": "当 model 为 'table' 时必填。目标表名。"
+      },
+      "label": {
+        "en_US": "Table",
+        "zh_CN": "表名"
+      }
+    },
+    {
+      "name": "measurements",
+      "default": [],
+      "optional": false,
+      "control": "list",
+      "type": "list_string",
+      "hint": {
+        "en_US": "List of measurement / column names to write.",
+        "zh_CN": "要写入的测点名或列名列表。"
+      },
+      "label": {
+        "en_US": "Measurements",
+        "zh_CN": "测点/列名"
+      }
+    },
+    {
+      "name": "dataTypes",
+      "default": [],
+      "optional": false,
+      "control": "list",
+      "type": "list_string",
+      "hint": {
+        "en_US": "List of IoTDB data types matching measurements one-by-one. Allowed: INT32, INT64, FLOAT, DOUBLE, BOOLEAN, TEXT, STRING, TIMESTAMP.",
+        "zh_CN": "与测点一一对应的 IoTDB 数据类型列表。可选值：INT32, INT64, FLOAT, DOUBLE, BOOLEAN, TEXT, STRING, TIMESTAMP。"
+      },
+      "label": {
+        "en_US": "Data Types",
+        "zh_CN": "数据类型"
+      }
+    },
+    {
+      "name": "columnCategories",
+      "default": [],
+      "optional": true,
+      "control": "list",
+      "type": "list_string",
+      "hint": {
+        "en_US": "Required when model is 'table'. Column categories matching measurements. Allowed: TAG, FIELD, ATTRIBUTE.",
+        "zh_CN": "当 model 为 'table' 时必填。与测点一一对应的列类别。可选值：TAG, FIELD, ATTRIBUTE。"
+      },
+      "label": {
+        "en_US": "Column Categories",
+        "zh_CN": "列类别"
+      }
+    },
+    {
+      "name": "tsFieldName",
+      "default": "",
+      "optional": true,
+      "control": "text",
+      "type": "string",
+      "hint": {
+        "en_US": "Optional. Field name from the incoming row that carries the millisecond timestamp. If empty, the current time is used.",
+        "zh_CN": "可选。用于提取毫秒级时间戳的输入字段名。若为空则使用当前时间。"
+      },
+      "label": {
+        "en_US": "Timestamp Field Name",
+        "zh_CN": "时间戳字段名"
+      }
+    },
+    {
+      "name": "batchSize",
+      "default": 10,
+      "optional": true,
+      "control": "text",
+      "type": "int",
+      "hint": {
+        "en_US": "Number of rows in a single tablet insert.",
+        "zh_CN": "单次 tablet 写入的行数。"
+      },
+      "label": {
+        "en_US": "Batch Size",
+        "zh_CN": "批处理大小"
+      }
+    },
+    {
+      "name": "timeout",
+      "default": 5000,
+      "optional": true,
+      "control": "text",
+      "type": "int",
+      "hint": {
+        "en_US": "Connection timeout in milliseconds.",
+        "zh_CN": "连接超时时间，单位毫秒。"
+      },
+      "label": {
+        "en_US": "Timeout (ms)",
+        "zh_CN": "连接超时(毫秒)"
+      }
+    },
+    {
+      "name": "poolSize",
+      "default": 3,
+      "optional": true,
+      "control": "text",
+      "type": "int",
+      "hint": {
+        "en_US": "Maximum number of sessions in the connection pool.",
+        "zh_CN": "连接池中的最大 session 数量。"
+      },
+      "label": {
+        "en_US": "Pool Size",
+        "zh_CN": "连接池大小"
+      }
+    },
+    {
+      "name": "nodeUrls",
+      "default": [],
+      "optional": true,
+      "control": "list",
+      "type": "list_string",
+      "hint": {
+        "en_US": "Optional cluster node URLs, e.g. ['host1:port1','host2:port2']. When set, this overrides addr for cluster mode.",
+        "zh_CN": "可选的集群节点列表，例如 ['host1:port1','host2:port2']。设置后将以集群模式连接，覆盖 addr 单机配置。"
+      },
+      "label": {
+        "en_US": "Node URLs",
+        "zh_CN": "集群节点列表"
+      }
+    }
+  ],
+  "node": {
+    "category": "sink",
+    "icon": "iconPath",
+    "label": {
+      "en": "IoTDB",
+      "zh": "IoTDB"
+    }
+  }
+}

--- a/extensions/sinks/iotdb/iotdb.json
+++ b/extensions/sinks/iotdb/iotdb.json
@@ -196,8 +196,8 @@
       "control": "text",
       "type": "string",
       "hint": {
-        "en_US": "Optional. Field name from the incoming row that carries the millisecond timestamp. If empty, the current time is used.",
-        "zh_CN": "可选。用于提取毫秒级时间戳的输入字段名。若为空则使用当前时间。"
+        "en_US": "Optional. Field name from the incoming row that carries the millisecond timestamp. If empty, the current time is used; when set, every row must contain this field.",
+        "zh_CN": "可选。用于提取毫秒级时间戳的输入字段名。若为空则使用当前时间；配置后每一行都必须包含该字段。"
       },
       "label": {
         "en_US": "Timestamp Field Name",

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/alicebob/miniredis/v2 v2.30.0
 	github.com/amsokol/ignite-go-client v0.12.2
 	github.com/apache/calcite-avatica-go/v5 v5.3.0
+	github.com/apache/iotdb-client-go/v2 v2.0.8
 	github.com/apple/foundationdb/bindings/go v0.0.0-20250221231555-5140696da2df
 	github.com/benbjohnson/clock v1.3.5
 	github.com/bippio/go-impala v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -372,6 +372,9 @@ github.com/apache/arrow-go/v18 v18.4.0/go.mod h1:Aawvwhj8x2jURIzD9Moy72cF0FyJXOp
 github.com/apache/arrow/go/v15 v15.0.2/go.mod h1:DGXsR3ajT524njufqf95822i+KTh+yea1jass9YXgjA=
 github.com/apache/calcite-avatica-go/v5 v5.3.0 h1:7Gooh7opt3TObRe7WstTWbQGaA16ERjzoGeB26l3s/w=
 github.com/apache/calcite-avatica-go/v5 v5.3.0/go.mod h1:xgozzeFAHCh2ZZ7NCrD4CHx9waunSMOMXLDZRj9Gn3s=
+github.com/apache/iotdb-client-go/v2 v2.0.8 h1:4Z2bmnoeH9gPNz0cDSfqbvwfyY0Ocbo18vtPfjKo34k=
+github.com/apache/iotdb-client-go/v2 v2.0.8/go.mod h1:keIG+1Xfw8n2NukUbrEcYnnyN9VxP8OJLYvnHsg1k2s=
+github.com/apache/thrift v0.15.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/apache/thrift v0.17.0/go.mod h1:OLxhMRJxomX+1I/KUw03qoV3mMz16BwaKI+d4fPBx7Q=
 github.com/apache/thrift v0.23.0 h1:wKR6YnefQSEnxpEfmgTPuJibNG4bF0p2TK34tHLWi3s=
 github.com/apache/thrift v0.23.0/go.mod h1:zPt6WxgvTOM6hF92y8C+MkEM5LMxZuk4JcQOiU4Esvs=
@@ -1436,6 +1439,7 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=

--- a/internal/binder/function/funcs_agg.go
+++ b/internal/binder/function/funcs_agg.go
@@ -423,6 +423,6 @@ func median[T Number](nums []T) interface{} {
 	if n%2 == 1 {
 		return nums[n/2]
 	} else {
-		return float64((nums[n/2-1])+(nums[n/2])) / 2
+		return float64(nums[n/2-1]+nums[n/2]) / 2
 	}
 }

--- a/internal/binder/function/funcs_math.go
+++ b/internal/binder/function/funcs_math.go
@@ -606,11 +606,11 @@ func registerMathFunc() {
 }
 
 func radians(degrees float64) float64 {
-	return degrees * (DegToRad)
+	return degrees * DegToRad
 }
 
 func degrees(radians float64) float64 {
-	return radians * (RadToDeg)
+	return radians * RadToDeg
 }
 
 func conv(str string, fromBase, toBase int64) (res string, isNull bool, err error) {

--- a/internal/binder/io/ext_full.go
+++ b/internal/binder/io/ext_full.go
@@ -22,6 +22,7 @@ import (
 	"github.com/lf-edge/ekuiper/v2/extensions/impl/image"
 	"github.com/lf-edge/ekuiper/v2/extensions/impl/influx"
 	"github.com/lf-edge/ekuiper/v2/extensions/impl/influx2"
+	"github.com/lf-edge/ekuiper/v2/extensions/impl/iotdb"
 	"github.com/lf-edge/ekuiper/v2/extensions/impl/kafka"
 	sql2 "github.com/lf-edge/ekuiper/v2/extensions/impl/sql"
 	"github.com/lf-edge/ekuiper/v2/extensions/impl/video"
@@ -35,6 +36,7 @@ func init() {
 	modules.RegisterSink("image", func() api.Sink { return image.GetSink() })
 	modules.RegisterSink("influx", func() api.Sink { return influx.GetSink() })
 	modules.RegisterSink("influx2", func() api.Sink { return influx2.GetSink() })
+	modules.RegisterSink("iotdb", func() api.Sink { return iotdb.GetSink() })
 	modules.RegisterSource("sql", sql2.GetSource)
 	modules.RegisterLookupSource("sql", sql2.GetLookupSource)
 	modules.RegisterSink("sql", sql2.GetSink)

--- a/internal/topo/node/window_op.go
+++ b/internal/topo/node/window_op.go
@@ -714,7 +714,7 @@ func (o *WindowOperator) scan(inputs []xsql.EventRow, triggerTime time.Time, ctx
 	case ast.TUMBLING_WINDOW, ast.SESSION_WINDOW:
 		windowStart = o.triggerTime.UnixMilli()
 	case ast.HOPPING_WINDOW:
-		windowStart = (o.triggerTime.Add(-o.window.Interval)).UnixMilli()
+		windowStart = o.triggerTime.Add(-o.window.Interval).UnixMilli()
 	case ast.SLIDING_WINDOW:
 		windowStart = triggerTime.Add(-length).UnixMilli()
 	}

--- a/internal/topo/operator/field_processor.go
+++ b/internal/topo/operator/field_processor.go
@@ -87,32 +87,32 @@ func (p *defaultFieldProcessor) validateAndConvertField(sf *ast.JsonStreamField,
 	v := reflect.ValueOf(t)
 	jtype := v.Kind()
 	switch sf.Type {
-	case (ast.BIGINT).String():
+	case ast.BIGINT.String():
 		if jtype == reflect.Int64 {
 			return t, nil
 		}
 
 		return cast.ToInt64(t, cast.CONVERT_SAMEKIND)
-	case (ast.FLOAT).String():
+	case ast.FLOAT.String():
 		if jtype == reflect.Float64 {
 			return t, nil
 		}
 		return cast.ToFloat64(t, cast.CONVERT_SAMEKIND)
-	case (ast.BOOLEAN).String():
+	case ast.BOOLEAN.String():
 		if jtype == reflect.Bool {
 			return t, nil
 		}
 		return cast.ToBool(t, cast.CONVERT_SAMEKIND)
-	case (ast.STRINGS).String():
+	case ast.STRINGS.String():
 		if jtype == reflect.String {
 			return t, nil
 		}
 		return cast.ToString(t, cast.CONVERT_SAMEKIND)
-	case (ast.DATETIME).String():
+	case ast.DATETIME.String():
 		return cast.InterfaceToTime(t, p.timestampFormat)
-	case (ast.BYTEA).String():
+	case ast.BYTEA.String():
 		return cast.ToByteA(t, cast.CONVERT_SAMEKIND)
-	case (ast.ARRAY).String():
+	case ast.ARRAY.String():
 		if t == nil {
 			return []interface{}(nil), nil
 		} else if jtype == reflect.Slice {
@@ -133,7 +133,7 @@ func (p *defaultFieldProcessor) validateAndConvertField(sf *ast.JsonStreamField,
 		} else {
 			return nil, fmt.Errorf("expect array but got %v", t)
 		}
-	case (ast.STRUCT).String():
+	case ast.STRUCT.String():
 		var (
 			nextJ map[string]interface{}
 			ok    bool

--- a/internal/topo/planner/dataSourcePlan.go
+++ b/internal/topo/planner/dataSourcePlan.go
@@ -159,11 +159,7 @@ func (p *DataSourcePlan) PushDownPredicate(condition ast.Expr) (ast.Expr, Logica
 }
 
 func (p *DataSourcePlan) extract(expr ast.Expr) (ast.Expr, ast.Expr) {
-	s, hasDefault := getRefSources(expr)
-	l := len(s)
-	if hasDefault {
-		l += 1
-	}
+	s, _ := getRefSources(expr)
 	switch len(s) {
 	case 0:
 		return expr, nil

--- a/internal/topo/planner/planner_sink.go
+++ b/internal/topo/planner/planner_sink.go
@@ -310,7 +310,6 @@ func splitSink(tp *topo.Topo, s api.Sink, sinkName string, options *def.RuleOpti
 		if err != nil {
 			return nil, err
 		}
-		index++
 		result = append(result, cacheOp)
 	}
 	return result, nil

--- a/internal/topo/planner/planner_sink_test.go
+++ b/internal/topo/planner/planner_sink_test.go
@@ -629,10 +629,14 @@ func TestSinkSchema(t *testing.T) {
 // MockHasFieldsSink implements api.Sink and model.SinkInfoNode
 type MockHasFieldsSink struct{}
 
-func (m *MockHasFieldsSink) Open(ctx api.StreamContext) error                           { return nil }
-func (m *MockHasFieldsSink) Close(ctx api.StreamContext) error                          { return nil }
-func (m *MockHasFieldsSink) Configure(props map[string]interface{}) error               { return nil }
+func (m *MockHasFieldsSink) Open(ctx api.StreamContext) error { return nil }
+
+func (m *MockHasFieldsSink) Close(ctx api.StreamContext) error { return nil }
+
+func (m *MockHasFieldsSink) Configure(props map[string]interface{}) error { return nil }
+
 func (m *MockHasFieldsSink) Collect(ctx api.StreamContext, item api.MessageTuple) error { return nil }
+
 func (m *MockHasFieldsSink) CollectList(ctx api.StreamContext, items api.MessageTupleList) error {
 	return nil
 }

--- a/internal/topo/planner/planner_source.go
+++ b/internal/topo/planner/planner_source.go
@@ -220,7 +220,6 @@ func splitSource(ctx api.StreamContext, t *DataSourcePlan, ss api.Source, option
 
 	if t.name != emitterName && !emitterOpAdded {
 		ops = append(ops, Transform(&operator.EmitterOp{Emitter: string(emitterName)}, fmt.Sprintf("%d_emitter", index), options))
-		index++
 	}
 
 	if t.streamStmt.Options.SHARED && !t.inRuleTest {


### PR DESCRIPTION
## What

Add an IoTDB predefined sink plugin that writes data into Apache IoTDB using the native Thrift RPC client. It supports both the tree model and the table model.

## Changes

- feat(sink): add IoTDB predefined sink plugin
  - tree model: device/isAligned properties, aligned time-series support
  - table model: database/table/columnCategories properties
  - plugin descriptor, registration, English and Chinese docs, and unit tests
  - register the new sink docs in docs/directory.json
- fix(iotdb): harden sink writers and review fixes
  - use `*SessionPool` and guard `close()` so closing before a successful connect no longer panics
  - make auto-generated timestamps strictly increase per writer to avoid same-millisecond collisions
  - extract shared `fillTablet` helper
  - reject INT32/FLOAT overflow in `convertValue`
  - support IPv6 host literals in `splitAddr`
  - add tests for close-without-connect, monotonic timestamps, and overflow handling

## Verification

- `go test ./extensions/impl/iotdb/...` passes locally.
- `gofmt` / `gofumpt` / `gci` (repository settings) pass on changed Go files.
- `markdownlint` passes on changed docs, and the docs directory check passes after registration.
- Plugin compiles with `go build -trimpath --buildmode=plugin -o plugins/sinks/Iotdb.so extensions/sinks/iotdb/*.go`.
