### PR TITLE
feat: add acc_min_by function

### DIFF
--- a/docs/en_US/sqls/functions/analytic_functions.md
+++ b/docs/en_US/sqls/functions/analytic_functions.md
@@ -427,6 +427,20 @@ Example: get the collection timestamp associated with the cumulative maximum tem
 acc_max_by(ts, temp) over (partition by soc)
 ```
 
+### ACC_MIN_BY
+
+```text
+acc_min_by(value, compare_value)
+```
+
+The `acc_min_by` function cumulatively compares `compare_value` and returns the `value` associated with its smallest value. If `compare_value` is equal, the `value` from the latest event is used. It returns `nil` when there is no valid `compare_value`.
+
+Example: get the collection timestamp associated with the cumulative minimum temperature.
+
+```text
+acc_min_by(ts, temp) over (partition by soc)
+```
+
 ### ACC_MAP_AGG
 
 ```text

--- a/docs/zh_CN/sqls/functions/analytic_functions.md
+++ b/docs/zh_CN/sqls/functions/analytic_functions.md
@@ -411,6 +411,20 @@ acc_max_by(value, compare_value)
 acc_max_by(ts, temp) over (partition by soc)
 ```
 
+### ACC_MIN_BY
+
+```text
+acc_min_by(value, compare_value)
+```
+
+`acc_min_by` 累计比较 `compare_value`，返回其最小值对应的 `value`。当 `compare_value` 相等时，使用最新一条数据对应的 `value`。当没有有效的 `compare_value` 时，返回 `nil`。
+
+示例：获取累计最低温度对应的采集时间。
+
+```text
+acc_min_by(ts, temp) over (partition by soc)
+```
+
 ### ACC_MAP_AGG
 
 ```text

--- a/internal/binder/function/funcs_acc.go
+++ b/internal/binder/function/funcs_acc.go
@@ -161,6 +161,25 @@ func registerGlobalAggFunc() {
 			return nil
 		},
 	}
