### PR TITLE
chore: fix golangci-lint SA4006 and gofumpt issues

### DIFF
--- a/internal/binder/function/funcs_agg.go
+++ b/internal/binder/function/funcs_agg.go
@@ -423,6 +423,6 @@ func median[T Number](nums []T) interface{} {
 	if n%2 == 1 {
 		return nums[n/2]
 	} else {
-		return float64((nums[n/2-1])+(nums[n/2])) / 2
+		return float64(nums[n/2-1]+nums[n/2]) / 2
 	}
 }

--- a/internal/binder/function/funcs_math.go
+++ b/internal/binder/function/funcs_math.go
@@ -606,11 +606,11 @@ func registerMathFunc() {
 }
 
 func radians(degrees float64) float64 {
-	return degrees * (DegToRad)
+	return degrees * DegToRad
 }
 
 func degrees(radians float64) float64 {
-	return radians * (RadToDeg)
+	return radians * RadToDeg
 }
 
 func conv(str string, fromBase, toBase int64) (res string, isNull bool, err error) {

--- a/internal/topo/node/window_op.go
+++ b/internal/topo/node/window_op.go
@@ -714,7 +714,7 @@ func (o *WindowOperator) scan(inputs []xsql.EventRow, triggerTime time.Time, ctx
 	case ast.TUMBLING_WINDOW, ast.SESSION_WINDOW:
 		windowStart = o.triggerTime.UnixMilli()
 	case ast.HOPPING_WINDOW:
-		windowStart = (o.triggerTime.Add(-o.window.Interval)).UnixMilli()
+		windowStart = o.triggerTime.Add(-o.window.Interval).UnixMilli()
 	case ast.SLIDING_WINDOW:
 		windowStart = triggerTime.Add(-length).UnixMilli()
 	}

--- a/internal/topo/operator/field_processor.go
+++ b/internal/topo/operator/field_processor.go
@@ -87,32 +87,32 @@ func (p *defaultFieldProcessor) validateAndConvertField(sf *ast.JsonStreamField,
 	v := reflect.ValueOf(t)
 	jtype := v.Kind()
 	switch sf.Type {
-	case (ast.BIGINT).String():
+	case ast.BIGINT.String():
 		if jtype == reflect.Int64 {
 			return t, nil
 		}
 
 		return cast.ToInt64(t, cast.CONVERT_SAMEKIND)
-	case (ast.FLOAT).String():
+	case ast.FLOAT.String():
 		if jtype == reflect.Float64 {
 			return t, nil
 		}
 		return cast.ToFloat64(t, cast.CONVERT_SAMEKIND)
-	case (ast.BOOLEAN).String():
+	case ast.BOOLEAN.String():
 		if jtype == reflect.Bool {
 			return t, nil
 		}
 		return cast.ToBool(t, cast.CONVERT_SAMEKIND)
-	case (ast.STRINGS).String():
+	case ast.STRINGS.String():
 		if jtype == reflect.String {
 			return t, nil
 		}
 		return cast.ToString(t, cast.CONVERT_SAMEKIND)
-	case (ast.DATETIME).String():
+	case ast.DATETIME.String():
 		return cast.InterfaceToTime(t, p.timestampFormat)
-	case (ast.BYTEA).String():
+	case ast.BYTEA.String():
 		return cast.ToByteA(t, cast.CONVERT_SAMEKIND)
-	case (ast.ARRAY).String():
+	case ast.ARRAY.String():
 		if t == nil {
 			return []interface{}(nil), nil
 		} else if jtype == reflect.Slice {
@@ -133,7 +133,7 @@ func (p *defaultFieldProcessor) validateAndConvertField(sf *ast.JsonStreamField,
 		} else {
 			return nil, fmt.Errorf("expect array but got %v", t)
 		}
-	case (ast.STRUCT).String():
+	case ast.STRUCT.String():
 		var (
 			nextJ map[string]interface{}
 			ok    bool

--- a/internal/topo/planner/dataSourcePlan.go
+++ b/internal/topo/planner/dataSourcePlan.go
@@ -159,11 +159,7 @@ func (p *DataSourcePlan) PushDownPredicate(condition ast.Expr) (ast.Expr, Logica
 }
 
 func (p *DataSourcePlan) extract(expr ast.Expr) (ast.Expr, ast.Expr) {
-	s, hasDefault := getRefSources(expr)
-	l := len(s)
-	if hasDefault {
-		l += 1
-	}
+	s, _ := getRefSources(expr)
 	switch len(s) {
 	case 0:
 		return expr, nil

--- a/internal/topo/planner/planner_sink.go
+++ b/internal/topo/planner/planner_sink.go
@@ -310,7 +310,6 @@ func splitSink(tp *topo.Topo, s api.Sink, sinkName string, options *def.RuleOpti
 		if err != nil {
 			return nil, err
 		}
-		index++
 		result = append(result, cacheOp)
 	}
 	return result, nil

--- a/internal/topo/planner/planner_sink_test.go
+++ b/internal/topo/planner/planner_sink_test.go
@@ -629,10 +629,14 @@ func TestSinkSchema(t *testing.T) {
 // MockHasFieldsSink implements api.Sink and model.SinkInfoNode
 type MockHasFieldsSink struct{}
 
-func (m *MockHasFieldsSink) Open(ctx api.StreamContext) error                           { return nil }
-func (m *MockHasFieldsSink) Close(ctx api.StreamContext) error                          { return nil }
-func (m *MockHasFieldsSink) Configure(props map[string]interface{}) error               { return nil }
+func (m *MockHasFieldsSink) Open(ctx api.StreamContext) error { return nil }
+
+func (m *MockHasFieldsSink) Close(ctx api.StreamContext) error { return nil }
+
+func (m *MockHasFieldsSink) Configure(props map[string]interface{}) error { return nil }
+
 func (m *MockHasFieldsSink) Collect(ctx api.StreamContext, item api.MessageTuple) error { return nil }
+
 func (m *MockHasFieldsSink) CollectList(ctx api.StreamContext, items api.MessageTupleList) error {
 	return nil
 }

--- a/internal/topo/planner/planner_source.go
+++ b/internal/topo/planner/planner_source.go
@@ -220,7 +220,6 @@ func splitSource(ctx api.StreamContext, t *DataSourcePlan, ss api.Source, option
 
 	if t.name != emitterName && !emitterOpAdded {
 		ops = append(ops, Transform(&operator.EmitterOp{Emitter: string(emitterName)}, fmt.Sprintf("%d_emitter", index), options))
-		index++
 	}
 
 	if t.streamStmt.Options.SHARED && !t.inRuleTest {


### PR DESCRIPTION
## Summary

Fix the golangci-lint failures currently blocking CI on master (see https://github.com/lf-edge/ekuiper/actions/runs/33459342457/job/99706202089?pr=4113).

## Changes

- Remove unused `index++` assignments in `planner_source.go` and `planner_sink.go` (staticcheck SA4006)
- Remove unused `l` / `hasDefault` computation in `dataSourcePlan.go` (staticcheck SA4006)
- Apply gofumpt formatting in:
  - `window_op.go`
  - `funcs_math.go`
  - `funcs_agg.go`
  - `field_processor.go`
  - `planner_sink_test.go`

The extra gofumpt files were hidden by golangci-lint's default `max-same-issues=3`.

## Verification

- `golangci-lint run --build-tags full --max-same-issues=0 --max-issues-per-linter=0 ./...` reports 0 issues
- Unit tests for planner / operator / node packages pass