+	builtins["acc_min_by"] = builtinFunc{
+		fType: ast.FuncTypeScalar,
+		exec: func(ctx api.FunctionContext, args []interface{}) (interface{}, bool) {
+			status, err := handleAccMinBy(ctx, args)
+			if err != nil {
+				return err, false
+			}
+			if status.Value == nil {
+				return nil, true
+			}
+			return status.Value.(*accMinByStatus).Value, true
+		},
+		val: func(_ api.FunctionContext, args []ast.Expr) error {
+			if len(args) != 2 && len(args) != 4 {
+				return fmt.Errorf("Expect 2/4 arguments but found %d.", len(args))
+			}
+			return nil
+		},
+	}
 	builtins["acc_map_agg"] = builtinFunc{
 		fType: ast.FuncTypeScalar,
 		exec: func(ctx api.FunctionContext, args []interface{}) (interface{}, bool) {
@@ -241,6 +260,79 @@ func accMaxByWithCond(ctx api.FunctionContext, value, by interface{}, begin, res
 	}
 	if status.HasBegin {
 		accMaxByExec(ctx, value, by, valid, key, status, true)
+	}
+	if reset {
+		status.HasBegin = false
+	}
+	if status.Err == nil {
+		if err := ctx.PutState(key, status); err != nil {
+			status.Err = err
+		}
+	}
+}
+
+// accMinByStatus keeps the latest value when compare values are equal.
+type accMinByStatus struct {
+	Value interface{}
+	By    float64
+}
+
+func handleAccMinBy(ctx api.FunctionContext, args []interface{}) (*accStatus, error) {
+	if len(args) != 4 && len(args) != 6 {
+		return nil, fmt.Errorf("wrong args length for acc_min_by: %d", len(args))
+	}
+	valid, key, status, err := extractAccStatus(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+	if len(args) == 6 {
+		begin, ok1 := args[2].(bool)
+		reset, ok2 := args[3].(bool)
+		if !ok1 || !ok2 {
+			return nil, fmt.Errorf("acc_min_by conditions should be boolean")
+		}
+		accMinByWithCond(ctx, args[0], args[1], begin, reset, valid, key, status)
+	} else {
+		accMinByExec(ctx, args[0], args[1], valid, key, status, false)
+	}
+	if status.Err != nil {
+		return nil, status.Err
+	}
+	return status, nil
+}
+
+func accMinByExec(ctx api.FunctionContext, value, by interface{}, valid bool, key string, status *accStatus, skip bool) {
+	if !valid || by == nil {
+		return
+	}
+	b, err := cast.ToFloat64(by, cast.CONVERT_SAMEKIND)
+	if err != nil {
+		status.Err = fmt.Errorf("acc_min_by compare_value should be number: %w", err)
+		return
+	}
+	if math.IsNaN(b) {
+		return
+	}
+	current, ok := status.Value.(*accMinByStatus)
+	if !ok || math.IsNaN(current.By) || b <= current.By {
+		status.Value = &accMinByStatus{Value: value, By: b}
+	}
+	if !skip {
+		if err := ctx.PutState(key, status); err != nil {
+			status.Err = err
+		}
+	}
+}
+
+func accMinByWithCond(ctx api.FunctionContext, value, by interface{}, begin, reset, valid bool, key string, status *accStatus) {
+	if !status.HasBegin {
+		status.Value = nil
+	}
+	if begin && !status.HasBegin {
+		status.HasBegin = true
+	}
+	if status.HasBegin {
+		accMinByExec(ctx, value, by, valid, key, status, true)
 	}
 	if reset {
 		status.HasBegin = false

--- a/internal/binder/function/funcs_acc_test.go
+++ b/internal/binder/function/funcs_acc_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
 	kctx "github.com/lf-edge/ekuiper/v2/internal/topo/context"
 	"github.com/lf-edge/ekuiper/v2/internal/topo/state"
+	"github.com/lf-edge/ekuiper/v2/pkg/ast"
 )
 
 func TestAccumulateAggCond(t *testing.T) {
@@ -349,6 +350,56 @@ func TestAccMinByEdgeCases(t *testing.T) {
 	result, ok = f.exec(fctx, args(5, 1, true, false, false))
 	require.True(t, ok)
 	require.Nil(t, result)
+}
+
+func TestAccMinByValidationAndState(t *testing.T) {
+	contextLogger := conf.Log.WithField("rule", "testAccMinByValidationAndState")
+	ctx := kctx.WithValue(kctx.Background(), kctx.LoggerKey, contextLogger)
+	tempStore, _ := state.CreateStore("acc_min_by_validation_test", def.AtMostOnce)
+	fctx := kctx.NewDefaultFuncContext(ctx.WithMeta("mockRule0", "test", tempStore), 0)
+	f := builtins["acc_min_by"]
+
+	// The validator accepts the normal and conditional forms only.
+	require.NoError(t, f.val(fctx, []ast.Expr{nil, nil}))
+	require.NoError(t, f.val(fctx, []ast.Expr{nil, nil, nil, nil}))
+	require.Error(t, f.val(fctx, []ast.Expr{nil}))
+	require.Error(t, f.val(fctx, []ast.Expr{nil, nil, nil}))
+	require.Error(t, f.val(fctx, []ast.Expr{nil, nil, nil, nil, nil}))
+
+	result, ok := f.exec(fctx, []interface{}{int64(1), int64(1)})
+	require.False(t, ok)
+	_, isErr := result.(error)
+	require.True(t, isErr)
+	result, ok = f.exec(fctx, []interface{}{int64(1), int64(1), "bad", true, true, "bad_conditions"})
+	require.False(t, ok)
+	_, isErr = result.(error)
+	require.True(t, isErr)
+	result, ok = f.exec(fctx, []interface{}{int64(1), int64(1), true, 123})
+	require.False(t, ok)
+	_, isErr = result.(error)
+	require.True(t, isErr)
+
+	// Invalid data does not replace the current result.
+	result, ok = f.exec(fctx, []interface{}{int64(1), float64(2.5), true, "validity"})
+	require.True(t, ok)
+	require.Equal(t, int64(1), result)
+	result, ok = f.exec(fctx, []interface{}{int64(2), float64(1.5), false, "validity"})
+	require.True(t, ok)
+	require.Equal(t, int64(1), result)
+	result, ok = f.exec(fctx, []interface{}{int64(3), "invalid", true, "invalid_value"})
+	require.False(t, ok)
+	_, isErr = result.(error)
+	require.True(t, isErr)
+
+	// Recover from an incompatible or malformed accumulator state.
+	require.NoError(t, fctx.PutState("wrong_type", &accStatus{Value: int64(1)}))
+	result, ok = f.exec(fctx, []interface{}{int64(4), int64(4), true, "wrong_type"})
+	require.True(t, ok)
+	require.Equal(t, int64(4), result)
+	require.NoError(t, fctx.PutState("nan_state", &accStatus{Value: &accMinByStatus{Value: int64(5), By: math.NaN()}}))
+	result, ok = f.exec(fctx, []interface{}{int64(6), int64(6), true, "nan_state"})
+	require.True(t, ok)
+	require.Equal(t, int64(6), result)
 }
 
 func TestAccMapAgg(t *testing.T) {

--- a/internal/binder/function/funcs_acc_test.go
+++ b/internal/binder/function/funcs_acc_test.go
@@ -292,6 +292,65 @@ func TestAccMaxBy(t *testing.T) {
 	require.Equal(t, int64(300), result)
 }
 
+func TestAccMinBy(t *testing.T) {
+	contextLogger := conf.Log.WithField("rule", "testAccMinBy")
+	tctx := kctx.WithValue(kctx.Background(), kctx.LoggerKey, contextLogger)
+	tempStore, _ := state.CreateStore("acc_min_by_test", def.AtMostOnce)
+	fctx := kctx.NewDefaultFuncContext(tctx.WithMeta("mockRule0", "test", tempStore), 0)
+	f := builtins["acc_min_by"]
+
+	args := func(value, by int64) []interface{} { return []interface{}{value, by, true, "min_by"} }
+	result, ok := f.exec(fctx, args(100, 10))
+	require.True(t, ok)
+	require.Equal(t, int64(100), result)
+	result, ok = f.exec(fctx, args(200, 11))
+	require.True(t, ok)
+	require.Equal(t, int64(100), result)
+	result, ok = f.exec(fctx, args(300, 10))
+	require.True(t, ok)
+	require.Equal(t, int64(300), result)
+}
+
+func TestAccMinByEdgeCases(t *testing.T) {
+	contextLogger := conf.Log.WithField("rule", "testAccMinByEdgeCases")
+	ctx := kctx.WithValue(kctx.Background(), kctx.LoggerKey, contextLogger)
+	tempStore, _ := state.CreateStore("acc_min_by_edge_test", def.AtMostOnce)
+	fctx := kctx.NewDefaultFuncContext(ctx.WithMeta("mockRule0", "test", tempStore), 0)
+	f := builtins["acc_min_by"]
+
+	result, ok := f.exec(fctx, []interface{}{int64(1), nil, true, "nil_by"})
+	require.True(t, ok)
+	require.Nil(t, result)
+	result, ok = f.exec(fctx, []interface{}{int64(1), math.NaN(), true, "nan_by"})
+	require.True(t, ok)
+	require.Nil(t, result)
+	result, ok = f.exec(fctx, []interface{}{int64(2), int64(10), true, "nan_by"})
+	require.True(t, ok)
+	require.Equal(t, int64(2), result)
+	result, ok = f.exec(fctx, []interface{}{int64(3), math.NaN(), true, "nan_by"})
+	require.True(t, ok)
+	require.Equal(t, int64(2), result)
+
+	args := func(value, by int64, valid, begin, reset bool) []interface{} {
+		return []interface{}{value, by, begin, reset, valid, "conditional_min_by"}
+	}
+	result, ok = f.exec(fctx, args(1, 10, true, false, false))
+	require.True(t, ok)
+	require.Nil(t, result)
+	result, ok = f.exec(fctx, args(2, 20, true, true, false))
+	require.True(t, ok)
+	require.Equal(t, int64(2), result)
+	result, ok = f.exec(fctx, args(3, 15, true, false, false))
+	require.True(t, ok)
+	require.Equal(t, int64(3), result)
+	result, ok = f.exec(fctx, args(4, 20, true, false, true))
+	require.True(t, ok)
+	require.Equal(t, int64(3), result)
+	result, ok = f.exec(fctx, args(5, 1, true, false, false))
+	require.True(t, ok)
+	require.Nil(t, result)
+}
+
 func TestAccMapAgg(t *testing.T) {
 	contextLogger := conf.Log.WithField("rule", "testAccMapAgg")
 	tctx := kctx.WithValue(kctx.Background(), kctx.LoggerKey, contextLogger)

--- a/internal/binder/function/function.go
+++ b/internal/binder/function/function.go
@@ -81,6 +81,7 @@ var analyticFuncs = map[string]struct{}{
 	"acc_count":   {},
 	"acc_collect": {},
 	"acc_max_by":  {},
+	"acc_min_by":  {},
 	"acc_map_agg": {},
 }
 


### PR DESCRIPTION
  ## Summary

  Add the `acc_min_by` cumulative analytic function.

  ### Behavior

  `acc_min_by(value, compare_value)` cumulatively compares `compare_value` and returns the `value` associated with the smallest comparison value.

  The behavior is consistent with `acc_max_by`:

  - Uses the latest event when comparison values are equal
  - Ignores `nil`, invalid data, and `NaN` comparison values
  - Supports conditional accumulation with `begin/reset`
  - Supports `OVER (PARTITION BY ...)`
  - Returns `nil` when no valid comparison value exists

  ### Changes

  - Register `acc_min_by` as an analytic function
  - Add English and Chinese documentation
  - Add unit tests for basic behavior, edge cases, and conditional accumulation

  ### Tests

  ```text
  go test ./internal/binder/function -run 'TestAcc(MinBy|MaxBy)' -count=1