### PR TITLE
refactor(checkpoint): isolate state snapshots

### DIFF
--- a/contract/api/source.go
+++ b/contract/api/source.go
@@ -1,4 +1,4 @@
-// Copyright 2024 EMQ Technologies Co., Ltd.
+// Copyright 2024-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -61,6 +61,11 @@ type Bounded interface {
 
 // Rewindable is a source feature that allows the source to rewind to a specific offset.
 type Rewindable interface {
+	// GetOffset returns the recovery position for the tuple most recently
+	// accepted by an ingest callback. The returned object graph must remain
+	// stable until that callback returns and must be gob-serializable. An
+	// error prevents checkpoint completion until a later callback returns a
+	// valid offset.
 	GetOffset() (any, error)
 	Rewind(offset any) error
 	ResetOffset(input map[string]any) error

--- a/contract/api/source.go
+++ b/contract/api/source.go
@@ -71,6 +71,15 @@ type Rewindable interface {
 	ResetOffset(input map[string]any) error
 }
 
+// ImmutableOffsetProvider marks a Rewindable source whose GetOffset result is
+// an immutable object graph. The checkpoint runtime may retain that graph
+// directly instead of cloning it for every tuple. Implementations must never
+// mutate any object reachable from an offset after returning it.
+type ImmutableOffsetProvider interface {
+	Rewindable
+	CheckpointOffsetIsImmutable()
+}
+
 // LookupSource is a source feature to query the source on demand
 type LookupSource interface {
 	Source

--- a/docs/en_US/extension/native/develop/source.md
+++ b/docs/en_US/extension/native/develop/source.md
@@ -161,6 +161,12 @@ If the [rule checkpoint](../../../guide/rules/state_and_fault_tolerance.md#sourc
 
 A typical implementation is to save an `offset` as a field of the source. And update the offset value when reading in new value. Notice that, when implementing GetOffset() will be called by eKuiper system which means the offset value can be accessed by multiple go routines. So a lock is required when read or write the offset.
 
+By default, eKuiper clones the offset returned by `GetOffset` to isolate the
+checkpoint from later source mutations. If the returned object graph is
+immutable after the call, implement `api.ImmutableOffsetProvider` to transfer
+it directly and avoid per-tuple serialization. Every value reachable from the
+offset must remain unchanged after `GetOffset` returns.
+
 ### Bounded Source
 
 Some data sources are bounded, such as files; some data sources are inherently unbounded, but in some scenarios, users

--- a/docs/en_US/operation/migration.md
+++ b/docs/en_US/operation/migration.md
@@ -4,6 +4,23 @@ This guide covers important breaking changes and migration steps when upgrading 
 
 ## Breaking Changes
 
+### Checkpoint format in v2.5
+
+eKuiper v2.5 writes checkpoint state in a versioned snapshot format. It can
+restore checkpoints written by earlier releases, but v2.4 and earlier cannot
+restore a checkpoint after v2.5 has successfully replaced it.
+
+Before upgrading, back up the data directory if rollback must preserve rule
+progress. To roll back after v2.5 has written a checkpoint, restore that backup,
+or delete and recreate the affected rule so that it starts from the source
+position configured for a new rule.
+
+Custom rewindable sources must also return a gob-serializable offset from
+`GetOffset`. The offset must represent the tuple most recently accepted by the
+ingest callback and remain unchanged until that callback returns. If
+`GetOffset` returns an error, eKuiper rejects checkpoints until a later ingest
+callback obtains a valid offset.
+
 ### SQLite Database Format
 
 eKuiper 2.x uses a different storage format for streams and tables in the SQLite database (`sqliteKV.db`). This means:

--- a/docs/en_US/operation/migration.md
+++ b/docs/en_US/operation/migration.md
@@ -21,6 +21,11 @@ ingest callback and remain unchanged until that callback returns. If
 `GetOffset` returns an error, eKuiper rejects checkpoints until a later ingest
 callback obtains a valid offset.
 
+Custom `api.Store` implementations remain compatible through `SaveState`.
+Stores may additionally implement the internal frozen-state extension to accept
+the already encoded snapshot directly; this is an optimization and is not
+required for checkpoint support.
+
 ### SQLite Database Format
 
 eKuiper 2.x uses a different storage format for streams and tables in the SQLite database (`sqliteKV.db`). This means:

--- a/docs/zh_CN/extension/native/develop/source.md
+++ b/docs/zh_CN/extension/native/develop/source.md
@@ -136,6 +136,11 @@ Lookup(ctx StreamContext, fields []string, keys []string, values []any) ([][]byt
 
 一个典型的实现是将 "offset" 作为源的一个字段来保存。当读入新的值时更新偏移值。注意，当实现 GetOffset() 时，将被 eKuiper 系统调用，这意味着偏移值可以被多个 go routines 访问。因此，在读或写偏移量时，需要一个锁。
 
+默认情况下，eKuiper 会克隆 `GetOffset` 返回的 offset，以隔离 checkpoint
+和 source 后续的修改。如果返回的对象图在调用后保持不可变，可以实现
+`api.ImmutableOffsetProvider`，直接移交对象并避免逐 tuple 序列化。实现方必须
+保证 `GetOffset` 返回后，offset 可达的所有值都不再变化。
+
 ### 有界源
 
 有些数据源是有界的，例如文件；有些数据源本身是无界的，但在某些场景用户希望能够在读取一定数据后停止。eKuiper

--- a/docs/zh_CN/operation/migration.md
+++ b/docs/zh_CN/operation/migration.md
@@ -4,6 +4,21 @@
 
 ## 破坏性变更
 
+### v2.5 Checkpoint 格式
+
+eKuiper v2.5 使用带版本号的快照格式写入 checkpoint。v2.5 可以恢复旧版本
+写入的 checkpoint；但 v2.5 成功生成新 checkpoint 后，v2.4 及更早版本不能
+读取该 checkpoint。
+
+如果回滚时需要保留规则处理进度，请在升级前备份数据目录。若 v2.5 已写入
+checkpoint，回滚时应恢复该备份；也可以删除并重新创建受影响的规则，使其从
+新规则配置的 source 位置开始。
+
+自定义 rewindable source 的 `GetOffset` 必须返回可被 gob 序列化的 offset。
+该 offset 必须表示 ingest callback 最近接收的 tuple，并且在 callback 返回前
+保持不变。若 `GetOffset` 返回错误，eKuiper 会拒绝 checkpoint，直到后续
+ingest callback 成功取得有效 offset。
+
 ### SQLite 数据库格式
 
 eKuiper 2.x 在 SQLite 数据库（`sqliteKV.db`）中使用了不同的存储格式。这意味着：

--- a/docs/zh_CN/operation/migration.md
+++ b/docs/zh_CN/operation/migration.md
@@ -19,6 +19,10 @@ checkpoint，回滚时应恢复该备份；也可以删除并重新创建受影�
 保持不变。若 `GetOffset` 返回错误，eKuiper 会拒绝 checkpoint，直到后续
 ingest callback 成功取得有效 offset。
 
+自定义 `api.Store` 实现仍可通过 `SaveState` 保持兼容。Store 也可以额外实现
+内部 frozen-state 扩展，直接接收已经编码的快照；这只是优化，并非支持
+checkpoint 的必要条件。
+
 ### SQLite 数据库格式
 
 eKuiper 2.x 在 SQLite 数据库（`sqliteKV.db`）中使用了不同的存储格式。这意味着：

--- a/extensions/impl/random/random.go
+++ b/extensions/impl/random/random.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2024 EMQ Technologies Co., Ltd.
+// Copyright 2021-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package random
 
 import (
 	"bytes"
+	"encoding/gob"
 	"encoding/json"
 	"fmt"
 	"math/rand"
@@ -29,6 +30,10 @@ import (
 )
 
 const dedupStateKey = "input"
+
+func init() {
+	gob.Register([][]byte{})
+}
 
 type randomSourceConfig struct {
 	Seed    int                    `json:"seed"`
@@ -69,16 +74,19 @@ func (s *randomSource) Connect(ctx api.StreamContext, sch api.StatusChangeHandle
 	logger := ctx.GetLogger()
 	logger.Debugf("open random source with deduplicate %d", s.conf.Deduplicate)
 	if s.conf.Deduplicate != 0 {
+		// Read the legacy state key for checkpoint compatibility. Keep an
+		// owned copy because the context state belongs to the checkpoint
+		// object graph.
 		list, err := ctx.GetState(dedupStateKey)
 		if err != nil {
 			return err
 		}
 		if list == nil {
-			list = make([][]byte, 0)
+			s.list = make([][]byte, 0)
 		} else {
 			if l, ok := list.([][]byte); ok {
 				logger.Debugf("restore list %v", l)
-				s.list = l
+				s.list = cloneDedupList(l)
 			} else {
 				s.list = make([][]byte, 0)
 				logger.Warnf("random source gets invalid state, ignore it")
@@ -128,11 +136,54 @@ func (s *randomSource) isDup(ctx api.StreamContext, next map[string]interface{})
 	}
 	logger.Debugf("no duplicate %s", ns)
 	if s.conf.Deduplicate > 0 && len(s.list) >= s.conf.Deduplicate {
-		s.list = s.list[1:]
+		// Offsets already published to SourceNode are immutable. Build a new
+		// outer slice before evicting an entry so a checkpoint cannot observe
+		// the replacement through an older slice header. The byte entries are
+		// immutable after json.Marshal and can be shared.
+		limit := s.conf.Deduplicate
+		nextList := make([][]byte, limit)
+		copy(nextList, s.list[len(s.list)-(limit-1):])
+		nextList[limit-1] = ns
+		s.list = nextList
+		return false
 	}
 	s.list = append(s.list, ns)
-	_ = ctx.PutState(dedupStateKey, s.list)
 	return false
+}
+
+func (s *randomSource) GetOffset() (any, error) {
+	if s.conf.Deduplicate == 0 {
+		return nil, nil
+	}
+	// Restrict capacity so callers cannot reslice into storage that a later
+	// append may reuse. Existing entries are never modified.
+	return s.list[:len(s.list):len(s.list)], nil
+}
+
+func (s *randomSource) CheckpointOffsetIsImmutable() {}
+
+func (s *randomSource) Rewind(offset any) error {
+	if offset == nil {
+		return nil
+	}
+	list, ok := offset.([][]byte)
+	if !ok {
+		return fmt.Errorf("random source dedup offset has invalid type %T", offset)
+	}
+	s.list = cloneDedupList(list)
+	return nil
+}
+
+func (s *randomSource) ResetOffset(_ map[string]any) error {
+	return fmt.Errorf("random source does not support resetting dedup offset")
+}
+
+func cloneDedupList(list [][]byte) [][]byte {
+	cloned := make([][]byte, len(list))
+	for i, item := range list {
+		cloned[i] = bytes.Clone(item)
+	}
+	return cloned
 }
 
 func (s *randomSource) Close(_ api.StreamContext) error {
@@ -143,4 +194,7 @@ func GetSource() api.Source {
 	return &randomSource{}
 }
 
-var _ api.PullTupleSource = &randomSource{}
+var (
+	_ api.PullTupleSource = &randomSource{}
+	_ api.Rewindable      = &randomSource{}
+)

--- a/extensions/impl/random/random_test.go
+++ b/extensions/impl/random/random_test.go
@@ -1,0 +1,197 @@
+// Copyright 2026 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package random
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/lf-edge/ekuiper/v2/internal/topo/checkpoint"
+	mockContext "github.com/lf-edge/ekuiper/v2/pkg/mock/context"
+)
+
+var _ checkpoint.ImmutableOffsetProvider = (*randomSource)(nil)
+
+func TestDedupStateCheckpointRoundTrip(t *testing.T) {
+	live := [][]byte{[]byte("first"), []byte("second")}
+	frozen, err := checkpoint.EncodeState(map[string]interface{}{dedupStateKey: live})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	live[0][0] = 'X'
+	restored, err := checkpoint.DecodeState(frozen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := restored[dedupStateKey].([][]byte)
+	if len(got) != 2 || !bytes.Equal(got[0], []byte("first")) || !bytes.Equal(got[1], []byte("second")) {
+		t.Fatalf("unexpected restored dedup state: %#v", got)
+	}
+}
+
+func TestDedupOffsetOwnsRestoredState(t *testing.T) {
+	restored := [][]byte{[]byte("first"), []byte("second")}
+	source := &randomSource{conf: &randomSourceConfig{Deduplicate: -1}}
+	if err := source.Rewind(restored); err != nil {
+		t.Fatal(err)
+	}
+
+	restored[0][0] = 'X'
+	offset, err := source.GetOffset()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := offset.([][]byte)
+	if !bytes.Equal(got[0], []byte("first")) {
+		t.Fatalf("source shared restored checkpoint state: %#v", got)
+	}
+}
+
+func TestDedupUsesImmutableRewindableOffsetInsteadOfLiveContextState(t *testing.T) {
+	ctx := mockContext.NewMockContext("rule", "random")
+	source := &randomSource{conf: &randomSourceConfig{Deduplicate: -1}}
+	next := map[string]interface{}{"value": int64(1)}
+
+	if source.isDup(ctx, next) {
+		t.Fatal("first value must not be a duplicate")
+	}
+	if state, err := ctx.GetState(dedupStateKey); err != nil {
+		t.Fatal(err)
+	} else if state != nil {
+		t.Fatalf("random source published live dedup state to context: %#v", state)
+	}
+
+	offset, err := source.GetOffset()
+	if err != nil {
+		t.Fatal(err)
+	}
+	published := offset.([][]byte)
+	if cap(published) != len(published) {
+		t.Fatalf("published offset retains mutable append capacity: len %d cap %d", len(published), cap(published))
+	}
+	if source.isDup(ctx, map[string]interface{}{"value": int64(2)}) {
+		t.Fatal("second value must not be a duplicate")
+	}
+	if len(published) != 1 || !bytes.Equal(published[0], []byte(`{"value":1}`)) {
+		t.Fatalf("published offset changed after append: %#v", published)
+	}
+}
+
+func TestBoundedDedupUsesCopyOnWriteForPublishedOffset(t *testing.T) {
+	ctx := mockContext.NewMockContext("rule", "random")
+	source := &randomSource{
+		conf: &randomSourceConfig{Deduplicate: 2},
+		list: [][]byte{[]byte(`{"value":1}`), []byte(`{"value":2}`)},
+	}
+	offset, err := source.GetOffset()
+	if err != nil {
+		t.Fatal(err)
+	}
+	published := offset.([][]byte)
+
+	if source.isDup(ctx, map[string]interface{}{"value": int64(3)}) {
+		t.Fatal("third value must not be a duplicate")
+	}
+	if !bytes.Equal(published[0], []byte(`{"value":1}`)) || !bytes.Equal(published[1], []byte(`{"value":2}`)) {
+		t.Fatalf("published bounded offset changed during eviction: %#v", published)
+	}
+	if len(source.list) != 2 || !bytes.Equal(source.list[0], []byte(`{"value":2}`)) || !bytes.Equal(source.list[1], []byte(`{"value":3}`)) {
+		t.Fatalf("unexpected current bounded dedup state: %#v", source.list)
+	}
+}
+
+func TestPublishedDedupOffsetCanFreezeWhileSourceAdvances(t *testing.T) {
+	for _, deduplicate := range []int{-1, 1_024} {
+		t.Run(fmt.Sprintf("deduplicate=%d", deduplicate), func(t *testing.T) {
+			initial := make([][]byte, 1_024, 2_048)
+			for i := range initial {
+				initial[i] = []byte("initial")
+			}
+			source := &randomSource{
+				conf: &randomSourceConfig{Deduplicate: deduplicate},
+				list: initial,
+			}
+			offset, err := source.GetOffset()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			start := make(chan struct{})
+			frozen := make(chan []byte, 1)
+			encodeErr := make(chan error, 1)
+			var ready sync.WaitGroup
+			ready.Add(1)
+			go func() {
+				ready.Done()
+				<-start
+				var encoded []byte
+				for range 20 {
+					var encodeStateErr error
+					encoded, encodeStateErr = checkpoint.EncodeState(map[string]interface{}{"offset": offset})
+					if encodeStateErr != nil {
+						encodeErr <- encodeStateErr
+						return
+					}
+				}
+				frozen <- encoded
+			}()
+			ready.Wait()
+			close(start)
+			ctx := mockContext.NewMockContext("rule", "random")
+			for i := range 100 {
+				if source.isDup(ctx, map[string]interface{}{"value": int64(i)}) {
+					t.Fatalf("new value %d must not be a duplicate", i)
+				}
+			}
+
+			select {
+			case err := <-encodeErr:
+				t.Fatal(err)
+			case encoded := <-frozen:
+				restored, err := checkpoint.DecodeState(encoded)
+				if err != nil {
+					t.Fatal(err)
+				}
+				published := restored["offset"].([][]byte)
+				if len(published) != len(initial) {
+					t.Fatalf("published offset length changed while freezing: got %d, want %d", len(published), len(initial))
+				}
+				if !bytes.Equal(published[0], []byte("initial")) || !bytes.Equal(published[len(published)-1], []byte("initial")) {
+					t.Fatalf("published offset changed while freezing: len=%d first=%q last=%q", len(published), published[0], published[len(published)-1])
+				}
+			}
+		})
+	}
+}
+
+func TestDedupConnectClonesLegacyState(t *testing.T) {
+	ctx := mockContext.NewMockContext("rule", "random")
+	legacy := [][]byte{[]byte("first")}
+	if err := ctx.PutState(dedupStateKey, legacy); err != nil {
+		t.Fatal(err)
+	}
+	source := &randomSource{conf: &randomSourceConfig{Deduplicate: -1}}
+	if err := source.Connect(ctx, func(string, string) {}); err != nil {
+		t.Fatal(err)
+	}
+
+	legacy[0][0] = 'X'
+	if !bytes.Equal(source.list[0], []byte("first")) {
+		t.Fatalf("source shared legacy context state: %#v", source.list)
+	}
+}

--- a/extensions/impl/random/random_test.go
+++ b/extensions/impl/random/random_test.go
@@ -24,8 +24,6 @@ import (
 	mockContext "github.com/lf-edge/ekuiper/v2/pkg/mock/context"
 )
 
-var _ checkpoint.ImmutableOffsetProvider = (*randomSource)(nil)
-
 func TestDedupStateCheckpointRoundTrip(t *testing.T) {
 	live := [][]byte{[]byte("first"), []byte("second")}
 	frozen, err := checkpoint.EncodeState(map[string]interface{}{dedupStateKey: live})

--- a/internal/binder/function/funcs_acc.go
+++ b/internal/binder/function/funcs_acc.go
@@ -1,4 +1,4 @@
-// Copyright 2025 EMQ Technologies Co., Ltd.
+// Copyright 2025-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package function
 
 import (
+	"encoding/gob"
 	"fmt"
 	"math"
 
@@ -23,6 +24,14 @@ import (
 	"github.com/lf-edge/ekuiper/v2/pkg/ast"
 	"github.com/lf-edge/ekuiper/v2/pkg/cast"
 )
+
+func init() {
+	gob.Register(&accStatus{})
+	gob.Register(&accAvgStatus{})
+	gob.Register(&accMaxByStatus{})
+	gob.Register(&accMinByStatus{})
+	gob.Register(&accMapAggStatus{})
+}
 
 func registerGlobalAggFunc() {
 	builtins["acc_avg"] = builtinFunc{
@@ -36,7 +45,7 @@ func registerGlobalAggFunc() {
 			case nil:
 				return float64(0), true
 			default:
-				return status.Value.(*accAvgStatus).avg, true
+				return status.Value.(*accAvgStatus).Avg, true
 			}
 		},
 		val: func(ctx api.FunctionContext, args []ast.Expr) error {
@@ -222,8 +231,8 @@ func handleAccMaxBy(ctx api.FunctionContext, args []interface{}) (*accStatus, er
 	} else {
 		accMaxByExec(ctx, args[0], args[1], valid, key, status, false)
 	}
-	if status.Err != nil {
-		return nil, status.Err
+	if status.err != nil {
+		return nil, status.err
 	}
 	return status, nil
 }
@@ -234,7 +243,7 @@ func accMaxByExec(ctx api.FunctionContext, value, by interface{}, valid bool, ke
 	}
 	b, err := cast.ToFloat64(by, cast.CONVERT_SAMEKIND)
 	if err != nil {
-		status.Err = fmt.Errorf("acc_max_by compare_value should be number: %w", err)
+		status.err = fmt.Errorf("acc_max_by compare_value should be number: %w", err)
 		return
 	}
 	if math.IsNaN(b) {
@@ -246,7 +255,7 @@ func accMaxByExec(ctx api.FunctionContext, value, by interface{}, valid bool, ke
 	}
 	if !skip {
 		if err := ctx.PutState(key, status); err != nil {
-			status.Err = err
+			status.err = err
 		}
 	}
 }
@@ -264,9 +273,9 @@ func accMaxByWithCond(ctx api.FunctionContext, value, by interface{}, begin, res
 	if reset {
 		status.HasBegin = false
 	}
-	if status.Err == nil {
+	if status.err == nil {
 		if err := ctx.PutState(key, status); err != nil {
-			status.Err = err
+			status.err = err
 		}
 	}
 }
@@ -295,8 +304,8 @@ func handleAccMinBy(ctx api.FunctionContext, args []interface{}) (*accStatus, er
 	} else {
 		accMinByExec(ctx, args[0], args[1], valid, key, status, false)
 	}
-	if status.Err != nil {
-		return nil, status.Err
+	if status.err != nil {
+		return nil, status.err
 	}
 	return status, nil
 }
@@ -307,7 +316,7 @@ func accMinByExec(ctx api.FunctionContext, value, by interface{}, valid bool, ke
 	}
 	b, err := cast.ToFloat64(by, cast.CONVERT_SAMEKIND)
 	if err != nil {
-		status.Err = fmt.Errorf("acc_min_by compare_value should be number: %w", err)
+		status.err = fmt.Errorf("acc_min_by compare_value should be number: %w", err)
 		return
 	}
 	if math.IsNaN(b) {
@@ -319,7 +328,7 @@ func accMinByExec(ctx api.FunctionContext, value, by interface{}, valid bool, ke
 	}
 	if !skip {
 		if err := ctx.PutState(key, status); err != nil {
-			status.Err = err
+			status.err = err
 		}
 	}
 }
@@ -337,9 +346,9 @@ func accMinByWithCond(ctx api.FunctionContext, value, by interface{}, begin, res
 	if reset {
 		status.HasBegin = false
 	}
-	if status.Err == nil {
+	if status.err == nil {
 		if err := ctx.PutState(key, status); err != nil {
-			status.Err = err
+			status.err = err
 		}
 	}
 }
@@ -397,8 +406,8 @@ func handleAccMapAgg(ctx api.FunctionContext, args []interface{}) (*accStatus, e
 	} else {
 		accMapAggExec(ctx, args[0], args[1], valid, key, status)
 	}
-	if status.Err != nil {
-		return nil, status.Err
+	if status.err != nil {
+		return nil, status.err
 	}
 	if err := ctx.PutState(key, status); err != nil {
 		return nil, err
@@ -412,7 +421,7 @@ func accMapAggExec(ctx api.FunctionContext, k, value interface{}, valid bool, st
 	}
 	ks, err := cast.ToString(k, cast.CONVERT_ALL)
 	if err != nil {
-		status.Err = fmt.Errorf("acc_map_agg key should be string-convertible: %w", err)
+		status.err = fmt.Errorf("acc_map_agg key should be string-convertible: %w", err)
 		return
 	}
 	s := status.Value.(*accMapAggStatus)
@@ -437,8 +446,8 @@ func handleAccFunc(ctx api.FunctionContext, args []interface{}, accFunc accFunc)
 	}
 	if len(args) == 3 {
 		accFunc.accFuncExec(ctx, args[0], validData, partitionKey, status, false)
-		if status.Err != nil {
-			return nil, status.Err
+		if status.err != nil {
+			return nil, status.err
 		}
 		return status, nil
 	}
@@ -446,8 +455,8 @@ func handleAccFunc(ctx api.FunctionContext, args []interface{}, accFunc accFunc)
 		if err := handleOnCondAccFunc(ctx, args, validData, partitionKey, status, accFunc); err != nil {
 			return nil, err
 		}
-		if status.Err != nil {
-			return nil, status.Err
+		if status.err != nil {
+			return nil, status.err
 		}
 		return status, nil
 	}
@@ -498,7 +507,7 @@ func extractAccStatus(ctx api.FunctionContext, args []interface{}) (validData bo
 	if !ok {
 		return false, "", nil, fmt.Errorf("invalid accumulator state type %T", val)
 	}
-	status.Err = nil
+	status.err = nil
 	return validData, partitionKey, status, nil
 }
 
@@ -516,7 +525,7 @@ func accFuncWithCond(ctx api.FunctionContext, value interface{}, onBegin, onRese
 	}
 	if status.HasBegin {
 		accFunc.accFuncExec(ctx, value, validData, partitionKey, status, true)
-		if status.Err != nil {
+		if status.err != nil {
 			return
 		}
 	}
@@ -526,15 +535,15 @@ func accFuncWithCond(ctx api.FunctionContext, value interface{}, onBegin, onRese
 		}
 	}
 	if err := ctx.PutState(partitionKey, status); err != nil {
-		status.Err = err
+		status.err = err
 		return
 	}
 }
 
 type accStatus struct {
-	Err      error
 	Value    interface{}
 	HasBegin bool
+	err      error
 }
 
 type accFunc interface {
@@ -558,7 +567,7 @@ func (a accCountFunc) accFuncExec(ctx api.FunctionContext, value interface{}, va
 	}
 	if !skipStatusSave {
 		if err := ctx.PutState(partitionKey, status); err != nil {
-			status.Err = err
+			status.err = err
 		}
 	}
 }
@@ -590,12 +599,12 @@ func (a accSumFunc) accFuncExec(ctx api.FunctionContext, value interface{}, vali
 			sum += v
 			status.Value = sum
 		default:
-			status.Err = fmt.Errorf("the value should be number")
+			status.err = fmt.Errorf("the value should be number")
 		}
 	}
 	if !skipStatusSave {
 		if err := ctx.PutState(partitionKey, status); err != nil {
-			status.Err = err
+			status.err = err
 		}
 	}
 }
@@ -626,11 +635,11 @@ func (a accMinFunc) accFuncExec(ctx api.FunctionContext, value interface{}, vali
 		mv = getMin(mv, v)
 		status.Value = mv
 	default:
-		status.Err = fmt.Errorf("the value should be number")
+		status.err = fmt.Errorf("the value should be number")
 	}
 	if !skipStatusSave {
 		if err := ctx.PutState(partitionKey, status); err != nil {
-			status.Err = err
+			status.err = err
 		}
 	}
 }
@@ -661,11 +670,11 @@ func (a accMaxFunc) accFuncExec(ctx api.FunctionContext, value interface{}, vali
 		mv = getMax(mv, v)
 		status.Value = mv
 	default:
-		status.Err = fmt.Errorf("the value should be number")
+		status.err = fmt.Errorf("the value should be number")
 	}
 	if !skipStatusSave {
 		if err := ctx.PutState(partitionKey, status); err != nil {
-			status.Err = err
+			status.err = err
 		}
 	}
 }
@@ -687,26 +696,26 @@ func (a accAvgFunc) accFuncExec(ctx api.FunctionContext, value interface{}, vali
 	}
 	switch v := value.(type) {
 	case int:
-		avgStatus.sum += float64(v)
-		avgStatus.count++
-		avgStatus.avg = avgStatus.sum / float64(avgStatus.count)
+		avgStatus.Sum += float64(v)
+		avgStatus.Count++
+		avgStatus.Avg = avgStatus.Sum / float64(avgStatus.Count)
 		status.Value = avgStatus
 	case int64:
-		avgStatus.sum += float64(v)
-		avgStatus.count++
-		avgStatus.avg = avgStatus.sum / float64(avgStatus.count)
+		avgStatus.Sum += float64(v)
+		avgStatus.Count++
+		avgStatus.Avg = avgStatus.Sum / float64(avgStatus.Count)
 		status.Value = avgStatus
 	case float64:
-		avgStatus.sum += v
-		avgStatus.count++
-		avgStatus.avg = avgStatus.sum / float64(avgStatus.count)
+		avgStatus.Sum += v
+		avgStatus.Count++
+		avgStatus.Avg = avgStatus.Sum / float64(avgStatus.Count)
 		status.Value = avgStatus
 	default:
-		status.Err = fmt.Errorf("the value should be number")
+		status.err = fmt.Errorf("the value should be number")
 	}
 	if !skipStatusSave {
 		if err := ctx.PutState(partitionKey, status); err != nil {
-			status.Err = err
+			status.err = err
 		}
 	}
 }
@@ -731,7 +740,7 @@ func (a accCollectFunc) accFuncExec(ctx api.FunctionContext, value interface{}, 
 	}
 	if !skipStatusSave {
 		if err := ctx.PutState(partitionKey, status); err != nil {
-			status.Err = err
+			status.err = err
 		}
 	}
 }
@@ -741,7 +750,7 @@ func (a accCollectFunc) accReset(status *accStatus) {
 }
 
 type accAvgStatus struct {
-	sum   float64
-	count int64
-	avg   float64
+	Sum   float64
+	Count int64
+	Avg   float64
 }

--- a/internal/binder/function/funcs_acc_test.go
+++ b/internal/binder/function/funcs_acc_test.go
@@ -1,6 +1,7 @@
 package function
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"testing"
@@ -9,10 +10,67 @@ import (
 
 	"github.com/lf-edge/ekuiper/v2/internal/conf"
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
+	"github.com/lf-edge/ekuiper/v2/internal/topo/checkpoint"
 	kctx "github.com/lf-edge/ekuiper/v2/internal/topo/context"
 	"github.com/lf-edge/ekuiper/v2/internal/topo/state"
 	"github.com/lf-edge/ekuiper/v2/pkg/ast"
 )
+
+func TestAccAvgCheckpointRoundTrip(t *testing.T) {
+	live := &accStatus{
+		Value:    &accAvgStatus{Sum: 12, Count: 3, Avg: 4},
+		HasBegin: true,
+	}
+	frozen, err := checkpoint.EncodeState(map[string]interface{}{"acc_avg": live})
+	require.NoError(t, err)
+
+	live.Value.(*accAvgStatus).Sum = 100
+	live.Value.(*accAvgStatus).Avg = 100
+
+	restored, err := checkpoint.DecodeState(frozen)
+	require.NoError(t, err)
+	status := restored["acc_avg"].(*accStatus)
+	require.True(t, status.HasBegin)
+	require.Equal(t, &accAvgStatus{Sum: 12, Count: 3, Avg: 4}, status.Value)
+}
+
+func TestAccCheckpointOmitsTransientError(t *testing.T) {
+	live := &accStatus{
+		Value:    int64(3),
+		HasBegin: true,
+		err:      errors.New("transient evaluation error"),
+	}
+	frozen, err := checkpoint.EncodeState(map[string]interface{}{"acc_count": live})
+	require.NoError(t, err)
+
+	restored, err := checkpoint.DecodeState(frozen)
+	require.NoError(t, err)
+	status := restored["acc_count"].(*accStatus)
+	require.NoError(t, status.err)
+	require.Equal(t, int64(3), status.Value)
+	require.True(t, status.HasBegin)
+}
+
+func TestAccByAndMapCheckpointRoundTrip(t *testing.T) {
+	tests := map[string]any{
+		"acc_max_by": &accMaxByStatus{Value: "max", By: 12},
+		"acc_min_by": &accMinByStatus{Value: "min", By: 3},
+		"acc_map_agg": &accMapAggStatus{
+			Entries: []accMapEntry{{Key: "key", Value: int64(42)}},
+			Index:   map[string]int{"key": 0},
+		},
+	}
+	for name, value := range tests {
+		t.Run(name, func(t *testing.T) {
+			frozen, err := checkpoint.EncodeState(map[string]interface{}{name: &accStatus{Value: value}})
+			require.NoError(t, err)
+
+			restored, err := checkpoint.DecodeState(frozen)
+			require.NoError(t, err)
+			require.Equal(t, value, restored[name].(*accStatus).Value)
+		})
+	}
+}
 
 func TestAccumulateAggCond(t *testing.T) {
 	tests := []struct {
@@ -547,7 +605,7 @@ func TestAccCollectFuncDirect(t *testing.T) {
 		s := &accStatus{Value: nil}
 		cf.accFuncExec(fctx, int64(1), true, "k1", s, true)
 		require.Equal(t, []interface{}{int64(1)}, s.Value)
-		require.Nil(t, s.Err)
+		require.Nil(t, s.err)
 	})
 
 	// Test accFuncExec with nil value arg (should skip)
@@ -569,6 +627,6 @@ func TestAccCollectFuncDirect(t *testing.T) {
 		s := &accStatus{Value: []interface{}{int64(1)}}
 		cf.accFuncExec(fctx, int64(2), true, "k4", s, false)
 		require.Equal(t, []interface{}{int64(1), int64(2)}, s.Value)
-		require.Nil(t, s.Err)
+		require.Nil(t, s.err)
 	})
 }

--- a/internal/io/file/source.go
+++ b/internal/io/file/source.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"sync/atomic"
 	"time"
 
 	"github.com/lf-edge/ekuiper/contract/v2/api"
@@ -67,7 +68,7 @@ type Source struct {
 	decorator modules.FileStreamDecorator
 	eof       api.EOFIngest
 	// rewind support state
-	rewindMeta *FileDirSourceRewindMeta
+	rewindMeta atomic.Pointer[FileDirSourceRewindMeta]
 }
 
 func (fs *Source) Provision(ctx api.StreamContext, props map[string]any) error {
@@ -155,7 +156,7 @@ func (fs *Source) Provision(ctx api.StreamContext, props map[string]any) error {
 		}
 		fs.decorator = decorator
 	}
-	fs.rewindMeta = &FileDirSourceRewindMeta{}
+	fs.rewindMeta.Store(&FileDirSourceRewindMeta{})
 	return nil
 }
 
@@ -430,15 +431,17 @@ func init() {
 }
 
 func (fs *Source) GetOffset() (any, error) {
-	return fs.rewindMeta, nil
+	return fs.rewindMeta.Load(), nil
 }
+
+func (fs *Source) CheckpointOffsetIsImmutable() {}
 
 func (fs *Source) Rewind(offset any) error {
 	rewindMeta, ok := offset.(*FileDirSourceRewindMeta)
 	if !ok {
 		return fmt.Errorf("fileDirSource rewind failed")
 	}
-	fs.rewindMeta = rewindMeta
+	fs.rewindMeta.Store(rewindMeta)
 	return nil
 }
 
@@ -455,15 +458,25 @@ func (fs *Source) checkFileRead(fileName string) (bool, time.Time, error) {
 		return false, time.Time{}, fmt.Errorf("%s is a directory", fileName)
 	}
 	fTime := fInfo.ModTime()
-	if fTime.After(fs.rewindMeta.LastModifyTime) {
+	rewindMeta := fs.rewindMeta.Load()
+	if rewindMeta == nil || fTime.After(rewindMeta.LastModifyTime) {
 		return true, fTime, nil
 	}
 	return false, time.Time{}, nil
 }
 
 func (fs *Source) updateRewindMeta(_ string, modifyTime time.Time) {
-	if modifyTime.After(fs.rewindMeta.LastModifyTime) {
-		fs.rewindMeta.LastModifyTime = modifyTime
+	for {
+		current := fs.rewindMeta.Load()
+		if current != nil && !modifyTime.After(current.LastModifyTime) {
+			return
+		}
+		// Replace instead of mutating so an offset already retained by a
+		// checkpoint remains immutable while the source advances.
+		next := &FileDirSourceRewindMeta{LastModifyTime: modifyTime}
+		if fs.rewindMeta.CompareAndSwap(current, next) {
+			return
+		}
 	}
 }
 

--- a/internal/io/file/source_test.go
+++ b/internal/io/file/source_test.go
@@ -32,6 +32,38 @@ import (
 	"github.com/lf-edge/ekuiper/v2/pkg/timex"
 )
 
+var _ interface{ CheckpointOffsetIsImmutable() } = (*Source)(nil)
+
+func TestPublishedOffsetRemainsImmutableWhileFileSourceAdvances(t *testing.T) {
+	firstTime := time.UnixMilli(100)
+	secondTime := time.UnixMilli(200)
+	source := &Source{}
+	source.rewindMeta.Store(&FileDirSourceRewindMeta{LastModifyTime: firstTime})
+
+	publishedValue, err := source.GetOffset()
+	assert.NoError(t, err)
+	published := publishedValue.(*FileDirSourceRewindMeta)
+	source.updateRewindMeta("ignored", secondTime)
+	currentValue, err := source.GetOffset()
+	assert.NoError(t, err)
+	current := currentValue.(*FileDirSourceRewindMeta)
+
+	assert.NotSame(t, published, current)
+	assert.Equal(t, firstTime, published.LastModifyTime)
+	assert.Equal(t, secondTime, current.LastModifyTime)
+}
+
+func BenchmarkFileSourceGetOffset(b *testing.B) {
+	source := &Source{}
+	source.rewindMeta.Store(&FileDirSourceRewindMeta{LastModifyTime: time.UnixMilli(100)})
+	b.ReportAllocs()
+	for b.Loop() {
+		benchmarkFileOffset, _ = source.GetOffset()
+	}
+}
+
+var benchmarkFileOffset any
+
 func TestSourceProvision(t *testing.T) {
 	// Create and write temp file
 	tmpfile, err := os.CreateTemp("", "test.lines")

--- a/internal/io/memory/sink.go
+++ b/internal/io/memory/sink.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2024 EMQ Technologies Co., Ltd.
+// Copyright 2021-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -81,8 +81,10 @@ func (s *sink) Collect(ctx api.StreamContext, data api.MessageTuple) error {
 	if dt, ok := data.(xsql.HasTracerCtx); ok {
 		spanCtx = dt.GetTracerCtx()
 	}
+	tuple := &xsql.Tuple{Message: data.ToMap(), Metadata: s.meta, Timestamp: timex.GetNow()}
+	tuple.SetTracerCtx(spanCtx)
 	var (
-		t   pubsub.MemTuple = &xsql.Tuple{Message: data.ToMap(), Metadata: s.meta, Timestamp: timex.GetNow(), Ctx: spanCtx}
+		t   pubsub.MemTuple = tuple
 		err error
 	)
 	if s.rowkindField != "" {
@@ -134,7 +136,8 @@ func (s *sink) CollectList(ctx api.StreamContext, tuples api.MessageTupleList) e
 	}
 	result := make([]pubsub.MemTuple, tuples.Len())
 	tuples.RangeOfTuples(func(index int, tuple api.MessageTuple) bool {
-		t := &xsql.Tuple{Message: tuple.ToMap(), Metadata: s.meta, Timestamp: timex.GetNow(), Ctx: spanCtx}
+		t := &xsql.Tuple{Message: tuple.ToMap(), Metadata: s.meta, Timestamp: timex.GetNow()}
+		t.SetTracerCtx(spanCtx)
 		if s.rowkindField != "" {
 			st, err := s.wrapUpdatable(t)
 			if err != nil {

--- a/internal/pkg/store/stores.go
+++ b/internal/pkg/store/stores.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 EMQ Technologies Co., Ltd.
+// Copyright 2021-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -137,14 +137,22 @@ func (s *stores) GetTS(table string) (kv.Tskv, error) {
 	return tts, nil
 }
 
-func (s *stores) DropTS(table string) {
+func (s *stores) DropTS(table string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if tts, contains := s.ts[table]; contains {
-		_ = tts.Drop()
+		if err := tts.Drop(); err != nil {
+			return err
+		}
 		delete(s.ts, table)
+		return nil
 	}
+	tts, err := s.tsBuilder.CreateTs(table)
+	if err != nil {
+		return err
+	}
+	return tts.Drop()
 }
 
 func GetKV(table string) (kv.KeyValue, error) {
@@ -166,14 +174,12 @@ func GetTS(table string) (kv.Tskv, error) {
 
 func DropTS(table string) error {
 	if checkpointStores != nil {
-		checkpointStores.DropTS(table)
-		return nil
+		return checkpointStores.DropTS(table)
 	}
 	if globalStores == nil {
 		return fmt.Errorf("global stores are not initialized")
 	}
-	globalStores.DropTS(table)
-	return nil
+	return globalStores.DropTS(table)
 }
 
 func DropKV(table string) error {

--- a/internal/pkg/store/stores.go
+++ b/internal/pkg/store/stores.go
@@ -107,7 +107,7 @@ func (s *stores) DropKV(table string) {
 
 	if ks, contains := s.kv[table]; contains {
 		_ = ks.Drop()
-		delete(s.ts, table)
+		delete(s.kv, table)
 	}
 }
 

--- a/internal/pkg/store/stores_test.go
+++ b/internal/pkg/store/stores_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023-2026 EMQ Technologies Co., Ltd.
+// Copyright 2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,21 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package xsql
+package store
 
 import (
-	"encoding/gob"
-	"time"
+	"testing"
+
+	"github.com/lf-edge/ekuiper/v2/internal/pkg/store/memory"
+	"github.com/lf-edge/ekuiper/v2/pkg/kv"
 )
 
-func init() {
-	gob.Register(time.Time{})
-	gob.Register(make(map[string]any))
-	gob.Register(make(map[string][]*Tuple))
-	gob.Register([]*Tuple{})
-	gob.Register(&Tuple{})
-	gob.Register(&SliceTuple{})
-	gob.Register(&JoinTuple{})
-	gob.Register([]any{})
-	gob.Register(&RawTuple{})
+func TestDropKVRemovesOnlyKVCacheEntry(t *testing.T) {
+	const table = "shared-name"
+	s := &stores{
+		kv: map[string]kv.KeyValue{table: memory.NewMemoryKV()},
+		ts: map[string]kv.Tskv{table: nil},
+	}
+
+	s.DropKV(table)
+	if _, ok := s.kv[table]; ok {
+		t.Fatal("dropped KV remained cached")
+	}
+	if _, ok := s.ts[table]; !ok {
+		t.Fatal("dropping KV removed the unrelated TS cache entry")
+	}
 }

--- a/internal/topo/checkpoint/barrier_handler.go
+++ b/internal/topo/checkpoint/barrier_handler.go
@@ -67,6 +67,7 @@ func (h *BarrierTracker) processBarrier(b *Barrier, ctx api.StreamContext) {
 		if c == h.inputCount {
 			err := h.responder.TriggerCheckpoint(b.CheckpointId)
 			if err != nil {
+				delete(h.pendingCheckpoints, b.CheckpointId)
 				logger.Errorf("trigger checkpoint for %s err: %s", h.responder.GetName(), err)
 				return
 			}
@@ -156,20 +157,11 @@ func (h *BarrierAligner) processBarrier(b *Barrier, ctx api.StreamContext) {
 		err := h.responder.TriggerCheckpoint(b.CheckpointId)
 		if err != nil {
 			logger.Errorf("trigger checkpoint for %s err: %s", h.responder.GetName(), err)
+			h.releaseBlocksAndReplay()
 			return
 		}
 
-		h.releaseBlocksAndResetBarriers()
-		// clean up all the buffer
-		var temp []*BufferOrEvent
-		temp = append(temp, h.buffer...)
-		go infra.SafeRun(func() error {
-			for _, d := range temp {
-				h.output <- d
-			}
-			return nil
-		})
-		h.buffer = make([]*BufferOrEvent, 0)
+		h.releaseBlocksAndReplay()
 	}
 }
 
@@ -187,6 +179,21 @@ func (h *BarrierAligner) SetOutput(output chan<- *BufferOrEvent) {
 
 func (h *BarrierAligner) releaseBlocksAndResetBarriers() {
 	h.blockedChannels = make(map[string]bool)
+}
+
+func (h *BarrierAligner) releaseBlocksAndReplay() {
+	h.releaseBlocksAndResetBarriers()
+	temp := append([]*BufferOrEvent(nil), h.buffer...)
+	h.buffer = make([]*BufferOrEvent, 0)
+	if len(temp) == 0 {
+		return
+	}
+	go infra.SafeRun(func() error {
+		for _, d := range temp {
+			h.output <- d
+		}
+		return nil
+	})
 }
 
 func (h *BarrierAligner) beginNewAlignment(barrier *Barrier, ctx api.StreamContext) {

--- a/internal/topo/checkpoint/barrier_handler_failure_test.go
+++ b/internal/topo/checkpoint/barrier_handler_failure_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checkpoint_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/lf-edge/ekuiper/v2/internal/topo/checkpoint"
+	topoContext "github.com/lf-edge/ekuiper/v2/internal/topo/context"
+)
+
+func TestBarrierAlignerReleasesInputsOnCheckpointFailure(t *testing.T) {
+	aligner := checkpoint.NewBarrierAligner(&failingResponder{name: "window"}, 2)
+	output := make(chan *checkpoint.BufferOrEvent, 1)
+	aligner.SetOutput(output)
+	ctx := topoContext.Background()
+
+	aligner.Process(&checkpoint.BufferOrEvent{Channel: "left", Data: &checkpoint.Barrier{CheckpointId: 1, OpId: "left"}}, ctx)
+	buffered := &checkpoint.BufferOrEvent{Channel: "left", Data: "row"}
+	if !aligner.Process(buffered, ctx) {
+		t.Fatal("row from an aligned input was not buffered")
+	}
+	aligner.Process(&checkpoint.BufferOrEvent{Channel: "right", Data: &checkpoint.Barrier{CheckpointId: 1, OpId: "right"}}, ctx)
+
+	if aligner.Process(&checkpoint.BufferOrEvent{Channel: "left", Data: "next-row"}, ctx) {
+		t.Fatal("input remained blocked after checkpoint failure")
+	}
+	select {
+	case got := <-output:
+		if got != buffered {
+			t.Fatalf("unexpected replayed row: %#v", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("buffered row was not replayed after checkpoint failure")
+	}
+}
+
+type failingResponder struct {
+	name string
+}
+
+func (r *failingResponder) TriggerCheckpoint(int64) error {
+	return errors.New("injected checkpoint failure")
+}
+
+func (r *failingResponder) GetName() string {
+	return r.name
+}

--- a/internal/topo/checkpoint/coordinator.go
+++ b/internal/topo/checkpoint/coordinator.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2024 EMQ Technologies Co., Ltd.
+// Copyright 2021-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ import (
 
 type pendingCheckpoint struct {
 	checkpointId   int64
-	isDiscarded    bool
 	notYetAckTasks map[string]bool
 }
 
@@ -46,13 +45,8 @@ func newPendingCheckpoint(checkpointId int64, tasksToWaitFor []Responder) *pendi
 	return pc
 }
 
-func (c *pendingCheckpoint) ack(opId string) bool {
-	if c.isDiscarded {
-		return false
-	}
+func (c *pendingCheckpoint) ack(opId string) {
 	delete(c.notYetAckTasks, opId)
-	// TODO serialize state
-	return true
 }
 
 func (c *pendingCheckpoint) isFullyAck() bool {
@@ -62,10 +56,6 @@ func (c *pendingCheckpoint) isFullyAck() bool {
 func (c *pendingCheckpoint) finalize() *completedCheckpoint {
 	ccp := &completedCheckpoint{checkpointId: c.checkpointId}
 	return ccp
-}
-
-func (c *pendingCheckpoint) dispose(_ bool) {
-	c.isDiscarded = true
 }
 
 type completedCheckpoint struct {
@@ -120,7 +110,9 @@ type Coordinator struct {
 	activated               atomic.Bool
 
 	inForceSaveState     atomic.Bool
+	forceCheckpointID    atomic.Int64
 	forceSaveStateNotify chan any
+	lastCheckpointID     int64
 }
 
 func NewCoordinator(ruleId string, sources []StreamTask, operators []NonSourceTask, sinks []SinkTask, qos def.Qos, store api.Store, interval time.Duration, ctx api.StreamContext) *Coordinator {
@@ -202,8 +194,7 @@ func (c *Coordinator) Activate() error {
 				case s := <-c.signal:
 					switch s.Message {
 					case ForceSaveState:
-						c.inForceSaveState.Store(true)
-						c.saveState(time.Now(), logger)
+						c.forceCheckpointID.Store(c.saveState(time.Now(), logger))
 					case STOP:
 						logger.Infof("Stop checkpoint scheduler")
 						if c.ticker != nil {
@@ -217,19 +208,15 @@ func (c *Coordinator) Activate() error {
 							checkpoint.ack(s.OpId)
 							if checkpoint.isFullyAck() {
 								c.complete(s.CheckpointId)
-								if c.inForceSaveState.Load() {
-									c.FinishForceSaveState()
-								}
+								c.finishForceSaveState(s.CheckpointId)
 							}
 						} else {
 							logger.Debugf("Receive ack from %s for non existing checkpoint %d", s.OpId, s.CheckpointId)
 						}
 					case DEC:
 						logger.Debugf("Receive dec from %s for checkpoint %d, cancel it", s.OpId, s.CheckpointId)
-						c.cancel(s.CheckpointId)
-						if c.inForceSaveState.Load() {
-							c.FinishForceSaveState()
-						}
+						c.cancel(s.CheckpointId, s.OpId)
+						c.finishForceSaveState(s.CheckpointId)
 					}
 				case <-c.ctx.Done():
 					logger.Info("Cancelling coordinator....")
@@ -246,7 +233,7 @@ func (c *Coordinator) Activate() error {
 	return nil
 }
 
-func (c *Coordinator) saveState(n time.Time, logger api.Logger) {
+func (c *Coordinator) saveState(n time.Time, logger api.Logger) int64 {
 	// trigger checkpoint
 	// TODO pose max attempt and min pause check for consequent pendingCheckpoints
 
@@ -254,6 +241,10 @@ func (c *Coordinator) saveState(n time.Time, logger api.Logger) {
 
 	// Create a pending checkpoint
 	checkpointId := cast.TimeToUnixMilli(n)
+	if checkpointId <= c.lastCheckpointID {
+		checkpointId = c.lastCheckpointID + 1
+	}
+	c.lastCheckpointID = checkpointId
 	checkpoint := newPendingCheckpoint(checkpointId, c.tasksToWaitFor)
 	logger.Debugf("Create checkpoint %d", checkpointId)
 	c.pendingCheckpoints.Store(checkpointId, checkpoint)
@@ -261,8 +252,7 @@ func (c *Coordinator) saveState(n time.Time, logger api.Logger) {
 	for _, r := range c.tasksToTrigger {
 		go func(t Responder) {
 			if err := t.TriggerCheckpoint(checkpointId); err != nil {
-				logger.Infof("Fail to trigger checkpoint for source %s with error %v, cancel it", t.GetName(), err)
-				c.cancel(checkpointId)
+				logger.Infof("Fail to trigger checkpoint for source %s with error %v", t.GetName(), err)
 			}
 		}(r)
 	}
@@ -271,6 +261,7 @@ func (c *Coordinator) saveState(n time.Time, logger api.Logger) {
 		c.store.Clean()
 		c.toBeClean = 0
 	}
+	return checkpointId
 }
 
 func (c *Coordinator) Deactivate() error {
@@ -282,25 +273,48 @@ func (c *Coordinator) Deactivate() error {
 }
 
 func (c *Coordinator) ForceSaveState() (chan any, error) {
-	if c.inForceSaveState.Load() {
+	if !c.inForceSaveState.CompareAndSwap(false, true) {
 		return nil, fmt.Errorf("duplicated force save state")
 	}
 	c.signal <- &Signal{Message: ForceSaveState}
 	return c.forceSaveStateNotify, nil
 }
 
-func (c *Coordinator) FinishForceSaveState() {
+func (c *Coordinator) finishForceSaveState(checkpointID int64) {
+	if !c.forceCheckpointID.CompareAndSwap(checkpointID, 0) {
+		return
+	}
 	c.inForceSaveState.Store(false)
 	c.forceSaveStateNotify <- struct{}{}
 }
 
-func (c *Coordinator) cancel(checkpointId int64) {
-	logger := c.ctx.GetLogger()
-	if checkpoint, ok := c.pendingCheckpoints.Load(checkpointId); ok {
-		c.pendingCheckpoints.Delete(checkpointId)
-		checkpoint.(*pendingCheckpoint).dispose(true)
+func (c *Coordinator) cancel(checkpointId int64, _ string) {
+	if _, ok := c.pendingCheckpoints.Load(checkpointId); ok {
+		// Checkpoint IDs are monotonic. Once a checkpoint is canceled, older
+		// in-flight checkpoints are obsolete as well; cancel them together so
+		// the store can use one bounded discard watermark for late snapshots.
+		c.pendingCheckpoints.Range(func(key, _ interface{}) bool {
+			candidate := key.(int64)
+			if candidate <= checkpointId {
+				c.discard(candidate)
+			}
+			return true
+		})
 	} else {
-		logger.Debugf("Cancel for non existing checkpoint %d. Just ignored", checkpointId)
+		c.ctx.GetLogger().Debugf("Cancel for non existing checkpoint %d. Just ignored", checkpointId)
+	}
+}
+
+func (c *Coordinator) discard(checkpointID int64) {
+	if _, ok := c.pendingCheckpoints.Load(checkpointID); ok {
+		c.pendingCheckpoints.Delete(checkpointID)
+		c.discardFrozenState(checkpointID)
+	}
+}
+
+func (c *Coordinator) discardFrozenState(checkpointID int64) {
+	if store, ok := c.store.(FrozenStateDiscarder); ok {
+		store.DiscardFrozenState(checkpointID)
 	}
 }
 
@@ -311,19 +325,16 @@ func (c *Coordinator) complete(checkpointId int64) {
 		err := c.store.SaveCheckpoint(checkpointId)
 		if err != nil {
 			logger.Infof("Cannot save checkpoint %d due to storage error: %v", checkpointId, err)
-			// TODO handle checkpoint error
+			c.cancel(checkpointId, "")
 			return
 		}
 		c.completedCheckpoints.add(ccp.(*pendingCheckpoint).finalize())
 		c.pendingCheckpoints.Delete(checkpointId)
 		// Drop the previous pendingCheckpoints
-		c.pendingCheckpoints.Range(func(a1 interface{}, a2 interface{}) bool {
+		c.pendingCheckpoints.Range(func(a1 interface{}, _ interface{}) bool {
 			cid := a1.(int64)
-			cp := a2.(*pendingCheckpoint)
 			if cid < checkpointId {
-				// TODO revisit how to abort a checkpoint, discard callback
-				cp.isDiscarded = true
-				c.pendingCheckpoints.Delete(cid)
+				c.discard(cid)
 			}
 			return true
 		})

--- a/internal/topo/checkpoint/coordinator.go
+++ b/internal/topo/checkpoint/coordinator.go
@@ -111,6 +111,7 @@ type Coordinator struct {
 
 	inForceSaveState     atomic.Bool
 	forceCheckpointID    atomic.Int64
+	forceSaveStateMu     sync.Mutex
 	forceSaveStateNotify chan any
 	lastCheckpointID     int64
 }
@@ -152,13 +153,12 @@ func NewCoordinator(ruleId string, sources []StreamTask, operators []NonSourceTa
 		completedCheckpoints: &checkpointStore{
 			maxNum: 3,
 		},
-		ruleId:               ruleId,
-		signal:               signal,
-		baseInterval:         interval,
-		store:                store,
-		ctx:                  ctx,
-		cleanThreshold:       100,
-		forceSaveStateNotify: make(chan any, 2),
+		ruleId:         ruleId,
+		signal:         signal,
+		baseInterval:   interval,
+		store:          store,
+		ctx:            ctx,
+		cleanThreshold: 100,
 	}
 }
 
@@ -200,6 +200,7 @@ func (c *Coordinator) Activate() error {
 						if c.ticker != nil {
 							c.ticker.Stop()
 						}
+						c.abortForceSaveState()
 						return nil
 					case ACK:
 						logger.Debugf("Receive ack from %s for checkpoint %d", s.OpId, s.CheckpointId)
@@ -224,6 +225,7 @@ func (c *Coordinator) Activate() error {
 						c.ticker.Stop()
 						logger.Info("Stop coordinator ticker")
 					}
+					c.abortForceSaveState()
 					return nil
 				}
 			}
@@ -268,24 +270,53 @@ func (c *Coordinator) Deactivate() error {
 	if c.ticker != nil {
 		c.ticker.Stop()
 	}
-	c.signal <- &Signal{Message: STOP}
+	select {
+	case c.signal <- &Signal{Message: STOP}:
+	case <-c.ctx.Done():
+		c.abortForceSaveState()
+	}
 	return nil
 }
 
 func (c *Coordinator) ForceSaveState() (chan any, error) {
+	c.forceSaveStateMu.Lock()
 	if !c.inForceSaveState.CompareAndSwap(false, true) {
+		c.forceSaveStateMu.Unlock()
 		return nil, fmt.Errorf("duplicated force save state")
 	}
-	c.signal <- &Signal{Message: ForceSaveState}
-	return c.forceSaveStateNotify, nil
+	notify := make(chan any)
+	c.forceSaveStateNotify = notify
+	c.forceSaveStateMu.Unlock()
+	select {
+	case c.signal <- &Signal{Message: ForceSaveState}:
+		return notify, nil
+	case <-c.ctx.Done():
+		c.abortForceSaveState()
+		return nil, c.ctx.Err()
+	}
 }
 
 func (c *Coordinator) finishForceSaveState(checkpointID int64) {
 	if !c.forceCheckpointID.CompareAndSwap(checkpointID, 0) {
 		return
 	}
+	c.closeForceSaveStateNotify()
+}
+
+func (c *Coordinator) abortForceSaveState() {
+	c.forceCheckpointID.Store(0)
+	c.closeForceSaveStateNotify()
+}
+
+func (c *Coordinator) closeForceSaveStateNotify() {
+	c.forceSaveStateMu.Lock()
+	notify := c.forceSaveStateNotify
+	c.forceSaveStateNotify = nil
 	c.inForceSaveState.Store(false)
-	c.forceSaveStateNotify <- struct{}{}
+	c.forceSaveStateMu.Unlock()
+	if notify != nil {
+		close(notify)
+	}
 }
 
 func (c *Coordinator) cancel(checkpointId int64, _ string) {

--- a/internal/topo/checkpoint/coordinator_lifecycle_test.go
+++ b/internal/topo/checkpoint/coordinator_lifecycle_test.go
@@ -1,0 +1,114 @@
+// Copyright 2026 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checkpoint
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestCanceledCheckpointIsRemovedImmediately(t *testing.T) {
+	store := &lifecycleStore{}
+	coordinator := &Coordinator{
+		pendingCheckpoints: &sync.Map{},
+		store:              store,
+	}
+	const checkpointID = int64(10)
+	const olderCheckpointID = int64(9)
+	coordinator.pendingCheckpoints.Store(olderCheckpointID, &pendingCheckpoint{
+		checkpointId: olderCheckpointID,
+		notYetAckTasks: map[string]bool{
+			"source": true,
+		},
+	})
+	coordinator.pendingCheckpoints.Store(checkpointID, &pendingCheckpoint{
+		checkpointId: checkpointID,
+		notYetAckTasks: map[string]bool{
+			"source": true,
+			"window": true,
+		},
+	})
+
+	coordinator.cancel(checkpointID, "source")
+	if len(store.discarded) != 2 {
+		t.Fatalf("canceled checkpoint and its older predecessor were not both discarded: %#v", store.discarded)
+	}
+	if _, ok := coordinator.pendingCheckpoints.Load(checkpointID); ok {
+		t.Fatal("canceled checkpoint remained pending")
+	}
+	if _, ok := coordinator.pendingCheckpoints.Load(olderCheckpointID); ok {
+		t.Fatal("older checkpoint remained pending after a newer cancellation")
+	}
+}
+
+func TestForceSaveCompletionIsBoundToCheckpointID(t *testing.T) {
+	coordinator := &Coordinator{
+		forceSaveStateNotify: make(chan any, 2),
+	}
+	const (
+		oldCheckpointID   = int64(1)
+		forceCheckpointID = int64(2)
+	)
+	coordinator.inForceSaveState.Store(true)
+	coordinator.forceCheckpointID.Store(forceCheckpointID)
+
+	coordinator.finishForceSaveState(oldCheckpointID)
+	select {
+	case <-coordinator.forceSaveStateNotify:
+		t.Fatal("an older periodic checkpoint completed the force-save request")
+	default:
+	}
+	if !coordinator.inForceSaveState.Load() {
+		t.Fatal("force-save flag cleared by an older checkpoint")
+	}
+
+	coordinator.finishForceSaveState(forceCheckpointID)
+	select {
+	case <-coordinator.forceSaveStateNotify:
+	default:
+		t.Fatal("force-save checkpoint did not notify completion synchronously")
+	}
+	if coordinator.inForceSaveState.Load() {
+		t.Fatal("force-save flag remained set after its checkpoint completed")
+	}
+}
+
+type lifecycleStore struct {
+	discarded []int64
+}
+
+func (s *lifecycleStore) SaveState(_ int64, _ string, _ map[string]interface{}) error {
+	return nil
+}
+
+func (s *lifecycleStore) SaveCheckpoint(_ int64) error {
+	return nil
+}
+
+func (s *lifecycleStore) GetOpState(_ string) (*sync.Map, error) {
+	return &sync.Map{}, nil
+}
+
+func (s *lifecycleStore) Clean() error {
+	return nil
+}
+
+func (s *lifecycleStore) SaveFrozenState(_ int64, _ string, _ []byte) error {
+	return nil
+}
+
+func (s *lifecycleStore) DiscardFrozenState(checkpointID int64) {
+	s.discarded = append(s.discarded, checkpointID)
+}

--- a/internal/topo/checkpoint/coordinator_lifecycle_test.go
+++ b/internal/topo/checkpoint/coordinator_lifecycle_test.go
@@ -15,8 +15,12 @@
 package checkpoint
 
 import (
+	"errors"
 	"sync"
 	"testing"
+	"time"
+
+	"github.com/lf-edge/ekuiper/contract/v2/api"
 )
 
 func TestCanceledCheckpointIsRemovedImmediately(t *testing.T) {
@@ -54,8 +58,9 @@ func TestCanceledCheckpointIsRemovedImmediately(t *testing.T) {
 }
 
 func TestForceSaveCompletionIsBoundToCheckpointID(t *testing.T) {
+	notify := make(chan any)
 	coordinator := &Coordinator{
-		forceSaveStateNotify: make(chan any, 2),
+		forceSaveStateNotify: notify,
 	}
 	const (
 		oldCheckpointID   = int64(1)
@@ -66,7 +71,7 @@ func TestForceSaveCompletionIsBoundToCheckpointID(t *testing.T) {
 
 	coordinator.finishForceSaveState(oldCheckpointID)
 	select {
-	case <-coordinator.forceSaveStateNotify:
+	case <-notify:
 		t.Fatal("an older periodic checkpoint completed the force-save request")
 	default:
 	}
@@ -76,7 +81,7 @@ func TestForceSaveCompletionIsBoundToCheckpointID(t *testing.T) {
 
 	coordinator.finishForceSaveState(forceCheckpointID)
 	select {
-	case <-coordinator.forceSaveStateNotify:
+	case <-notify:
 	default:
 		t.Fatal("force-save checkpoint did not notify completion synchronously")
 	}
@@ -85,8 +90,75 @@ func TestForceSaveCompletionIsBoundToCheckpointID(t *testing.T) {
 	}
 }
 
+func TestAbandonedForceSaveNotificationDoesNotAffectNextCall(t *testing.T) {
+	first := make(chan any)
+	coordinator := &Coordinator{forceSaveStateNotify: first}
+	coordinator.inForceSaveState.Store(true)
+	coordinator.forceCheckpointID.Store(1)
+	coordinator.finishForceSaveState(1)
+
+	second := make(chan any)
+	coordinator.forceSaveStateNotify = second
+	coordinator.inForceSaveState.Store(true)
+	coordinator.forceCheckpointID.Store(2)
+	select {
+	case <-second:
+		t.Fatal("second force-save call consumed the first call's completion")
+	default:
+	}
+	coordinator.finishForceSaveState(2)
+	select {
+	case <-second:
+	case <-time.After(time.Second):
+		t.Fatal("second force-save call was not completed")
+	}
+	select {
+	case <-first:
+	default:
+		t.Fatal("abandoned first completion was not independently closed")
+	}
+}
+
+func TestCheckpointIDsRemainMonotonicAtSameTimestamp(t *testing.T) {
+	coordinator := &Coordinator{
+		pendingCheckpoints: &sync.Map{},
+		store:              &lifecycleStore{},
+		cleanThreshold:     100,
+	}
+	now := time.UnixMilli(100)
+	first := coordinator.saveState(now, noopLogger{})
+	second := coordinator.saveState(now, noopLogger{})
+	if second != first+1 {
+		t.Fatalf("checkpoint IDs are not monotonic: first %d, second %d", first, second)
+	}
+}
+
+func TestSaveCheckpointFailureCancelsPendingCheckpoint(t *testing.T) {
+	store := &lifecycleStore{saveCheckpointErr: errors.New("injected save failure")}
+	coordinator := &Coordinator{
+		pendingCheckpoints:   &sync.Map{},
+		completedCheckpoints: &checkpointStore{maxNum: 3},
+		store:                store,
+		ctx:                  &lifecycleContext{logger: noopLogger{}},
+	}
+	const checkpointID = int64(30)
+	coordinator.pendingCheckpoints.Store(checkpointID, &pendingCheckpoint{checkpointId: checkpointID})
+
+	coordinator.complete(checkpointID)
+	if _, ok := coordinator.pendingCheckpoints.Load(checkpointID); ok {
+		t.Fatal("checkpoint remained pending after SaveCheckpoint failure")
+	}
+	if len(store.discarded) != 1 || store.discarded[0] != checkpointID {
+		t.Fatalf("failed checkpoint was not discarded: %#v", store.discarded)
+	}
+	if coordinator.completedCheckpoints.getCount() != 0 {
+		t.Fatal("failed checkpoint was recorded as complete")
+	}
+}
+
 type lifecycleStore struct {
-	discarded []int64
+	discarded         []int64
+	saveCheckpointErr error
 }
 
 func (s *lifecycleStore) SaveState(_ int64, _ string, _ map[string]interface{}) error {
@@ -94,7 +166,7 @@ func (s *lifecycleStore) SaveState(_ int64, _ string, _ map[string]interface{}) 
 }
 
 func (s *lifecycleStore) SaveCheckpoint(_ int64) error {
-	return nil
+	return s.saveCheckpointErr
 }
 
 func (s *lifecycleStore) GetOpState(_ string) (*sync.Map, error) {
@@ -112,3 +184,23 @@ func (s *lifecycleStore) SaveFrozenState(_ int64, _ string, _ []byte) error {
 func (s *lifecycleStore) DiscardFrozenState(checkpointID int64) {
 	s.discarded = append(s.discarded, checkpointID)
 }
+
+type lifecycleContext struct {
+	api.StreamContext
+	logger api.Logger
+}
+
+func (c *lifecycleContext) GetLogger() api.Logger {
+	return c.logger
+}
+
+type noopLogger struct{}
+
+func (noopLogger) Debug(...interface{})          {}
+func (noopLogger) Info(...interface{})           {}
+func (noopLogger) Warn(...interface{})           {}
+func (noopLogger) Error(...interface{})          {}
+func (noopLogger) Debugf(string, ...interface{}) {}
+func (noopLogger) Infof(string, ...interface{})  {}
+func (noopLogger) Warnf(string, ...interface{})  {}
+func (noopLogger) Errorf(string, ...interface{}) {}

--- a/internal/topo/checkpoint/coordinator_stop_test.go
+++ b/internal/topo/checkpoint/coordinator_stop_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checkpoint_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
+	"github.com/lf-edge/ekuiper/v2/internal/topo/checkpoint"
+	topoContext "github.com/lf-edge/ekuiper/v2/internal/topo/context"
+	"github.com/lf-edge/ekuiper/v2/internal/topo/state"
+)
+
+func TestCoordinatorStopUnblocksForceSaveWaiter(t *testing.T) {
+	ctx := topoContext.Background().WithMeta("rule", "coordinator", &state.MemoryStore{})
+	coordinator := checkpoint.NewCoordinator("rule", nil, nil, nil, def.AtLeastOnce, &state.MemoryStore{}, time.Hour, ctx)
+	if err := coordinator.Activate(); err != nil {
+		t.Fatal(err)
+	}
+	notify, err := coordinator.ForceSaveState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := coordinator.Deactivate(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-notify:
+	case <-time.After(time.Second):
+		t.Fatal("coordinator stop left force-save waiter blocked")
+	}
+}

--- a/internal/topo/checkpoint/defs.go
+++ b/internal/topo/checkpoint/defs.go
@@ -72,15 +72,6 @@ type CheckpointStateValidator interface {
 	CheckpointError() error
 }
 
-// ImmutableOffsetProvider marks a Rewindable source whose GetOffset result is
-// an immutable object graph. SourceNode may retain that graph directly instead
-// of cloning it on every tuple. Implementations must never mutate any object
-// reachable from an offset after returning it.
-type ImmutableOffsetProvider interface {
-	api.Rewindable
-	CheckpointOffsetIsImmutable()
-}
-
 // CheckpointPreparer materializes operator state at the checkpoint boundary.
 // Non-source tasks are called synchronously by their barrier handler, after
 // alignment and before forwarding the barrier or taking the context snapshot.

--- a/internal/topo/checkpoint/defs.go
+++ b/internal/topo/checkpoint/defs.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2024 EMQ Technologies Co., Ltd.
+// Copyright 2021-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -52,8 +52,33 @@ type BufferOrEvent struct {
 }
 
 type StreamCheckpointContext interface {
-	Snapshot() error
-	SaveState(checkpointId int64) error
+	Snapshot(checkpointID int64) error
+	SaveSnapshot(checkpointID int64) error
+}
+
+// CheckpointGuard serializes source ingestion with barrier emission and state
+// capture. Non-source tasks do not need to implement it because they process a
+// barrier on their event-loop goroutine.
+type CheckpointGuard interface {
+	LockCheckpoint()
+	UnlockCheckpoint()
+}
+
+// CheckpointStateValidator reports whether task state is safe to capture.
+// Responder calls it while the CheckpointGuard is held and after propagating
+// the barrier, so every downstream task can still terminate the checkpoint.
+type CheckpointStateValidator interface {
+	CheckpointGuard
+	CheckpointError() error
+}
+
+// ImmutableOffsetProvider marks a Rewindable source whose GetOffset result is
+// an immutable object graph. SourceNode may retain that graph directly instead
+// of cloning it on every tuple. Implementations must never mutate any object
+// reachable from an offset after returning it.
+type ImmutableOffsetProvider interface {
+	api.Rewindable
+	CheckpointOffsetIsImmutable()
 }
 
 // CheckpointPreparer materializes operator state at the checkpoint boundary.

--- a/internal/topo/checkpoint/responder.go
+++ b/internal/topo/checkpoint/responder.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2024 EMQ Technologies Co., Ltd.
+// Copyright 2021-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,14 +42,14 @@ func (re *ResponderExecutor) GetName() string {
 }
 
 func (re *ResponderExecutor) TriggerCheckpoint(checkpointId int64) error {
+	name := re.GetName()
 	ctx := re.task.GetStreamContext()
 	logger := ctx.GetLogger()
-	sctx, ok := ctx.(StreamCheckpointContext)
-	if !ok {
-		return fmt.Errorf("invalid context for checkpoint responder, must be a StreamCheckpointContext")
-	}
-	name := re.GetName()
 	logger.Debugf("Starting checkpoint %d on task %s", checkpointId, name)
+	if guard, ok := re.task.(CheckpointGuard); ok {
+		guard.LockCheckpoint()
+		defer guard.UnlockCheckpoint()
+	}
 	if preparer, ok := re.task.(CheckpointPreparer); ok {
 		if err := preparer.PrepareCheckpoint(); err != nil {
 			return err
@@ -64,14 +64,37 @@ func (re *ResponderExecutor) TriggerCheckpoint(checkpointId int64) error {
 	if nonSink, ok := re.task.(NonSinkTask); ok {
 		nonSink.Broadcast(barrier)
 	}
+	if validator, ok := re.task.(CheckpointStateValidator); ok {
+		if checkpointErr := validator.CheckpointError(); checkpointErr != nil {
+			re.responder <- &Signal{
+				Message: DEC,
+				Barrier: Barrier{CheckpointId: checkpointId, OpId: name},
+			}
+			return fmt.Errorf("task %s cannot checkpoint: %w", name, checkpointErr)
+		}
+	}
+	sctx, ok := ctx.(StreamCheckpointContext)
+	if !ok {
+		re.responder <- &Signal{
+			Message: DEC,
+			Barrier: Barrier{CheckpointId: checkpointId, OpId: name},
+		}
+		return fmt.Errorf("invalid context for checkpoint responder, must be a StreamCheckpointContext")
+	}
 	// Save key state to the global state
-	err := sctx.Snapshot()
+	err := sctx.Snapshot(checkpointId)
 	if err != nil {
+		re.responder <- &Signal{
+			Message: DEC,
+			Barrier: Barrier{CheckpointId: checkpointId, OpId: name},
+		}
 		return err
 	}
-	go infra.SafeRun(func() error {
+	go func() {
 		state := ACK
-		err := sctx.SaveState(checkpointId)
+		err := infra.SafeRun(func() error {
+			return sctx.SaveSnapshot(checkpointId)
+		})
 		if err != nil {
 			logger.Infof("save checkpoint error %s", err)
 			state = DEC
@@ -83,7 +106,6 @@ func (re *ResponderExecutor) TriggerCheckpoint(checkpointId int64) error {
 		}
 		re.responder <- signal
 		logger.Debugf("Complete checkpoint %d on task %s", checkpointId, name)
-		return nil
-	})
+	}()
 	return nil
 }

--- a/internal/topo/checkpoint/responder.go
+++ b/internal/topo/checkpoint/responder.go
@@ -46,13 +46,32 @@ func (re *ResponderExecutor) TriggerCheckpoint(checkpointId int64) error {
 	ctx := re.task.GetStreamContext()
 	logger := ctx.GetLogger()
 	logger.Debugf("Starting checkpoint %d on task %s", checkpointId, name)
-	if guard, ok := re.task.(CheckpointGuard); ok {
+	var guard CheckpointGuard
+	if g, ok := re.task.(CheckpointGuard); ok {
+		guard = g
 		guard.LockCheckpoint()
-		defer guard.UnlockCheckpoint()
+	}
+	unlockCheckpoint := func() {
+		if guard != nil {
+			guard.UnlockCheckpoint()
+			guard = nil
+		}
+	}
+	sendSignal := func(message Message) {
+		signal := &Signal{
+			Message: message,
+			Barrier: Barrier{CheckpointId: checkpointId, OpId: name},
+		}
+		select {
+		case re.responder <- signal:
+		case <-ctx.Done():
+		}
 	}
 	if preparer, ok := re.task.(CheckpointPreparer); ok {
 		if err := preparer.PrepareCheckpoint(); err != nil {
-			return err
+			unlockCheckpoint()
+			sendSignal(DEC)
+			return fmt.Errorf("task %s cannot prepare checkpoint: %w", name, err)
 		}
 	}
 	// create
@@ -66,30 +85,25 @@ func (re *ResponderExecutor) TriggerCheckpoint(checkpointId int64) error {
 	}
 	if validator, ok := re.task.(CheckpointStateValidator); ok {
 		if checkpointErr := validator.CheckpointError(); checkpointErr != nil {
-			re.responder <- &Signal{
-				Message: DEC,
-				Barrier: Barrier{CheckpointId: checkpointId, OpId: name},
-			}
+			unlockCheckpoint()
+			sendSignal(DEC)
 			return fmt.Errorf("task %s cannot checkpoint: %w", name, checkpointErr)
 		}
 	}
 	sctx, ok := ctx.(StreamCheckpointContext)
 	if !ok {
-		re.responder <- &Signal{
-			Message: DEC,
-			Barrier: Barrier{CheckpointId: checkpointId, OpId: name},
-		}
+		unlockCheckpoint()
+		sendSignal(DEC)
 		return fmt.Errorf("invalid context for checkpoint responder, must be a StreamCheckpointContext")
 	}
 	// Save key state to the global state
 	err := sctx.Snapshot(checkpointId)
 	if err != nil {
-		re.responder <- &Signal{
-			Message: DEC,
-			Barrier: Barrier{CheckpointId: checkpointId, OpId: name},
-		}
+		unlockCheckpoint()
+		sendSignal(DEC)
 		return err
 	}
+	unlockCheckpoint()
 	go func() {
 		state := ACK
 		err := infra.SafeRun(func() error {
@@ -100,11 +114,7 @@ func (re *ResponderExecutor) TriggerCheckpoint(checkpointId int64) error {
 			state = DEC
 		}
 
-		signal := &Signal{
-			Message: state,
-			Barrier: Barrier{CheckpointId: checkpointId, OpId: name},
-		}
-		re.responder <- signal
+		sendSignal(state)
 		logger.Debugf("Complete checkpoint %d on task %s", checkpointId, name)
 	}()
 	return nil

--- a/internal/topo/checkpoint/responder_test.go
+++ b/internal/topo/checkpoint/responder_test.go
@@ -1,0 +1,214 @@
+// Copyright 2026 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checkpoint_test
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lf-edge/ekuiper/contract/v2/api"
+
+	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
+	"github.com/lf-edge/ekuiper/v2/internal/topo/checkpoint"
+	topoContext "github.com/lf-edge/ekuiper/v2/internal/topo/context"
+	"github.com/lf-edge/ekuiper/v2/internal/topo/state"
+)
+
+func TestResponderSendsACKAndHoldsGuard(t *testing.T) {
+	ctx := topoContext.Background().WithMeta("rule", "source", &state.MemoryStore{})
+	task := &guardedTask{name: "source", ctx: ctx}
+	signals := make(chan *checkpoint.Signal, 1)
+	responder := checkpoint.NewResponderExecutor(signals, task)
+
+	if err := responder.TriggerCheckpoint(1); err != nil {
+		t.Fatal(err)
+	}
+	signal := receiveSignal(t, signals)
+	if signal.Message != checkpoint.ACK || signal.CheckpointId != 1 || signal.OpId != "source" {
+		t.Fatalf("unexpected signal: %#v", signal)
+	}
+	task.mu.Lock()
+	defer task.mu.Unlock()
+	if task.guardDepth != 0 {
+		t.Fatalf("checkpoint guard was not released: depth %d", task.guardDepth)
+	}
+	if len(task.broadcasts) != 1 {
+		t.Fatalf("barrier count mismatch: %d", len(task.broadcasts))
+	}
+}
+
+func TestResponderSendsDECOnCaptureFailure(t *testing.T) {
+	ctx := topoContext.Background().WithMeta("rule", "op", &state.MemoryStore{})
+	if err := ctx.PutState("unsupported", make(chan int)); err != nil {
+		t.Fatal(err)
+	}
+	task := &guardedTask{name: "op", ctx: ctx}
+	signals := make(chan *checkpoint.Signal, 1)
+	responder := checkpoint.NewResponderExecutor(signals, task)
+
+	if err := responder.TriggerCheckpoint(2); err == nil {
+		t.Fatal("capture failure must be returned")
+	}
+	signal := receiveSignal(t, signals)
+	if signal.Message != checkpoint.DEC || signal.CheckpointId != 2 || signal.OpId != "op" {
+		t.Fatalf("unexpected signal: %#v", signal)
+	}
+	task.mu.Lock()
+	defer task.mu.Unlock()
+	if task.guardDepth != 0 {
+		t.Fatalf("checkpoint guard was not released: depth %d", task.guardDepth)
+	}
+}
+
+func TestResponderSendsDECAfterBarrierOnGuardError(t *testing.T) {
+	ctx := topoContext.Background().WithMeta("rule", "source", &state.MemoryStore{})
+	task := &guardedTask{
+		name:          "source",
+		ctx:           ctx,
+		checkpointErr: errors.New("offset unavailable"),
+	}
+	signals := make(chan *checkpoint.Signal, 1)
+	responder := checkpoint.NewResponderExecutor(signals, task)
+
+	if err := responder.TriggerCheckpoint(4); err == nil {
+		t.Fatal("checkpoint guard error must be returned")
+	}
+	signal := receiveSignal(t, signals)
+	if signal.Message != checkpoint.DEC || signal.CheckpointId != 4 || signal.OpId != "source" {
+		t.Fatalf("unexpected signal: %#v", signal)
+	}
+	task.mu.Lock()
+	defer task.mu.Unlock()
+	if task.guardDepth != 0 {
+		t.Fatalf("checkpoint guard was not released: depth %d", task.guardDepth)
+	}
+	if len(task.broadcasts) != 1 {
+		t.Fatalf("barrier must propagate so downstream tasks can terminate the checkpoint: %#v", task.broadcasts)
+	}
+}
+
+func TestResponderSendsDECAfterBarrierOnInvalidContext(t *testing.T) {
+	baseCtx := topoContext.Background().WithMeta("rule", "source", &state.MemoryStore{})
+	task := &guardedTask{
+		name: "source",
+		ctx:  &nonCheckpointContext{StreamContext: baseCtx},
+	}
+	signals := make(chan *checkpoint.Signal, 1)
+	responder := checkpoint.NewResponderExecutor(signals, task)
+
+	if err := responder.TriggerCheckpoint(5); err == nil {
+		t.Fatal("invalid checkpoint context must be returned")
+	}
+	signal := receiveSignal(t, signals)
+	if signal.Message != checkpoint.DEC || signal.CheckpointId != 5 || signal.OpId != "source" {
+		t.Fatalf("unexpected signal: %#v", signal)
+	}
+	task.mu.Lock()
+	defer task.mu.Unlock()
+	if task.guardDepth != 0 {
+		t.Fatalf("checkpoint guard was not released: depth %d", task.guardDepth)
+	}
+	if len(task.broadcasts) != 1 {
+		t.Fatalf("barrier must propagate so downstream tasks can terminate the checkpoint: %#v", task.broadcasts)
+	}
+}
+
+func TestResponderSendsDECOnSaveFailure(t *testing.T) {
+	ctx := topoContext.Background().WithMeta("rule", "op", &failingFrozenStore{})
+	task := &guardedTask{name: "op", ctx: ctx}
+	signals := make(chan *checkpoint.Signal, 1)
+	responder := checkpoint.NewResponderExecutor(signals, task)
+
+	if err := responder.TriggerCheckpoint(3); err != nil {
+		t.Fatal(err)
+	}
+	signal := receiveSignal(t, signals)
+	if signal.Message != checkpoint.DEC || signal.CheckpointId != 3 || signal.OpId != "op" {
+		t.Fatalf("unexpected signal: %#v", signal)
+	}
+}
+
+func receiveSignal(t *testing.T, signals <-chan *checkpoint.Signal) *checkpoint.Signal {
+	t.Helper()
+	select {
+	case signal := <-signals:
+		return signal
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for checkpoint signal")
+		return nil
+	}
+}
+
+type guardedTask struct {
+	name string
+	ctx  api.StreamContext
+
+	mu         sync.Mutex
+	guardDepth int
+	broadcasts []any
+
+	checkpointErr error
+}
+
+type failingFrozenStore struct {
+	state.MemoryStore
+}
+
+type nonCheckpointContext struct {
+	api.StreamContext
+}
+
+func (s *failingFrozenStore) SaveFrozenState(_ int64, _ string, _ []byte) error {
+	return errors.New("injected frozen state failure")
+}
+
+func (t *guardedTask) GetName() string {
+	return t.name
+}
+
+func (t *guardedTask) GetStreamContext() api.StreamContext {
+	return t.ctx
+}
+
+func (t *guardedTask) SetQos(_ def.Qos) {}
+
+func (t *guardedTask) LockCheckpoint() {
+	t.mu.Lock()
+	t.guardDepth++
+	t.mu.Unlock()
+}
+
+func (t *guardedTask) UnlockCheckpoint() {
+	t.mu.Lock()
+	t.guardDepth--
+	t.mu.Unlock()
+}
+
+func (t *guardedTask) CheckpointError() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.checkpointErr
+}
+
+func (t *guardedTask) Broadcast(data any) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.guardDepth != 1 {
+		panic("broadcast outside checkpoint guard")
+	}
+	t.broadcasts = append(t.broadcasts, data)
+}

--- a/internal/topo/checkpoint/responder_test.go
+++ b/internal/topo/checkpoint/responder_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/lf-edge/ekuiper/contract/v2/api"
+	"github.com/stretchr/testify/require"
 
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
 	"github.com/lf-edge/ekuiper/v2/internal/topo/checkpoint"
@@ -71,6 +72,69 @@ func TestResponderSendsDECOnCaptureFailure(t *testing.T) {
 	defer task.mu.Unlock()
 	if task.guardDepth != 0 {
 		t.Fatalf("checkpoint guard was not released: depth %d", task.guardDepth)
+	}
+}
+
+func TestResponderSendsDECOnPrepareFailure(t *testing.T) {
+	ctx := topoContext.Background().WithMeta("rule", "op", &state.MemoryStore{})
+	task := &guardedTask{name: "op", ctx: ctx, prepareErr: errors.New("snapshot failed")}
+	signals := make(chan *checkpoint.Signal, 1)
+	responder := checkpoint.NewResponderExecutor(signals, task)
+
+	if err := responder.TriggerCheckpoint(6); err == nil {
+		t.Fatal("prepare failure must be returned")
+	}
+	signal := receiveSignal(t, signals)
+	if signal.Message != checkpoint.DEC || signal.CheckpointId != 6 || signal.OpId != "op" {
+		t.Fatalf("unexpected signal: %#v", signal)
+	}
+	task.mu.Lock()
+	defer task.mu.Unlock()
+	if task.guardDepth != 0 {
+		t.Fatalf("checkpoint guard was not released: depth %d", task.guardDepth)
+	}
+	if len(task.broadcasts) != 0 {
+		t.Fatalf("barrier must not propagate after prepare failure: %#v", task.broadcasts)
+	}
+}
+
+func TestResponderReleasesGuardBeforeBackpressuredDEC(t *testing.T) {
+	ctx := topoContext.Background().WithMeta("rule", "source", &state.MemoryStore{})
+	task := &guardedTask{name: "source", ctx: ctx, checkpointErr: errors.New("offset unavailable")}
+	signals := make(chan *checkpoint.Signal, 1)
+	signals <- &checkpoint.Signal{Message: checkpoint.ACK}
+	responder := checkpoint.NewResponderExecutor(signals, task)
+	done := make(chan error, 1)
+	go func() {
+		done <- responder.TriggerCheckpoint(7)
+	}()
+
+	require.Eventually(t, func() bool {
+		task.mu.Lock()
+		defer task.mu.Unlock()
+		return len(task.broadcasts) == 1
+	}, time.Second, time.Millisecond)
+	guardAcquired := make(chan struct{})
+	go func() {
+		task.checkpointMu.Lock()
+		close(guardAcquired)
+		task.checkpointMu.Unlock()
+	}()
+	select {
+	case <-guardAcquired:
+	case <-time.After(time.Second):
+		<-signals
+		<-done
+		t.Fatal("checkpoint guard remained held while DEC send was backpressured")
+	}
+
+	<-signals
+	if err := <-done; err == nil {
+		t.Fatal("checkpoint validation failure must be returned")
+	}
+	signal := receiveSignal(t, signals)
+	if signal.Message != checkpoint.DEC || signal.CheckpointId != 7 {
+		t.Fatalf("unexpected signal: %#v", signal)
 	}
 }
 
@@ -157,11 +221,13 @@ type guardedTask struct {
 	name string
 	ctx  api.StreamContext
 
-	mu         sync.Mutex
-	guardDepth int
-	broadcasts []any
+	checkpointMu sync.Mutex
+	mu           sync.Mutex
+	guardDepth   int
+	broadcasts   []any
 
 	checkpointErr error
+	prepareErr    error
 }
 
 type failingFrozenStore struct {
@@ -187,6 +253,7 @@ func (t *guardedTask) GetStreamContext() api.StreamContext {
 func (t *guardedTask) SetQos(_ def.Qos) {}
 
 func (t *guardedTask) LockCheckpoint() {
+	t.checkpointMu.Lock()
 	t.mu.Lock()
 	t.guardDepth++
 	t.mu.Unlock()
@@ -196,6 +263,11 @@ func (t *guardedTask) UnlockCheckpoint() {
 	t.mu.Lock()
 	t.guardDepth--
 	t.mu.Unlock()
+	t.checkpointMu.Unlock()
+}
+
+func (t *guardedTask) PrepareCheckpoint() error {
+	return t.prepareErr
 }
 
 func (t *guardedTask) CheckpointError() error {

--- a/internal/topo/checkpoint/state.go
+++ b/internal/topo/checkpoint/state.go
@@ -1,0 +1,51 @@
+// Copyright 2026 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checkpoint
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+)
+
+// FrozenStateStore accepts immutable, gob-encoded operator state. The bytes
+// must not be changed after the call returns.
+type FrozenStateStore interface {
+	SaveFrozenState(checkpointID int64, opID string, state []byte) error
+}
+
+// FrozenStateDiscarder removes an incomplete checkpoint and rejects late task
+// snapshots for that ID and every older checkpoint.
+type FrozenStateDiscarder interface {
+	DiscardFrozenState(checkpointID int64)
+}
+
+// EncodeState freezes a complete operator state graph.
+func EncodeState(state map[string]interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(state); err != nil {
+		return nil, fmt.Errorf("encode checkpoint state: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// DecodeState restores a complete operator state graph.
+func DecodeState(state []byte) (map[string]interface{}, error) {
+	var result map[string]interface{}
+	if err := gob.NewDecoder(bytes.NewReader(state)).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode checkpoint state: %w", err)
+	}
+	return result, nil
+}

--- a/internal/topo/checkpoint/state_benchmark_test.go
+++ b/internal/topo/checkpoint/state_benchmark_test.go
@@ -1,0 +1,157 @@
+// Copyright 2026 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checkpoint_test
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/lf-edge/ekuiper/v2/internal/topo/checkpoint"
+	"github.com/lf-edge/ekuiper/v2/internal/xsql"
+	"github.com/lf-edge/ekuiper/v2/pkg/ast"
+)
+
+func init() {
+	gob.Register([]*xsql.Tuple{})
+}
+
+func BenchmarkCheckpointState(b *testing.B) {
+	for _, tupleCount := range []int{0, 1, 10, 100, 1000, 10000} {
+		state := benchmarkState(tupleCount)
+		frozen, err := checkpoint.EncodeState(state)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.Run(fmt.Sprintf("Freeze/Tuples_%d", tupleCount), func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(int64(len(frozen)))
+			for b.Loop() {
+				if _, err := checkpoint.EncodeState(state); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+		b.Run(fmt.Sprintf("Envelope/Tuples_%d", tupleCount), func(b *testing.B) {
+			envelope := struct {
+				Format    string
+				Version   uint16
+				Operators map[string][]byte
+			}{
+				Format:    "ekuiper-checkpoint",
+				Version:   2,
+				Operators: map[string][]byte{"window": frozen},
+			}
+			b.ReportAllocs()
+			b.SetBytes(int64(len(frozen)))
+			for b.Loop() {
+				var buf bytes.Buffer
+				if err := gob.NewEncoder(&buf).Encode(envelope); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkSourceOffsetClone(b *testing.B) {
+	offsets := map[string]map[string]interface{}{
+		"Scalar": {"offset": int64(42)},
+		"Map": {
+			"offset": map[string]interface{}{
+				"partition-0": int64(42),
+				"partition-1": int64(84),
+			},
+		},
+	}
+	for name, state := range offsets {
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				frozen, err := checkpoint.EncodeState(state)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if _, err := checkpoint.DecodeState(frozen); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkAggregateAliasCache(b *testing.B) {
+	expressions := map[string]ast.Expr{
+		"DirectField": &ast.FieldRef{Name: "id", StreamName: ast.DefaultStream},
+		"Alias": &ast.FieldRef{
+			Name:       "derived",
+			StreamName: ast.AliasStream,
+			AliasRef: &ast.AliasRef{
+				Expression: &ast.FieldRef{Name: "id", StreamName: ast.DefaultStream},
+			},
+		},
+	}
+	for name, expression := range expressions {
+		b.Run(name, func(b *testing.B) {
+			for _, tupleCount := range []int{1, 10, 100, 1000, 10000} {
+				tuples := benchmarkTuples(tupleCount)
+				content := make([]xsql.Row, len(tuples))
+				for i, tuple := range tuples {
+					content[i] = tuple
+				}
+				window := &xsql.WindowTuples{Content: content}
+				b.Run(fmt.Sprintf("Tuples_%d", tupleCount), func(b *testing.B) {
+					b.ReportAllocs()
+					for b.Loop() {
+						_ = window.AggregateEval(expression, nil)
+					}
+				})
+			}
+		})
+	}
+}
+
+func benchmarkState(tupleCount int) map[string]interface{} {
+	return map[string]interface{}{
+		"watermark": time.UnixMilli(1000),
+		"buffer":    benchmarkTuples(tupleCount),
+	}
+}
+
+func benchmarkTuples(tupleCount int) []*xsql.Tuple {
+	tuples := make([]*xsql.Tuple, tupleCount)
+	for i := range tuples {
+		tuples[i] = &xsql.Tuple{
+			Emitter:   "demo",
+			Timestamp: time.UnixMilli(int64(i)),
+			Message: xsql.Message{
+				"id":    int64(i),
+				"value": float64(i) * 1.5,
+				"name":  "checkpoint-benchmark",
+				"ok":    true,
+				"tag":   "sensor",
+			},
+			Metadata: xsql.Metadata{"topic": "demo"},
+			Props:    map[string]string{"source": "benchmark"},
+			AffiliateRow: xsql.AffiliateRow{
+				CalCols:  map[string]interface{}{"calculated": i},
+				AliasMap: map[string]interface{}{"alias": i},
+			},
+		}
+	}
+	return tuples
+}

--- a/internal/topo/checkpoint/state_benchmark_test.go
+++ b/internal/topo/checkpoint/state_benchmark_test.go
@@ -26,10 +26,6 @@ import (
 	"github.com/lf-edge/ekuiper/v2/pkg/ast"
 )
 
-func init() {
-	gob.Register([]*xsql.Tuple{})
-}
-
 func BenchmarkCheckpointState(b *testing.B) {
 	for _, tupleCount := range []int{0, 1, 10, 100, 1000, 10000} {
 		state := benchmarkState(tupleCount)

--- a/internal/topo/context/default.go
+++ b/internal/topo/context/default.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 EMQ Technologies Co., Ltd.
+// Copyright 2022-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/lf-edge/ekuiper/v2/internal/conf"
+	"github.com/lf-edge/ekuiper/v2/internal/topo/checkpoint"
 	"github.com/lf-edge/ekuiper/v2/internal/topo/transform"
 	"github.com/lf-edge/ekuiper/v2/pkg/cast"
 	"github.com/lf-edge/ekuiper/v2/pkg/syncx"
@@ -64,13 +65,17 @@ type DefaultContext struct {
 	isTraceEnabled *atomic.Bool
 	strategy       *TraceStrategyWrapper
 	// Only initialized after withMeta set
-	store    api.Store
-	state    *sync.Map
-	snapshot map[string]interface{}
-	mu       syncx.Mutex
+	store       api.Store
+	state       *sync.Map
+	checkpoints *checkpointSnapshots
 	// cache
 	tpReg sync.Map
 	jpReg sync.Map
+}
+
+type checkpointSnapshots struct {
+	mu     syncx.Mutex
+	states map[int64][]byte
 }
 
 func RuleBackground(ruleName string) *DefaultContext {
@@ -234,13 +239,16 @@ func (c *DefaultContext) WithMeta(ruleId string, opId string, store api.Store) a
 		c.GetLogger().Warnf("Initialize context store error for %s: %s", opId, err)
 	}
 	return &DefaultContext{
-		ruleId:         ruleId,
-		opId:           opId,
-		runId:          c.runId,
-		instanceId:     c.instanceId,
-		ctx:            c.ctx,
-		store:          store,
-		state:          s,
+		ruleId:     ruleId,
+		opId:       opId,
+		runId:      c.runId,
+		instanceId: c.instanceId,
+		ctx:        c.ctx,
+		store:      store,
+		state:      s,
+		checkpoints: &checkpointSnapshots{
+			states: make(map[int64][]byte),
+		},
 		tpReg:          sync.Map{},
 		jpReg:          sync.Map{},
 		isTraceEnabled: c.isTraceEnabled,
@@ -255,7 +263,9 @@ func (c *DefaultContext) WithInstance(instanceId int) api.StreamContext {
 		ruleId:         c.ruleId,
 		opId:           c.opId,
 		ctx:            c.ctx,
+		store:          c.store,
 		state:          c.state,
+		checkpoints:    c.checkpoints,
 		isTraceEnabled: c.isTraceEnabled,
 		strategy:       c.strategy,
 	}
@@ -268,7 +278,9 @@ func (c *DefaultContext) WithRuleId(ruleId string) api.StreamContext {
 		ruleId:         ruleId,
 		opId:           c.opId,
 		ctx:            c.ctx,
+		store:          c.store,
 		state:          c.state,
+		checkpoints:    c.checkpoints,
 		isTraceEnabled: c.isTraceEnabled,
 		strategy:       c.strategy,
 	}
@@ -281,7 +293,9 @@ func (c *DefaultContext) WithOpId(opId string) api.StreamContext {
 		ruleId:         c.ruleId,
 		opId:           opId,
 		ctx:            c.ctx,
+		store:          c.store,
 		state:          c.state,
+		checkpoints:    c.checkpoints,
 		isTraceEnabled: c.isTraceEnabled,
 		strategy:       c.strategy,
 	}
@@ -294,7 +308,9 @@ func (c *DefaultContext) WithRun(runId int) api.StreamContext {
 		ruleId:         c.ruleId,
 		opId:           c.opId,
 		ctx:            c.ctx,
+		store:          c.store,
 		state:          c.state,
+		checkpoints:    c.checkpoints,
 		isTraceEnabled: c.isTraceEnabled,
 		strategy:       c.strategy,
 	}
@@ -308,7 +324,9 @@ func (c *DefaultContext) WithCancel() (api.StreamContext, context.CancelFunc) {
 		instanceId:     c.instanceId,
 		runId:          c.runId,
 		ctx:            ctx,
+		store:          c.store,
 		state:          c.state,
+		checkpoints:    c.checkpoints,
 		isTraceEnabled: c.isTraceEnabled,
 		strategy:       c.strategy,
 	}, cancel
@@ -373,27 +391,44 @@ func (c *DefaultContext) DeleteState(key string) error {
 	return nil
 }
 
-func (c *DefaultContext) Snapshot() error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.snapshot = cast.SyncMapToMap(c.state)
+func (c *DefaultContext) Snapshot(checkpointID int64) error {
+	snapshot, err := checkpoint.EncodeState(c.GetAllState())
+	if err != nil {
+		return err
+	}
+	if c.checkpoints == nil {
+		return fmt.Errorf("checkpoint context is not initialized")
+	}
+	c.checkpoints.mu.Lock()
+	defer c.checkpoints.mu.Unlock()
+	if _, ok := c.checkpoints.states[checkpointID]; ok {
+		return fmt.Errorf("snapshot for checkpoint %d already exists", checkpointID)
+	}
+	c.checkpoints.states[checkpointID] = snapshot
 	return nil
 }
 
-func (c *DefaultContext) SaveState(checkpointId int64) error {
-	if c.store != nil {
-		c.mu.Lock()
-		snap := c.snapshot
-		c.snapshot = nil
-		c.mu.Unlock()
-		if snap != nil {
-			err := c.store.SaveState(checkpointId, c.opId, snap)
-			if err != nil {
-				return err
-			}
-		}
+func (c *DefaultContext) SaveSnapshot(checkpointID int64) error {
+	if c.store == nil {
+		return nil
 	}
-	return nil
+	if c.checkpoints == nil {
+		return fmt.Errorf("checkpoint context is not initialized")
+	}
+	c.checkpoints.mu.Lock()
+	snapshot, ok := c.checkpoints.states[checkpointID]
+	if ok {
+		delete(c.checkpoints.states, checkpointID)
+	}
+	c.checkpoints.mu.Unlock()
+	if !ok {
+		return fmt.Errorf("snapshot for checkpoint %d does not exist", checkpointID)
+	}
+	store, ok := c.store.(checkpoint.FrozenStateStore)
+	if !ok {
+		return fmt.Errorf("checkpoint store %T does not support frozen state", c.store)
+	}
+	return store.SaveFrozenState(checkpointID, c.opId, snapshot)
 }
 
 func (c *DefaultContext) EnableTracer(enabled bool) {

--- a/internal/topo/context/default.go
+++ b/internal/topo/context/default.go
@@ -425,10 +425,14 @@ func (c *DefaultContext) SaveSnapshot(checkpointID int64) error {
 		return fmt.Errorf("snapshot for checkpoint %d does not exist", checkpointID)
 	}
 	store, ok := c.store.(checkpoint.FrozenStateStore)
-	if !ok {
-		return fmt.Errorf("checkpoint store %T does not support frozen state", c.store)
+	if ok {
+		return store.SaveFrozenState(checkpointID, c.opId, snapshot)
 	}
-	return store.SaveFrozenState(checkpointID, c.opId, snapshot)
+	state, err := checkpoint.DecodeState(snapshot)
+	if err != nil {
+		return err
+	}
+	return c.store.SaveState(checkpointID, c.opId, state)
 }
 
 func (c *DefaultContext) EnableTracer(enabled bool) {

--- a/internal/topo/context/default_test.go
+++ b/internal/topo/context/default_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 EMQ Technologies Co., Ltd.
+// Copyright 2022-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,12 +16,14 @@ package context
 
 import (
 	"context"
+	"encoding/gob"
 	"fmt"
 	"log"
 	"os"
 	"path"
 	"reflect"
 	"runtime/pprof"
+	"sync"
 	"testing"
 	"time"
 
@@ -30,6 +32,7 @@ import (
 	"github.com/lf-edge/ekuiper/v2/internal/conf"
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/store"
+	"github.com/lf-edge/ekuiper/v2/internal/topo/checkpoint"
 	"github.com/lf-edge/ekuiper/v2/internal/topo/state"
 )
 
@@ -132,15 +135,134 @@ func TestState(t *testing.T) {
 		t.Errorf("%d.Delete state key2 error: %s", i, err)
 		return
 	}
-	err = ctx.Snapshot()
+	err = ctx.Snapshot(1)
 	if err != nil {
 		t.Errorf("%d.Snapshot error: %s", i, err)
 		return
 	}
-	rs := ctx.snapshot
+	rs, err := checkpoint.DecodeState(ctx.checkpoints.states[1])
+	if err != nil {
+		t.Errorf("%d.Decode snapshot error: %s", i, err)
+		return
+	}
 	if !reflect.DeepEqual(s, rs) {
 		t.Errorf("%d.Snapshot\n\nresult mismatch:\n\nexp=%#v\n\ngot=%#v\n\n", i, s, rs)
 	}
+}
+
+func TestSnapshotIsolationAndCheckpointIDs(t *testing.T) {
+	gob.Register([]int{})
+	cStore := &frozenCaptureStore{}
+	ctx := Background().WithMeta("snapshotRule", "op1", cStore).(*DefaultContext)
+	live := map[string]interface{}{
+		"nested": map[string]interface{}{"value": 1},
+		"slice":  []int{1, 2, 3},
+	}
+	if err := ctx.PutState("mutable", live); err != nil {
+		t.Fatal(err)
+	}
+	if err := ctx.Snapshot(1); err != nil {
+		t.Fatal(err)
+	}
+	if err := ctx.Snapshot(1); err == nil {
+		t.Fatal("duplicate checkpoint ID must fail")
+	}
+
+	live["nested"].(map[string]interface{})["value"] = 2
+	live["slice"].([]int)[0] = 9
+	first, err := checkpoint.DecodeState(ctx.checkpoints.states[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantFirst := map[string]interface{}{
+		"mutable": map[string]interface{}{
+			"nested": map[string]interface{}{"value": 1},
+			"slice":  []int{1, 2, 3},
+		},
+	}
+	if !reflect.DeepEqual(wantFirst, first) {
+		t.Fatalf("first snapshot mismatch: want %#v, got %#v", wantFirst, first)
+	}
+
+	if err := ctx.Snapshot(2); err != nil {
+		t.Fatal(err)
+	}
+	if err := ctx.SaveSnapshot(1); err != nil {
+		t.Fatal(err)
+	}
+	if err := ctx.SaveSnapshot(1); err == nil {
+		t.Fatal("saving an unknown checkpoint ID must fail")
+	}
+	stored, ok := cStore.states.Load(int64(1))
+	if !ok {
+		t.Fatal("frozen state was not saved")
+	}
+	saved, err := checkpoint.DecodeState(stored.([]byte))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(wantFirst, saved) {
+		t.Fatalf("saved snapshot mismatch: want %#v, got %#v", wantFirst, saved)
+	}
+
+	second, err := checkpoint.DecodeState(ctx.checkpoints.states[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reflect.DeepEqual(first, second) {
+		t.Fatal("successive checkpoints must capture distinct state")
+	}
+}
+
+func TestDerivedContextSharesCheckpointLifecycle(t *testing.T) {
+	cStore := &frozenCaptureStore{}
+	base := Background().WithMeta("rule", "op", cStore).(*DefaultContext)
+	derived := base.WithRun(1).WithInstance(2).(*DefaultContext)
+	if err := derived.PutState("count", 42); err != nil {
+		t.Fatal(err)
+	}
+	if err := derived.Snapshot(10); err != nil {
+		t.Fatal(err)
+	}
+	if err := base.SaveSnapshot(10); err != nil {
+		t.Fatal(err)
+	}
+	raw, ok := cStore.states.Load(int64(10))
+	if !ok {
+		t.Fatal("derived context snapshot was not persisted by base context")
+	}
+	saved, err := checkpoint.DecodeState(raw.([]byte))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if saved["count"] != 42 {
+		t.Fatalf("unexpected derived context state: %#v", saved)
+	}
+}
+
+type frozenCaptureStore struct {
+	states sync.Map
+}
+
+func (s *frozenCaptureStore) SaveState(_ int64, _ string, _ map[string]interface{}) error {
+	return nil
+}
+
+func (s *frozenCaptureStore) SaveFrozenState(checkpointID int64, _ string, state []byte) error {
+	s.states.Store(checkpointID, append([]byte(nil), state...))
+	return nil
+}
+
+func (s *frozenCaptureStore) SaveCheckpoint(_ int64) error {
+	return nil
+}
+
+func (s *frozenCaptureStore) GetOpState(_ string) (*sync.Map, error) {
+	return &sync.Map{}, nil
+}
+
+func (s *frozenCaptureStore) Clean() error {
+	return nil
 }
 
 func cleanStateData() {

--- a/internal/topo/context/default_test.go
+++ b/internal/topo/context/default_test.go
@@ -240,8 +240,80 @@ func TestDerivedContextSharesCheckpointLifecycle(t *testing.T) {
 	}
 }
 
+func TestSaveSnapshotFallsBackToStoreSaveState(t *testing.T) {
+	cStore := &legacyCaptureStore{}
+	ctx := Background().WithMeta("rule", "op", cStore).(*DefaultContext)
+	live := map[string]interface{}{"nested": map[string]interface{}{"value": 1}}
+	if err := ctx.PutState("mutable", live); err != nil {
+		t.Fatal(err)
+	}
+	if err := ctx.Snapshot(20); err != nil {
+		t.Fatal(err)
+	}
+	live["nested"].(map[string]interface{})["value"] = 99
+	if err := ctx.SaveSnapshot(20); err != nil {
+		t.Fatal(err)
+	}
+	if err := cStore.SaveCheckpoint(20); err != nil {
+		t.Fatal(err)
+	}
+	restored, err := cStore.GetOpState("op")
+	if err != nil {
+		t.Fatal(err)
+	}
+	mutable, ok := restored.Load("mutable")
+	if !ok {
+		t.Fatal("snapshot was not restored through the api.Store lifecycle")
+	}
+	want := map[string]interface{}{"nested": map[string]interface{}{"value": 1}}
+	if !reflect.DeepEqual(want, mutable) {
+		t.Fatalf("fallback snapshot mismatch: want %#v, got %#v", want, mutable)
+	}
+}
+
 type frozenCaptureStore struct {
 	states sync.Map
+}
+
+type legacyCaptureStore struct {
+	mu        sync.Mutex
+	pending   map[int64]map[string]map[string]interface{}
+	committed map[string]map[string]interface{}
+}
+
+func (s *legacyCaptureStore) SaveState(checkpointID int64, opID string, state map[string]interface{}) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.pending == nil {
+		s.pending = make(map[int64]map[string]map[string]interface{})
+	}
+	if s.pending[checkpointID] == nil {
+		s.pending[checkpointID] = make(map[string]map[string]interface{})
+	}
+	s.pending[checkpointID][opID] = state
+	return nil
+}
+
+func (s *legacyCaptureStore) SaveCheckpoint(checkpointID int64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.committed = s.pending[checkpointID]
+	delete(s.pending, checkpointID)
+	return nil
+}
+
+func (s *legacyCaptureStore) GetOpState(opID string) (*sync.Map, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	result := &sync.Map{}
+	for key, value := range s.committed[opID] {
+		result.Store(key, value)
+	}
+	return result, nil
+}
+
+func (s *legacyCaptureStore) Clean() error {
+	return nil
 }
 
 func (s *frozenCaptureStore) SaveState(_ int64, _ string, _ map[string]interface{}) error {

--- a/internal/topo/node/decode_op.go
+++ b/internal/topo/node/decode_op.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2025 EMQ Technologies Co., Ltd.
+// Copyright 2021-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -391,12 +391,12 @@ func mergeTuple(ctx api.StreamContext, d *xsql.Tuple, result any) {
 
 func toTupleFromRawTuple(ctx api.StreamContext, v map[string]any, d *xsql.RawTuple) *xsql.Tuple {
 	t := &xsql.Tuple{
-		Ctx:       d.Ctx,
 		Message:   v,
 		Metadata:  d.Metadata,
 		Timestamp: d.Timestamp,
 		Emitter:   d.Emitter,
 	}
+	t.SetTracerCtx(d.GetTracerCtx())
 	return t
 }
 

--- a/internal/topo/node/decode_op.go
+++ b/internal/topo/node/decode_op.go
@@ -408,12 +408,17 @@ func cloneTuple(d *xsql.Tuple, hint int) *xsql.Tuple {
 	for k, v := range d.Message {
 		m[k] = v
 	}
-	return &xsql.Tuple{
+	result := &xsql.Tuple{
 		Message:   m,
 		Metadata:  d.Metadata,
 		Timestamp: d.Timestamp,
 		Emitter:   d.Emitter,
+		Props:     d.Props,
+
+		AffiliateRow: d.AffiliateRow.Clone(),
 	}
+	result.SetTracerCtx(d.GetTracerCtx())
+	return result
 }
 
 func tupleAppend(d *xsql.Tuple, mv map[string]any) {

--- a/internal/topo/node/decode_op_test.go
+++ b/internal/topo/node/decode_op_test.go
@@ -31,6 +31,37 @@ import (
 	"github.com/lf-edge/ekuiper/v2/pkg/timex"
 )
 
+func TestCloneTuplePreservesRowSemantics(t *testing.T) {
+	ctx := mockContext.NewMockContext("rule", "decode")
+	source := &xsql.Tuple{
+		Emitter:   "source",
+		Message:   xsql.Message{"value": 1},
+		Metadata:  xsql.Metadata{"topic": "demo"},
+		Timestamp: time.UnixMilli(100),
+		Props:     map[string]string{"format": "json"},
+		AffiliateRow: xsql.AffiliateRow{
+			CalCols:  map[string]interface{}{"calculated": 2},
+			AliasMap: map[string]interface{}{"alias": 3},
+		},
+	}
+	source.SetTracerCtx(ctx)
+
+	cloned := cloneTuple(source, 0)
+	require.Equal(t, source.Emitter, cloned.Emitter)
+	require.Equal(t, source.Message, cloned.Message)
+	require.Equal(t, source.Metadata, cloned.Metadata)
+	require.Equal(t, source.Timestamp, cloned.Timestamp)
+	require.Equal(t, source.Props, cloned.Props)
+	require.Equal(t, source.CalCols, cloned.CalCols)
+	require.Equal(t, source.AliasMap, cloned.AliasMap)
+	require.Same(t, ctx, cloned.GetTracerCtx())
+
+	cloned.Message["value"] = 99
+	cloned.CalCols["calculated"] = 99
+	require.Equal(t, 1, source.Message["value"])
+	require.Equal(t, 2, source.CalCols["calculated"])
+}
+
 func TestJSON(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/internal/topo/node/dedup_trigger_op.go
+++ b/internal/topo/node/dedup_trigger_op.go
@@ -1,4 +1,4 @@
-// Copyright 2024 EMQ Technologies Co., Ltd.
+// Copyright 2024-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package node
 
 import (
+	"encoding/gob"
 	"fmt"
 	"strconv"
 	"time"
@@ -28,6 +29,10 @@ import (
 	"github.com/lf-edge/ekuiper/v2/pkg/infra"
 	"github.com/lf-edge/ekuiper/v2/pkg/timex"
 )
+
+func init() {
+	gob.Register([][]int64{})
+}
 
 type DedupTriggerNode struct {
 	*defaultSinkNode

--- a/internal/topo/node/node_test.go
+++ b/internal/topo/node/node_test.go
@@ -75,7 +75,6 @@ func TestMultipleOutputsBroadcast(t *testing.T) {
 		{
 			name: "row broadcast",
 			data: &xsql.Tuple{
-				Ctx:       nil,
 				Emitter:   "test",
 				Message:   map[string]any{"a": 20},
 				Timestamp: time.UnixMilli(123456789),
@@ -86,7 +85,6 @@ func TestMultipleOutputsBroadcast(t *testing.T) {
 			data: &xsql.WindowTuples{
 				Content: []xsql.Row{
 					&xsql.Tuple{
-						Ctx:       nil,
 						Emitter:   "test",
 						Message:   map[string]any{"a": 30},
 						Timestamp: time.UnixMilli(123456789),

--- a/internal/topo/node/node_test/window_inc_agg_event_op_test.go
+++ b/internal/topo/node/node_test/window_inc_agg_event_op_test.go
@@ -550,6 +550,69 @@ func TestTestIncEventSlidingWindowState(t *testing.T) {
 	op2.Close()
 }
 
+func TestIncEventSlidingWindowRestoreFromDecodedState(t *testing.T) {
+	conf.IsTesting = true
+	incPlan := buildIncAggPlan(t, "select count(*) from stream group by slidingWindow(ss,10,1)")
+	options := &def.RuleOption{
+		BufferLength: 16,
+		IsEventTime:  true,
+	}
+	config := &node.WindowConfig{
+		Type:   incPlan.WType,
+		Length: time.Second,
+		Delay:  time.Second,
+	}
+	base := time.Unix(4_000, 0)
+
+	ctx, cancel := newIncAggTestContext("event_sliding_decode", "op")
+	op, input, _, _ := startIncAggTestOperator(t, incPlan, config, options, ctx)
+	input <- &xsql.Tuple{
+		Message:   map[string]any{"a": int64(1)},
+		Timestamp: base,
+	}
+	waitForIncAggProcessed(t, op, 1)
+	waitForIncAggState(t, op, ctx, func(value any) bool {
+		state, ok := value.(node.SlidingWindowIncAggEventOpState)
+		return ok && len(state.CurrWindowList) == 1 && len(state.EmitList) == 1
+	})
+	frozen := freezeIncAggState(t, ctx)
+	stopIncAggOperator(t, ctx, cancel)
+
+	restoredCtx, restoredCancel := decodedIncAggContext(t, frozen, "event_sliding_decode", "op")
+	restoredOp, err := node.NewWindowIncAggOp(
+		"checkpoint_test",
+		config,
+		incPlan.Dimensions,
+		incPlan.IncAggFuncs,
+		options,
+	)
+	require.NoError(t, err)
+	sliding, ok := restoredOp.WindowExec.(*node.SlidingWindowIncAggEventOp)
+	require.True(t, ok)
+	require.NoError(t, sliding.RestoreFromState(restoredCtx))
+
+	restoredInput, _ := restoredOp.GetInput()
+	restoredOutput := make(chan any, 4)
+	require.NoError(t, restoredOp.AddOutput(restoredOutput, "output"))
+	restoredErrCh := make(chan error, 2)
+	restoredOp.Exec(restoredCtx, restoredErrCh)
+	restoredInput <- &xsql.Tuple{
+		Message:   map[string]any{"a": int64(2)},
+		Timestamp: base.Add(500 * time.Millisecond),
+	}
+	waitForIncAggProcessed(t, restoredOp, 1)
+	waitForIncAggState(t, restoredOp, restoredCtx, func(value any) bool {
+		state, ok := value.(node.SlidingWindowIncAggEventOpState)
+		return ok && len(state.CurrWindowList) == 2 && len(state.EmitList) == 2
+	})
+	restoredInput <- &xsql.WatermarkTuple{Timestamp: base.Add(2 * time.Second)}
+	first := receiveIncAggWindow(t, restoredOutput, restoredErrCh)
+	require.Equal(t, int64(2), first.ToMaps()[0]["inc_agg_col_1"])
+	second := receiveIncAggWindow(t, restoredOutput, restoredErrCh)
+	require.Equal(t, int64(2), second.ToMaps()[0]["inc_agg_col_1"])
+	stopIncAggOperator(t, restoredCtx, restoredCancel)
+}
+
 func TestIncEventCountWindowState(t *testing.T) {
 	conf.IsTesting = true
 	o := &def.RuleOption{

--- a/internal/topo/node/node_test/window_inc_agg_op_test.go
+++ b/internal/topo/node/node_test/window_inc_agg_op_test.go
@@ -15,19 +15,26 @@
 package node_test
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/lf-edge/ekuiper/contract/v2/api"
 	"github.com/stretchr/testify/require"
 
 	"github.com/lf-edge/ekuiper/v2/internal/conf"
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/store"
 	"github.com/lf-edge/ekuiper/v2/internal/testx"
+	"github.com/lf-edge/ekuiper/v2/internal/topo/checkpoint"
+	topoContext "github.com/lf-edge/ekuiper/v2/internal/topo/context"
 	"github.com/lf-edge/ekuiper/v2/internal/topo/node"
 	"github.com/lf-edge/ekuiper/v2/internal/topo/planner"
+	"github.com/lf-edge/ekuiper/v2/internal/topo/topotest/mockclock"
 	"github.com/lf-edge/ekuiper/v2/internal/xsql"
 	"github.com/lf-edge/ekuiper/v2/pkg/ast"
 	mockContext "github.com/lf-edge/ekuiper/v2/pkg/mock/context"
@@ -75,6 +82,7 @@ func TestWindowState(t *testing.T) {
 		require.NotNil(t, incPlan)
 		op, err := node.NewWindowIncAggOp("1", &node.WindowConfig{
 			Type:     incPlan.WType,
+			Length:   time.Second,
 			Interval: time.Second,
 		}, incPlan.Dimensions, incPlan.IncAggFuncs, o)
 		require.NoError(t, err)
@@ -92,6 +100,7 @@ func TestWindowState(t *testing.T) {
 
 		op2, err := node.NewWindowIncAggOp("1", &node.WindowConfig{
 			Type:     incPlan.WType,
+			Length:   time.Second,
 			Interval: time.Second,
 		}, incPlan.Dimensions, incPlan.IncAggFuncs, o)
 		require.NoError(t, err)
@@ -381,6 +390,279 @@ func TestIncAggSlidingWindow(t *testing.T) {
 	op.Close()
 }
 
+func TestIncAggSlidingWindowRestoreFromDecodedState(t *testing.T) {
+	conf.IsTesting = true
+	incPlan := buildIncAggPlan(t, "select count(*) from stream group by slidingWindow(ss,100)")
+	options := &def.RuleOption{BufferLength: 10}
+	config := &node.WindowConfig{
+		Type:   incPlan.WType,
+		Length: time.Minute,
+	}
+
+	ctx, cancel := newIncAggTestContext("decode_rule", "sliding")
+	op, input, output, errCh := startIncAggTestOperator(t, incPlan, config, options, ctx)
+	input <- &xsql.Tuple{Message: map[string]any{"a": int64(1)}}
+	first := receiveIncAggWindow(t, output, errCh)
+	require.Equal(t, int64(1), first.ToMaps()[0]["inc_agg_col_1"])
+	require.NoError(t, op.PutState4Test(ctx))
+
+	frozen := freezeIncAggState(t, ctx)
+	stopIncAggOperator(t, ctx, cancel)
+	restoredCtx, restoredCancel := decodedIncAggContext(t, frozen, "decode_rule", "sliding")
+
+	restoredOp, err := node.NewWindowIncAggOp("checkpoint_test", config, incPlan.Dimensions, incPlan.IncAggFuncs, options)
+	require.NoError(t, err)
+	sliding, ok := restoredOp.WindowExec.(*node.SlidingWindowIncAggOp)
+	require.True(t, ok)
+	require.NoError(t, sliding.RestoreFromState(restoredCtx))
+
+	restoredInput, _ := restoredOp.GetInput()
+	restoredOutput := make(chan any, 2)
+	require.NoError(t, restoredOp.AddOutput(restoredOutput, "output"))
+	restoredErrCh := make(chan error, 2)
+	restoredOp.Exec(restoredCtx, restoredErrCh)
+	restoredInput <- &xsql.Tuple{Message: map[string]any{"a": int64(2)}}
+	second := receiveIncAggWindow(t, restoredOutput, restoredErrCh)
+	require.Equal(t, int64(2), second.ToMaps()[0]["inc_agg_col_1"])
+	stopIncAggOperator(t, restoredCtx, restoredCancel)
+}
+
+func TestProcessingIncAggSlidingDelayCheckpointDeadlines(t *testing.T) {
+	base := time.Unix(1_000, 0)
+	previousClock := timex.Clock
+	previousAlign := node.EnableAlignWindow
+	mockclock.ResetClock(base.UnixMilli())
+	node.EnableAlignWindow = false
+	defer func() {
+		timex.Clock = previousClock
+		node.EnableAlignWindow = previousAlign
+	}()
+
+	incPlan := buildIncAggPlan(t, "select count(*) from stream group by slidingWindow(ss,10,5)")
+	options := &def.RuleOption{BufferLength: 16}
+	config := &node.WindowConfig{
+		Type:   incPlan.WType,
+		Length: 10 * time.Second,
+		Delay:  5 * time.Second,
+	}
+	ctx1, cancel1 := newIncAggTestContext("sliding_timer", "op")
+	op1, input1, output1, errCh1 := startIncAggTestOperator(t, incPlan, config, options, ctx1)
+	input1 <- &xsql.Tuple{Message: map[string]any{"a": int64(1)}}
+	waitForIncAggProcessed(t, op1, 1)
+	waitForIncAggState(t, op1, ctx1, func(value any) bool {
+		state, ok := value.(node.SlidingWindowIncAggOpState)
+		return ok && len(state.Pending) == 1 && len(state.CurrWindowList) == 1
+	})
+	requireNoIncAggOutput(t, output1, errCh1)
+	timex.Add(2 * time.Second)
+	frozen := freezeIncAggState(t, ctx1)
+	stopIncAggOperator(t, ctx1, cancel1)
+
+	t.Run("future deadline", func(t *testing.T) {
+		mockclock.ResetClock(base.Add(4 * time.Second).UnixMilli())
+		ctx, cancel := decodedIncAggContext(t, frozen, "sliding_timer", "op")
+		op, _, output, errCh := startIncAggTestOperator(t, incPlan, config, options, ctx)
+		timex.Add(999 * time.Millisecond)
+		requireNoIncAggOutput(t, output, errCh)
+		timex.Add(time.Millisecond)
+		window := receiveIncAggWindow(t, output, errCh)
+		require.Equal(t, int64(1), window.ToMaps()[0]["inc_agg_col_1"])
+		waitForIncAggState(t, op, ctx, func(value any) bool {
+			state, ok := value.(node.SlidingWindowIncAggOpState)
+			return ok && len(state.Pending) == 0
+		})
+		timex.Add(10 * time.Second)
+		requireNoIncAggOutput(t, output, errCh)
+		stopIncAggOperator(t, ctx, cancel)
+	})
+
+	t.Run("overdue deadline", func(t *testing.T) {
+		mockclock.ResetClock(base.Add(6 * time.Second).UnixMilli())
+		ctx, cancel := decodedIncAggContext(t, frozen, "sliding_timer", "op")
+		op, _, output, errCh := startIncAggTestOperator(t, incPlan, config, options, ctx)
+		window := receiveIncAggWindow(t, output, errCh)
+		require.Equal(t, int64(1), window.ToMaps()[0]["inc_agg_col_1"])
+		waitForIncAggState(t, op, ctx, func(value any) bool {
+			state, ok := value.(node.SlidingWindowIncAggOpState)
+			return ok && len(state.Pending) == 0
+		})
+		timex.Add(10 * time.Second)
+		requireNoIncAggOutput(t, output, errCh)
+		stopIncAggOperator(t, ctx, cancel)
+	})
+
+	t.Run("multiple overdue deadlines", func(t *testing.T) {
+		multiBase := base.Add(100 * time.Second)
+		mockclock.ResetClock(multiBase.UnixMilli())
+		ctx1, cancel1 := newIncAggTestContext("sliding_multi_timer", "op")
+		op1, input1, output1, errCh1 := startIncAggTestOperator(t, incPlan, config, options, ctx1)
+		input1 <- &xsql.Tuple{Message: map[string]any{"a": int64(1)}}
+		waitForIncAggProcessed(t, op1, 1)
+		timex.Add(time.Second)
+		input1 <- &xsql.Tuple{Message: map[string]any{"a": int64(2)}}
+		waitForIncAggProcessed(t, op1, 2)
+		waitForIncAggState(t, op1, ctx1, func(value any) bool {
+			state, ok := value.(node.SlidingWindowIncAggOpState)
+			return ok && len(state.Pending) == 2
+		})
+		requireNoIncAggOutput(t, output1, errCh1)
+		multiFrozen := freezeIncAggState(t, ctx1)
+		stopIncAggOperator(t, ctx1, cancel1)
+
+		mockclock.ResetClock(multiBase.Add(20 * time.Second).UnixMilli())
+		ctx, cancel := decodedIncAggContext(t, multiFrozen, "sliding_multi_timer", "op")
+		op, input, output, errCh := startIncAggTestOperator(t, incPlan, config, options, ctx)
+		input <- &xsql.Tuple{Message: map[string]any{"a": int64(3)}}
+		first := receiveIncAggWindow(t, output, errCh)
+		require.Equal(t, int64(2), first.ToMaps()[0]["inc_agg_col_1"])
+		firstEnd, ok := first.FuncValue("window_end")
+		require.True(t, ok)
+		require.Equal(t, multiBase.Add(5*time.Second).UnixMilli(), firstEnd)
+		second := receiveIncAggWindow(t, output, errCh)
+		require.Equal(t, int64(2), second.ToMaps()[0]["inc_agg_col_1"])
+		secondEnd, ok := second.FuncValue("window_end")
+		require.True(t, ok)
+		require.Equal(t, multiBase.Add(6*time.Second).UnixMilli(), secondEnd)
+		waitForIncAggProcessed(t, op, 1)
+		waitForIncAggState(t, op, ctx, func(value any) bool {
+			state, ok := value.(node.SlidingWindowIncAggOpState)
+			return ok && len(state.Pending) == 1 &&
+				state.Pending[0].FireAt.Equal(multiBase.Add(25*time.Second)) &&
+				len(state.CurrWindowList) == 1
+		})
+		requireNoIncAggOutput(t, output, errCh)
+		stopIncAggOperator(t, ctx, cancel)
+	})
+}
+
+func TestProcessingIncAggTumblingCheckpointDeadlines(t *testing.T) {
+	base := time.Unix(2_000, 0)
+	previousClock := timex.Clock
+	previousAlign := node.EnableAlignWindow
+	mockclock.ResetClock(base.UnixMilli())
+	node.EnableAlignWindow = false
+	defer func() {
+		timex.Clock = previousClock
+		node.EnableAlignWindow = previousAlign
+	}()
+
+	incPlan := buildIncAggPlan(t, "select count(*) from stream group by tumblingWindow(ss,5)")
+	options := &def.RuleOption{BufferLength: 16}
+	config := &node.WindowConfig{
+		Type:        incPlan.WType,
+		Interval:    5 * time.Second,
+		RawInterval: 5,
+		TimeUnit:    ast.SS,
+	}
+	ctx1, cancel1 := newIncAggTestContext("tumbling_timer", "op")
+	op1, input1, _, _ := startIncAggTestOperator(t, incPlan, config, options, ctx1)
+	input1 <- &xsql.Tuple{Message: map[string]any{"a": int64(1)}}
+	waitForIncAggProcessed(t, op1, 1)
+	waitForIncAggState(t, op1, ctx1, func(value any) bool {
+		state, ok := value.(node.TumblingWindowIncAggOpState)
+		return ok && state.CurrWindow != nil && state.NextTriggerTime.Equal(base.Add(5*time.Second))
+	})
+	timex.Add(2 * time.Second)
+	frozen := freezeIncAggState(t, ctx1)
+	stopIncAggOperator(t, ctx1, cancel1)
+
+	t.Run("future deadline", func(t *testing.T) {
+		mockclock.ResetClock(base.Add(4 * time.Second).UnixMilli())
+		ctx, cancel := decodedIncAggContext(t, frozen, "tumbling_timer", "op")
+		_, _, output, errCh := startIncAggTestOperator(t, incPlan, config, options, ctx)
+		timex.Add(999 * time.Millisecond)
+		requireNoIncAggOutput(t, output, errCh)
+		timex.Add(time.Millisecond)
+		window := receiveIncAggWindow(t, output, errCh)
+		require.Equal(t, int64(1), window.ToMaps()[0]["inc_agg_col_1"])
+		timex.Add(4999 * time.Millisecond)
+		requireNoIncAggOutput(t, output, errCh)
+		stopIncAggOperator(t, ctx, cancel)
+	})
+
+	t.Run("overdue deadline", func(t *testing.T) {
+		mockclock.ResetClock(base.Add(6 * time.Second).UnixMilli())
+		ctx, cancel := decodedIncAggContext(t, frozen, "tumbling_timer", "op")
+		op, _, output, errCh := startIncAggTestOperator(t, incPlan, config, options, ctx)
+		window := receiveIncAggWindow(t, output, errCh)
+		require.Equal(t, int64(1), window.ToMaps()[0]["inc_agg_col_1"])
+		waitForIncAggState(t, op, ctx, func(value any) bool {
+			state, ok := value.(node.TumblingWindowIncAggOpState)
+			return ok && state.CurrWindow == nil && state.NextTriggerTime.Equal(base.Add(10*time.Second))
+		})
+		timex.Add(3999 * time.Millisecond)
+		requireNoIncAggOutput(t, output, errCh)
+		stopIncAggOperator(t, ctx, cancel)
+	})
+}
+
+func TestProcessingIncAggHoppingCheckpointDeadlines(t *testing.T) {
+	base := time.Unix(3_000, 0)
+	previousClock := timex.Clock
+	previousAlign := node.EnableAlignWindow
+	mockclock.ResetClock(base.UnixMilli())
+	node.EnableAlignWindow = false
+	defer func() {
+		timex.Clock = previousClock
+		node.EnableAlignWindow = previousAlign
+	}()
+
+	incPlan := buildIncAggPlan(t, "select count(*) from stream group by hoppingWindow(ss,5,2)")
+	options := &def.RuleOption{BufferLength: 16}
+	config := &node.WindowConfig{
+		Type:        incPlan.WType,
+		Length:      5 * time.Second,
+		Interval:    2 * time.Second,
+		RawInterval: 2,
+		TimeUnit:    ast.SS,
+	}
+	ctx1, cancel1 := newIncAggTestContext("hopping_timer", "op")
+	op1, input1, _, _ := startIncAggTestOperator(t, incPlan, config, options, ctx1)
+	input1 <- &xsql.Tuple{Message: map[string]any{"a": int64(1)}}
+	waitForIncAggProcessed(t, op1, 1)
+	waitForIncAggState(t, op1, ctx1, func(value any) bool {
+		state, ok := value.(node.HoppingWindowIncAggOpState)
+		return ok && len(state.CurrWindowList) == 1 &&
+			len(state.CurrWindowList[0].DimensionsIncAggRange) == 1 &&
+			state.NextWindowTime.Equal(base.Add(2*time.Second))
+	})
+	timex.Add(time.Second)
+	frozen := freezeIncAggState(t, ctx1)
+	stopIncAggOperator(t, ctx1, cancel1)
+
+	t.Run("future deadline", func(t *testing.T) {
+		mockclock.ResetClock(base.Add(4 * time.Second).UnixMilli())
+		ctx, cancel := decodedIncAggContext(t, frozen, "hopping_timer", "op")
+		op, _, output, errCh := startIncAggTestOperator(t, incPlan, config, options, ctx)
+		waitForIncAggState(t, op, ctx, func(value any) bool {
+			state, ok := value.(node.HoppingWindowIncAggOpState)
+			return ok && state.NextWindowTime.Equal(base.Add(6*time.Second))
+		})
+		timex.Add(999 * time.Millisecond)
+		requireNoIncAggOutput(t, output, errCh)
+		timex.Add(time.Millisecond)
+		window := receiveIncAggWindow(t, output, errCh)
+		require.Equal(t, int64(1), window.ToMaps()[0]["inc_agg_col_1"])
+		requireNoIncAggOutput(t, output, errCh)
+		stopIncAggOperator(t, ctx, cancel)
+	})
+
+	t.Run("overdue deadline", func(t *testing.T) {
+		mockclock.ResetClock(base.Add(6 * time.Second).UnixMilli())
+		ctx, cancel := decodedIncAggContext(t, frozen, "hopping_timer", "op")
+		op, _, output, errCh := startIncAggTestOperator(t, incPlan, config, options, ctx)
+		window := receiveIncAggWindow(t, output, errCh)
+		require.Equal(t, int64(1), window.ToMaps()[0]["inc_agg_col_1"])
+		waitForIncAggState(t, op, ctx, func(value any) bool {
+			state, ok := value.(node.HoppingWindowIncAggOpState)
+			return ok && state.NextWindowTime.Equal(base.Add(8*time.Second))
+		})
+		timex.Add(999 * time.Millisecond)
+		requireNoIncAggOutput(t, output, errCh)
+		stopIncAggOperator(t, ctx, cancel)
+	})
+}
+
 func TestIncAggSlidingWindowOver(t *testing.T) {
 	conf.IsTesting = true
 	o := &def.RuleOption{
@@ -637,6 +919,155 @@ func extractIncWindowPlan(cur planner.LogicalPlan) *planner.IncWindowPlan {
 		}
 	}
 	return nil
+}
+
+func buildIncAggPlan(t *testing.T, sql string) *planner.IncWindowPlan {
+	t.Helper()
+	kv, err := store.GetKV("stream")
+	require.NoError(t, err)
+	require.NoError(t, prepareStream())
+	stmt, err := xsql.NewParser(strings.NewReader(sql)).Parse()
+	require.NoError(t, err)
+	plan, err := planner.CreateLogicalPlan(stmt, &def.RuleOption{
+		PlanOptimizeStrategy: &def.PlanOptimizeStrategy{
+			EnableIncrementalWindow: true,
+		},
+		Qos: 0,
+	}, kv)
+	require.NoError(t, err)
+	incPlan := extractIncWindowPlan(plan)
+	require.NotNil(t, incPlan)
+	return incPlan
+}
+
+func startIncAggTestOperator(
+	t *testing.T,
+	incPlan *planner.IncWindowPlan,
+	config *node.WindowConfig,
+	options *def.RuleOption,
+	ctx api.StreamContext,
+) (*node.WindowIncAggOperator, chan any, chan any, chan error) {
+	t.Helper()
+	op, err := node.NewWindowIncAggOp("checkpoint_test", config, incPlan.Dimensions, incPlan.IncAggFuncs, options)
+	require.NoError(t, err)
+	input, _ := op.GetInput()
+	output := make(chan any, 16)
+	require.NoError(t, op.AddOutput(output, "output"))
+	errCh := make(chan error, 4)
+	op.Exec(ctx, errCh)
+	return op, input, output, errCh
+}
+
+func freezeIncAggState(t *testing.T, ctx api.StreamContext) []byte {
+	t.Helper()
+	key := incAggStateKey(ctx)
+	stateValue, err := ctx.GetState(key)
+	require.NoError(t, err)
+	require.NotNil(t, stateValue)
+	frozen, err := checkpoint.EncodeState(map[string]interface{}{key: stateValue})
+	require.NoError(t, err)
+	return frozen
+}
+
+func restoreIncAggState(t *testing.T, frozen []byte, ctx api.StreamContext) {
+	t.Helper()
+	key := incAggStateKey(ctx)
+	decoded, err := checkpoint.DecodeState(frozen)
+	require.NoError(t, err)
+	require.NoError(t, ctx.PutState(key, decoded[key]))
+}
+
+func incAggStateKey(ctx api.StreamContext) string {
+	return fmt.Sprintf("%v_%v_%v/state", ctx.GetRuleId(), ctx.GetOpId(), ctx.GetInstanceId())
+}
+
+func waitForIncAggState(
+	t *testing.T,
+	op *node.WindowIncAggOperator,
+	ctx api.StreamContext,
+	ready func(any) bool,
+) {
+	t.Helper()
+	require.NoError(t, op.PutState4Test(ctx))
+	key := incAggStateKey(ctx)
+	stateValue, err := ctx.GetState(key)
+	require.NoError(t, err)
+	require.NotNil(t, stateValue)
+	require.True(t, ready(stateValue))
+}
+
+func waitForIncAggProcessed(t *testing.T, op *node.WindowIncAggOperator, want int64) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		metrics := op.GetMetrics()
+		return len(metrics) > 2 && metrics[2] == want
+	}, time.Second, time.Millisecond)
+}
+
+func requireNoIncAggOutput(t *testing.T, output <-chan any, errCh <-chan error) {
+	t.Helper()
+	select {
+	case value := <-output:
+		t.Fatalf("unexpected incremental window output: %#v", value)
+	case err := <-errCh:
+		t.Fatalf("incremental window failed: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+type incAggTestContext struct {
+	api.StreamContext
+	waitGroup sync.WaitGroup
+}
+
+func (c *incAggTestContext) Value(key interface{}) interface{} {
+	if key == topoContext.RuleWaitGroupKey {
+		return &c.waitGroup
+	}
+	return c.StreamContext.Value(key)
+}
+
+func newIncAggTestContext(ruleID, opID string) (*incAggTestContext, context.CancelFunc) {
+	ctx, cancel := mockContext.NewMockContext(ruleID, opID).WithCancel()
+	return &incAggTestContext{StreamContext: ctx}, cancel
+}
+
+func stopIncAggOperator(t *testing.T, ctx *incAggTestContext, cancel context.CancelFunc) {
+	t.Helper()
+	cancel()
+	done := make(chan struct{})
+	go func() {
+		ctx.waitGroup.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out stopping incremental window operator")
+	}
+}
+
+func decodedIncAggContext(t *testing.T, frozen []byte, ruleID, opID string) (*incAggTestContext, context.CancelFunc) {
+	t.Helper()
+	ctx, cancel := newIncAggTestContext(ruleID, opID)
+	restoreIncAggState(t, frozen, ctx)
+	return ctx, cancel
+}
+
+func receiveIncAggWindow(t *testing.T, output <-chan any, errCh <-chan error) *xsql.WindowTuples {
+	t.Helper()
+	select {
+	case value := <-output:
+		window, ok := value.(*xsql.WindowTuples)
+		require.True(t, ok, "unexpected output type %T", value)
+		return window
+	case err := <-errCh:
+		t.Fatalf("incremental window failed: %v", err)
+		return nil
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for incremental window output")
+		return nil
+	}
 }
 
 func prepareStream() error {

--- a/internal/topo/node/node_test/window_v2_checkpoint_test.go
+++ b/internal/topo/node/node_test/window_v2_checkpoint_test.go
@@ -1,0 +1,376 @@
+// Copyright 2026 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lf-edge/ekuiper/contract/v2/api"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
+	"github.com/lf-edge/ekuiper/v2/internal/topo/checkpoint"
+	topoContext "github.com/lf-edge/ekuiper/v2/internal/topo/context"
+	"github.com/lf-edge/ekuiper/v2/internal/topo/node"
+	"github.com/lf-edge/ekuiper/v2/internal/topo/topotest/mockclock"
+	"github.com/lf-edge/ekuiper/v2/internal/xsql"
+	"github.com/lf-edge/ekuiper/v2/pkg/ast"
+	mockContext "github.com/lf-edge/ekuiper/v2/pkg/mock/context"
+	"github.com/lf-edge/ekuiper/v2/pkg/timex"
+)
+
+type windowV2CheckpointContext struct {
+	api.StreamContext
+	stateSaved chan struct{}
+	waitGroup  sync.WaitGroup
+}
+
+func (c *windowV2CheckpointContext) PutState(key string, value interface{}) error {
+	err := c.StreamContext.PutState(key, value)
+	if err == nil && key == node.V2WindowInputsKey {
+		select {
+		case c.stateSaved <- struct{}{}:
+		default:
+		}
+	}
+	return err
+}
+
+func (c *windowV2CheckpointContext) Value(key interface{}) interface{} {
+	if key == topoContext.RuleWaitGroupKey {
+		return &c.waitGroup
+	}
+	return c.StreamContext.Value(key)
+}
+
+func newWindowV2CheckpointContext(t *testing.T, state map[string]interface{}) (*windowV2CheckpointContext, context.CancelFunc) {
+	t.Helper()
+	raw, cancel := mockContext.NewMockContext("window_v2_checkpoint", "window").WithCancel()
+	for key, value := range state {
+		require.NoError(t, raw.PutState(key, value))
+	}
+	return &windowV2CheckpointContext{
+		StreamContext: raw,
+		stateSaved:    make(chan struct{}, 16),
+	}, cancel
+}
+
+func waitWindowV2StateSaved(t *testing.T, ctx *windowV2CheckpointContext) {
+	t.Helper()
+	select {
+	case <-ctx.stateSaved:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Window V2 state")
+	}
+}
+
+func waitWindowV2Processed(t *testing.T, op *node.WindowV2Operator, want int64) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		metrics := op.GetMetrics()
+		return len(metrics) > 2 && metrics[2] == want
+	}, time.Second, time.Millisecond)
+}
+
+func stopWindowV2Operator(t *testing.T, ctx *windowV2CheckpointContext, cancel context.CancelFunc) {
+	t.Helper()
+	cancel()
+	done := make(chan struct{})
+	go func() {
+		ctx.waitGroup.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out stopping Window V2 operator")
+	}
+}
+
+func freezeWindowV2State(t *testing.T, ctx *windowV2CheckpointContext) []byte {
+	t.Helper()
+	stateCtx, ok := ctx.StreamContext.(interface {
+		GetAllState() map[string]interface{}
+	})
+	require.True(t, ok)
+	frozen, err := checkpoint.EncodeState(stateCtx.GetAllState())
+	require.NoError(t, err)
+	return frozen
+}
+
+func decodeWindowV2State(t *testing.T, frozen []byte) map[string]interface{} {
+	t.Helper()
+	state, err := checkpoint.DecodeState(frozen)
+	require.NoError(t, err)
+	return state
+}
+
+func receiveWindowV2Output(t *testing.T, output <-chan any) *xsql.WindowTuples {
+	t.Helper()
+	select {
+	case got := <-output:
+		window, ok := got.(*xsql.WindowTuples)
+		require.True(t, ok)
+		return window
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Window V2 output")
+		return nil
+	}
+}
+
+func requireNoWindowV2Output(t *testing.T, output <-chan any) {
+	t.Helper()
+	select {
+	case got := <-output:
+		t.Fatalf("unexpected Window V2 output: %#v", got)
+	default:
+	}
+}
+
+func newWindowV2Operator(t *testing.T, config node.WindowConfig, options *def.RuleOption, ctx api.StreamContext) (*node.WindowV2Operator, chan any, chan any) {
+	t.Helper()
+	op, err := node.NewWindowV2Op("window", config, options)
+	require.NoError(t, err)
+	input, _ := op.GetInput()
+	output := make(chan any, 16)
+	require.NoError(t, op.AddOutput(output, "output"))
+	op.Exec(ctx, make(chan error, 4))
+	return op, input, output
+}
+
+func triggerOnOne() ast.Expr {
+	return &ast.BinaryExpr{
+		OP: ast.EQ,
+		LHS: &ast.FieldRef{
+			StreamName: ast.DefaultStream,
+			Name:       "a",
+		},
+		RHS: &ast.IntegerLiteral{Val: 1},
+	}
+}
+
+func TestWindowV2SlidingCheckpointRestore(t *testing.T) {
+	base := time.Unix(100, 0)
+	previousClock := timex.Clock
+	mockclock.ResetClock(base.UnixMilli())
+	defer func() {
+		timex.Clock = previousClock
+	}()
+
+	options := &def.RuleOption{BufferLength: 16}
+	config := node.WindowConfig{
+		Type:   ast.SLIDING_WINDOW,
+		Length: 10 * time.Second,
+	}
+	ctx1, cancel1 := newWindowV2CheckpointContext(t, nil)
+	op1, input1, output1 := newWindowV2Operator(t, config, options, ctx1)
+	waitWindowV2StateSaved(t, ctx1)
+	input1 <- &xsql.Tuple{
+		Message:   map[string]interface{}{"a": int64(1)},
+		Timestamp: base,
+	}
+	_ = receiveWindowV2Output(t, output1)
+	waitWindowV2Processed(t, op1, 1)
+	frozen := freezeWindowV2State(t, ctx1)
+
+	live, err := ctx1.GetState(node.V2WindowInputsKey)
+	require.NoError(t, err)
+	liveState := live.(*node.SlidingWindowV2State)
+	liveState.Scanner.Tuples[0].Message["a"] = int64(99)
+	stopWindowV2Operator(t, ctx1, cancel1)
+
+	restored := decodeWindowV2State(t, frozen)
+	restoredState := restored[node.V2WindowInputsKey].(*node.SlidingWindowV2State)
+	require.NotSame(t, liveState, restoredState)
+	require.NotSame(t, liveState.Scanner, restoredState.Scanner)
+	require.Equal(t, int64(1), restoredState.Scanner.Tuples[0].Message["a"])
+
+	ctx2, cancel2 := newWindowV2CheckpointContext(t, restored)
+	op2, input2, output2 := newWindowV2Operator(t, config, options, ctx2)
+	waitWindowV2StateSaved(t, ctx2)
+	input2 <- &xsql.Tuple{
+		Message:   map[string]interface{}{"a": int64(2)},
+		Timestamp: base.Add(time.Second),
+	}
+	require.Equal(t, []map[string]interface{}{
+		{"a": int64(1)},
+		{"a": int64(2)},
+	}, receiveWindowV2Output(t, output2).ToMaps())
+	waitWindowV2Processed(t, op2, 1)
+	stopWindowV2Operator(t, ctx2, cancel2)
+}
+
+func TestWindowV2SlidingDelayCheckpointRestore(t *testing.T) {
+	base := time.Unix(200, 0)
+	previousClock := timex.Clock
+	mockclock.ResetClock(base.UnixMilli())
+	defer func() {
+		timex.Clock = previousClock
+	}()
+
+	options := &def.RuleOption{BufferLength: 16}
+	config := node.WindowConfig{
+		Type:             ast.SLIDING_WINDOW,
+		Delay:            5 * time.Second,
+		Length:           10 * time.Second,
+		TriggerCondition: triggerOnOne(),
+	}
+	ctx1, cancel1 := newWindowV2CheckpointContext(t, nil)
+	op1, input1, output1 := newWindowV2Operator(t, config, options, ctx1)
+	waitWindowV2StateSaved(t, ctx1)
+	input1 <- &xsql.Tuple{
+		Message:   map[string]interface{}{"a": int64(1)},
+		Timestamp: base,
+	}
+	waitWindowV2Processed(t, op1, 1)
+	timex.Add(2 * time.Second)
+	input1 <- &xsql.Tuple{
+		Message:   map[string]interface{}{"a": int64(2)},
+		Timestamp: base.Add(2 * time.Second),
+	}
+	waitWindowV2Processed(t, op1, 2)
+	requireNoWindowV2Output(t, output1)
+	frozen := freezeWindowV2State(t, ctx1)
+
+	live, err := ctx1.GetState(node.V2WindowInputsKey)
+	require.NoError(t, err)
+	liveState := live.(*node.SlidingWindowV2State)
+	require.Len(t, liveState.Pending, 1)
+	liveState.Scanner.Tuples[0].Message["a"] = int64(99)
+	stopWindowV2Operator(t, ctx1, cancel1)
+
+	t.Run("future deadline", func(t *testing.T) {
+		mockclock.ResetClock(base.Add(4 * time.Second).UnixMilli())
+		restored := decodeWindowV2State(t, frozen)
+		restoredState := restored[node.V2WindowInputsKey].(*node.SlidingWindowV2State)
+		require.NotSame(t, liveState, restoredState)
+		require.Equal(t, int64(1), restoredState.Scanner.Tuples[0].Message["a"])
+
+		ctx2, cancel2 := newWindowV2CheckpointContext(t, restored)
+		_, _, output2 := newWindowV2Operator(t, config, options, ctx2)
+		waitWindowV2StateSaved(t, ctx2)
+		timex.Add(999 * time.Millisecond)
+		requireNoWindowV2Output(t, output2)
+		timex.Add(time.Millisecond)
+		window := receiveWindowV2Output(t, output2)
+		require.Equal(t, []map[string]interface{}{
+			{"a": int64(1)},
+			{"a": int64(2)},
+		}, window.ToMaps())
+		state, stateErr := ctx2.GetState(node.V2WindowInputsKey)
+		require.NoError(t, stateErr)
+		require.Empty(t, state.(*node.SlidingWindowV2State).Pending)
+		timex.Add(10 * time.Second)
+		requireNoWindowV2Output(t, output2)
+		stopWindowV2Operator(t, ctx2, cancel2)
+	})
+
+	t.Run("overdue deadline", func(t *testing.T) {
+		mockclock.ResetClock(base.Add(6 * time.Second).UnixMilli())
+		restored := decodeWindowV2State(t, frozen)
+		ctx2, cancel2 := newWindowV2CheckpointContext(t, restored)
+		_, _, output2 := newWindowV2Operator(t, config, options, ctx2)
+		waitWindowV2StateSaved(t, ctx2)
+		require.Equal(t, []map[string]interface{}{
+			{"a": int64(1)},
+			{"a": int64(2)},
+		}, receiveWindowV2Output(t, output2).ToMaps())
+		state, stateErr := ctx2.GetState(node.V2WindowInputsKey)
+		require.NoError(t, stateErr)
+		require.Empty(t, state.(*node.SlidingWindowV2State).Pending)
+		timex.Add(10 * time.Second)
+		requireNoWindowV2Output(t, output2)
+		stopWindowV2Operator(t, ctx2, cancel2)
+	})
+}
+
+func TestEventSlidingWindowV2CheckpointRestore(t *testing.T) {
+	base := time.Unix(300, 0)
+	options := &def.RuleOption{
+		BufferLength: 16,
+		IsEventTime:  true,
+	}
+	config := node.WindowConfig{
+		Type:             ast.SLIDING_WINDOW,
+		Delay:            5 * time.Second,
+		Length:           10 * time.Second,
+		TriggerCondition: triggerOnOne(),
+	}
+	ctx1, cancel1 := newWindowV2CheckpointContext(t, nil)
+	op1, input1, output1 := newWindowV2Operator(t, config, options, ctx1)
+	waitWindowV2StateSaved(t, ctx1)
+	input1 <- &xsql.Tuple{
+		Message:   map[string]interface{}{"a": int64(1)},
+		Timestamp: base.Add(10 * time.Second),
+	}
+	waitWindowV2Processed(t, op1, 1)
+	input1 <- &xsql.Tuple{
+		Message:   map[string]interface{}{"a": int64(2)},
+		Timestamp: base.Add(12 * time.Second),
+	}
+	waitWindowV2Processed(t, op1, 2)
+	requireNoWindowV2Output(t, output1)
+	frozen := freezeWindowV2State(t, ctx1)
+
+	live, err := ctx1.GetState(node.V2WindowInputsKey)
+	require.NoError(t, err)
+	liveState := live.(*node.EventSlidingWindowV2State)
+	require.Len(t, liveState.DelayTS, 1)
+	liveState.Scanner.Tuples[0].Message["a"] = int64(99)
+	stopWindowV2Operator(t, ctx1, cancel1)
+
+	restored := decodeWindowV2State(t, frozen)
+	restoredState := restored[node.V2WindowInputsKey].(*node.EventSlidingWindowV2State)
+	require.NotSame(t, liveState, restoredState)
+	require.NotSame(t, liveState.Scanner, restoredState.Scanner)
+	require.Equal(t, int64(1), restoredState.Scanner.Tuples[0].Message["a"])
+
+	ctx2, cancel2 := newWindowV2CheckpointContext(t, restored)
+	op2, input2, output2 := newWindowV2Operator(t, config, options, ctx2)
+	waitWindowV2StateSaved(t, ctx2)
+	input2 <- &xsql.WatermarkTuple{Timestamp: base.Add(14 * time.Second)}
+	input2 <- &xsql.Tuple{
+		Message:   map[string]interface{}{"a": int64(3)},
+		Timestamp: base.Add(14 * time.Second),
+	}
+	waitWindowV2Processed(t, op2, 1)
+	requireNoWindowV2Output(t, output2)
+	input2 <- &xsql.WatermarkTuple{Timestamp: base.Add(15 * time.Second)}
+	input2 <- &xsql.Tuple{
+		Message:   map[string]interface{}{"a": int64(5)},
+		Timestamp: base.Add(15 * time.Second),
+	}
+	waitWindowV2Processed(t, op2, 2)
+	require.Equal(t, []map[string]interface{}{
+		{"a": int64(1)},
+		{"a": int64(2)},
+		{"a": int64(3)},
+	}, receiveWindowV2Output(t, output2).ToMaps())
+	state, stateErr := ctx2.GetState(node.V2WindowInputsKey)
+	require.NoError(t, stateErr)
+	require.Empty(t, state.(*node.EventSlidingWindowV2State).DelayTS)
+
+	input2 <- &xsql.WatermarkTuple{Timestamp: base.Add(16 * time.Second)}
+	input2 <- &xsql.Tuple{
+		Message:   map[string]interface{}{"a": int64(4)},
+		Timestamp: base.Add(16 * time.Second),
+	}
+	waitWindowV2Processed(t, op2, 3)
+	requireNoWindowV2Output(t, output2)
+	stopWindowV2Operator(t, ctx2, cancel2)
+}

--- a/internal/topo/node/node_test/window_v2_op_test.go
+++ b/internal/topo/node/node_test/window_v2_op_test.go
@@ -100,7 +100,6 @@ func TestStateWindowStatePartition(t *testing.T) {
 
 func TestStateWindowState(t *testing.T) {
 	conf.IsTesting = true
-	ctx, cancel := mockContext.NewMockContext("1", "2").WithCancel()
 	now := time.Now()
 	o := &def.RuleOption{
 		BufferLength: 10,
@@ -126,11 +125,17 @@ func TestStateWindowState(t *testing.T) {
 	output := make(chan any, 10)
 	op.AddOutput(output, "output")
 	errCh := make(chan error, 10)
-	op.Exec(ctx, errCh)
-	waitExecute()
+	ctx1, cancel1 := newWindowV2CheckpointContext(t, nil)
+	op.Exec(ctx1, errCh)
+	waitWindowV2StateSaved(t, ctx1)
 	input <- &xsql.Tuple{Message: map[string]any{"a": true}, Timestamp: now}
 	input <- &xsql.Tuple{Message: map[string]any{"a": false}, Timestamp: now.Add(500 * time.Millisecond)}
-	waitExecute()
+	waitWindowV2Processed(t, op, 2)
+	frozen := freezeWindowV2State(t, ctx1)
+	stopWindowV2Operator(t, ctx1, cancel1)
+
+	restored := decodeWindowV2State(t, frozen)
+	ctx2, cancel2 := newWindowV2CheckpointContext(t, restored)
 	op2, err := node.NewWindowV2Op("window", node.WindowConfig{
 		Type:            windowPlan.WindowType(),
 		SingleCondition: windowPlan.GetSingleCondition(),
@@ -141,12 +146,12 @@ func TestStateWindowState(t *testing.T) {
 	output2 := make(chan any, 10)
 	op2.AddOutput(output2, "output")
 	errCh2 := make(chan error, 10)
-	op2.Exec(ctx, errCh2)
-	waitExecute()
+	op2.Exec(ctx2, errCh2)
+	waitWindowV2StateSaved(t, ctx2)
 	input2 <- &xsql.Tuple{Message: map[string]any{"a": false}, Timestamp: now.Add(500 * time.Millisecond)}
 	input2 <- &xsql.Tuple{Message: map[string]any{"a": true}, Timestamp: now.Add(500 * time.Millisecond)}
-	waitExecute()
 	got := <-output2
+	waitWindowV2Processed(t, op2, 2)
 	wt, ok := got.(*xsql.WindowTuples)
 	require.True(t, ok)
 	require.NotNil(t, wt)
@@ -162,10 +167,7 @@ func TestStateWindowState(t *testing.T) {
 			"a": false,
 		},
 	}, d)
-	cancel()
-	waitExecute()
-	op.Close()
-	op2.Close()
+	stopWindowV2Operator(t, ctx2, cancel2)
 }
 
 func TestSingleConditionStWindow(t *testing.T) {

--- a/internal/topo/node/rate_limit.go
+++ b/internal/topo/node/rate_limit.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 EMQ Technologies Co., Ltd.
+// Copyright 2024-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -206,7 +206,6 @@ func (o *RateLimitOp) Exec(ctx api.StreamContext, errCh chan<- error) {
 							}
 						}
 						val := &xsql.Tuple{
-							Ctx:       rt.Ctx,
 							Emitter:   rt.Emitter,
 							Timestamp: t,
 							Metadata:  rt.Metadata,
@@ -214,6 +213,7 @@ func (o *RateLimitOp) Exec(ctx api.StreamContext, errCh chan<- error) {
 								"frames": frames,
 							},
 						}
+						val.SetTracerCtx(rt.GetTracerCtx())
 						if o.span != nil {
 							o.span.End()
 						}
@@ -269,7 +269,6 @@ func (o *RateLimitOp) Exec(ctx api.StreamContext, errCh chan<- error) {
 					if ok && o.latest != nil {
 						rt := o.latest.(*xsql.RawTuple)
 						val := &xsql.Tuple{
-							Ctx:       rt.Ctx,
 							Emitter:   rt.Emitter,
 							Timestamp: t,
 							Metadata:  rt.Metadata,
@@ -277,6 +276,7 @@ func (o *RateLimitOp) Exec(ctx api.StreamContext, errCh chan<- error) {
 								"frames": frames,
 							},
 						}
+						val.SetTracerCtx(rt.GetTracerCtx())
 						if o.span != nil {
 							o.span.End()
 						}

--- a/internal/topo/node/sink_node.go
+++ b/internal/topo/node/sink_node.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 EMQ Technologies Co., Ltd.
+// Copyright 2024-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -262,39 +262,41 @@ func decodeAndCollect(ctx api.StreamContext, sink api.TupleCollector, d *xsql.Ra
 	switch r := result.(type) {
 	case map[string]any:
 		t := &xsql.Tuple{
-			Ctx:       d.Ctx,
 			Metadata:  d.Metadata,
 			Timestamp: d.Timestamp,
 			Emitter:   d.Emitter,
 			Props:     d.Props,
 			Message:   r,
 		}
+		t.SetTracerCtx(d.GetTracerCtx())
 		return sink.Collect(ctx, t)
 	case []map[string]any:
 		tuples := make([]api.MessageTuple, len(r))
 		for i, m := range r {
-			tuples[i] = &xsql.Tuple{
-				Ctx:       d.Ctx,
+			tuple := &xsql.Tuple{
 				Metadata:  d.Metadata,
 				Timestamp: d.Timestamp,
 				Emitter:   d.Emitter,
 				Props:     d.Props,
 				Message:   m,
 			}
+			tuple.SetTracerCtx(d.GetTracerCtx())
+			tuples[i] = tuple
 		}
 		return sink.CollectList(ctx, &xsql.TransformedTupleList{Content: tuples})
 	case []any:
 		tuples := make([]api.MessageTuple, 0, len(r))
 		for _, v := range r {
 			if m, ok := v.(map[string]any); ok {
-				tuples = append(tuples, &xsql.Tuple{
-					Ctx:       d.Ctx,
+				tuple := &xsql.Tuple{
 					Metadata:  d.Metadata,
 					Timestamp: d.Timestamp,
 					Emitter:   d.Emitter,
 					Props:     d.Props,
 					Message:   m,
-				})
+				}
+				tuple.SetTracerCtx(d.GetTracerCtx())
+				tuples = append(tuples, tuple)
 			} else {
 				return fmt.Errorf("only map[string]any inside a list is supported but got: %T", v)
 			}

--- a/internal/topo/node/source_node.go
+++ b/internal/topo/node/source_node.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 EMQ Technologies Co., Ltd.
+// Copyright 2024-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@ package node
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/lf-edge/ekuiper/contract/v2/api"
@@ -25,6 +26,7 @@ import (
 	"github.com/lf-edge/ekuiper/v2/internal/io/memory/pubsub"
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/sig"
+	"github.com/lf-edge/ekuiper/v2/internal/topo/checkpoint"
 	topoContext "github.com/lf-edge/ekuiper/v2/internal/topo/context"
 	"github.com/lf-edge/ekuiper/v2/internal/topo/node/tracenode"
 	"github.com/lf-edge/ekuiper/v2/internal/xsql"
@@ -43,7 +45,15 @@ type SourceNode struct {
 	s         api.Source
 	interval  time.Duration
 	notifySub bool
+
+	checkpointMu  sync.Mutex
+	checkpointErr error
 }
+
+var (
+	_ checkpoint.CheckpointGuard          = (*SourceNode)(nil)
+	_ checkpoint.CheckpointStateValidator = (*SourceNode)(nil)
+)
 
 type sourceConf struct {
 	Interval cast.DurationConf `json:"interval"`
@@ -84,6 +94,8 @@ func (m *SourceNode) Open(ctx api.StreamContext, ctrlCh chan<- error) {
 }
 
 func (m *SourceNode) ingestBytes(ctx api.StreamContext, data []byte, meta map[string]any, ts time.Time) {
+	m.checkpointMu.Lock()
+	defer m.checkpointMu.Unlock()
 	ctx.GetLogger().Debugf("source connector %s receive data %+v", m.name, data)
 	m.onProcessStart(ctx, nil)
 	if meta == nil {
@@ -94,7 +106,7 @@ func (m *SourceNode) ingestBytes(ctx api.StreamContext, data []byte, meta map[st
 	m.Broadcast(tuple)
 	m.onSend(ctx, tuple)
 	m.onProcessEnd(ctx)
-	_ = m.updateState(ctx)
+	m.refreshCheckpointStateAndReport(ctx)
 }
 
 func (m *SourceNode) traceStart(ctx api.StreamContext, meta map[string]any, tuple xsql.HasTracerCtx) {
@@ -138,6 +150,8 @@ func (m *SourceNode) traceStart(ctx api.StreamContext, meta map[string]any, tupl
 }
 
 func (m *SourceNode) ingestAnyTuple(ctx api.StreamContext, data any, meta map[string]any, ts time.Time) {
+	m.checkpointMu.Lock()
+	defer m.checkpointMu.Unlock()
 	ctx.GetLogger().Debugf("source connector %s receive data %+v", m.name, data)
 	m.onProcessStart(ctx, nil)
 	if meta == nil {
@@ -175,7 +189,7 @@ func (m *SourceNode) ingestAnyTuple(ctx api.StreamContext, data any, meta map[st
 		panic(fmt.Sprintf("receive wrong data %v", data))
 	}
 	m.onProcessEnd(ctx)
-	_ = m.updateState(ctx)
+	m.refreshCheckpointStateAndReport(ctx)
 }
 
 func (m *SourceNode) connectionStatusChange(status string, message string) {
@@ -195,7 +209,8 @@ func (m *SourceNode) ingestMap(t map[string]any, meta map[string]any, ts time.Ti
 }
 
 func (m *SourceNode) ingestTuple(t *xsql.Tuple, ts time.Time) {
-	tuple := &xsql.Tuple{Emitter: m.name, Message: t.Message, Timestamp: ts, Metadata: t.Metadata, Ctx: t.Ctx}
+	tuple := &xsql.Tuple{Emitter: m.name, Message: t.Message, Timestamp: ts, Metadata: t.Metadata}
+	tuple.SetTracerCtx(t.GetTracerCtx())
 	// If receiving tuple, its source is still in the system. So continue tracing
 	traced, spanCtx, span := tracenode.TraceInput(m.ctx, tuple, m.name)
 	if traced {
@@ -208,12 +223,28 @@ func (m *SourceNode) ingestTuple(t *xsql.Tuple, ts time.Time) {
 }
 
 func (m *SourceNode) ingestError(ctx api.StreamContext, err error) {
+	m.checkpointMu.Lock()
+	defer m.checkpointMu.Unlock()
 	m.onError(ctx, err)
 }
 
 func (m *SourceNode) ingestEof(ctx api.StreamContext, msg string) {
+	m.checkpointMu.Lock()
+	defer m.checkpointMu.Unlock()
 	ctx.GetLogger().Infof("send out EOF %s", msg)
 	m.Broadcast(xsql.EOFTuple(msg))
+}
+
+func (m *SourceNode) LockCheckpoint() {
+	m.checkpointMu.Lock()
+}
+
+func (m *SourceNode) UnlockCheckpoint() {
+	m.checkpointMu.Unlock()
+}
+
+func (m *SourceNode) CheckpointError() error {
+	return m.checkpointErr
 }
 
 // GetSource only used for test
@@ -248,9 +279,42 @@ func (m *SourceNode) updateState(ctx api.StreamContext) error {
 		if err != nil {
 			return err
 		}
-		return ctx.PutState(OffsetKey, state)
+		if state == nil {
+			return ctx.PutState(OffsetKey, nil)
+		}
+		if _, ok := rw.(checkpoint.ImmutableOffsetProvider); ok {
+			return ctx.PutState(OffsetKey, state)
+		}
+		frozen, err := checkpoint.EncodeState(map[string]interface{}{OffsetKey: state})
+		if err != nil {
+			return err
+		}
+		owned, err := checkpoint.DecodeState(frozen)
+		if err != nil {
+			return err
+		}
+		return ctx.PutState(OffsetKey, owned[OffsetKey])
 	}
 	return nil
+}
+
+func (m *SourceNode) refreshCheckpointState(ctx api.StreamContext) error {
+	err := m.updateState(ctx)
+	if err != nil {
+		m.checkpointErr = fmt.Errorf("update source checkpoint offset: %w", err)
+	} else {
+		m.checkpointErr = nil
+	}
+	return m.checkpointErr
+}
+
+func (m *SourceNode) refreshCheckpointStateAndReport(ctx api.StreamContext) {
+	wasHealthy := m.checkpointErr == nil
+	if err := m.refreshCheckpointState(ctx); err != nil && wasHealthy {
+		// Do not broadcast an error for every tuple. The next checkpoint emits
+		// DEC while the error remains, and a successful offset update clears it.
+		m.onErrorOpt(ctx, err, false)
+	}
 }
 
 // Run Subscribe could be a long-running function

--- a/internal/topo/node/source_node.go
+++ b/internal/topo/node/source_node.go
@@ -53,6 +53,7 @@ type SourceNode struct {
 var (
 	_ checkpoint.CheckpointGuard          = (*SourceNode)(nil)
 	_ checkpoint.CheckpointStateValidator = (*SourceNode)(nil)
+	_ checkpoint.CheckpointPreparer       = (*SourceNode)(nil)
 )
 
 type sourceConf struct {
@@ -245,6 +246,15 @@ func (m *SourceNode) UnlockCheckpoint() {
 
 func (m *SourceNode) CheckpointError() error {
 	return m.checkpointErr
+}
+
+// PrepareCheckpoint refreshes source-owned state after the ingest boundary is
+// locked. Some sources can advance an offset after their final ingest callback.
+func (m *SourceNode) PrepareCheckpoint() error {
+	if _, ok := m.s.(immutableOffsetProvider); !ok {
+		return nil
+	}
+	return m.refreshCheckpointState(m.ctx)
 }
 
 // GetSource only used for test

--- a/internal/topo/node/source_node.go
+++ b/internal/topo/node/source_node.go
@@ -282,7 +282,7 @@ func (m *SourceNode) updateState(ctx api.StreamContext) error {
 		if state == nil {
 			return ctx.PutState(OffsetKey, nil)
 		}
-		if _, ok := rw.(checkpoint.ImmutableOffsetProvider); ok {
+		if _, ok := rw.(immutableOffsetProvider); ok {
 			return ctx.PutState(OffsetKey, state)
 		}
 		frozen, err := checkpoint.EncodeState(map[string]interface{}{OffsetKey: state})
@@ -296,6 +296,13 @@ func (m *SourceNode) updateState(ctx api.StreamContext) error {
 		return ctx.PutState(OffsetKey, owned[OffsetKey])
 	}
 	return nil
+}
+
+// immutableOffsetProvider mirrors api.ImmutableOffsetProvider structurally.
+// The contract is released as a separate Go module, so the runtime cannot
+// reference a newly added contract symbol until that module is published.
+type immutableOffsetProvider interface {
+	CheckpointOffsetIsImmutable()
 }
 
 func (m *SourceNode) refreshCheckpointState(ctx api.StreamContext) error {

--- a/internal/topo/node/source_node_test.go
+++ b/internal/topo/node/source_node_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 EMQ Technologies Co., Ltd.
+// Copyright 2024-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package node
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -26,6 +27,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/def"
+	"github.com/lf-edge/ekuiper/v2/internal/topo/checkpoint"
+	topoContext "github.com/lf-edge/ekuiper/v2/internal/topo/context"
+	"github.com/lf-edge/ekuiper/v2/internal/topo/state"
 	"github.com/lf-edge/ekuiper/v2/internal/topo/topotest/mockclock"
 	"github.com/lf-edge/ekuiper/v2/internal/xsql"
 	mockContext "github.com/lf-edge/ekuiper/v2/pkg/mock/context"
@@ -365,8 +369,9 @@ func (m *MockPullSource) SetEofIngest(eof api.EOFIngest) {
 }
 
 type MockRewindSource struct {
-	notify chan struct{}
-	state  int
+	notify   chan struct{}
+	ingested chan struct{}
+	state    int
 }
 
 func (m *MockRewindSource) GetOffset() (any, error) {
@@ -397,10 +402,12 @@ func (m *MockRewindSource) Connect(ctx api.StreamContext, _ api.StatusChangeHand
 func (m *MockRewindSource) Subscribe(ctx api.StreamContext, ingest api.TupleIngest, ingestError api.ErrorIngest) error {
 	go func() {
 		for range m.notify {
-			ingest(ctx, map[string]any{
-				"key": m.state,
-			}, nil, time.Now())
+			current := m.state
 			m.state++
+			ingest(ctx, map[string]any{
+				"key": current,
+			}, nil, time.Now())
+			m.ingested <- struct{}{}
 		}
 	}()
 	return nil
@@ -409,7 +416,8 @@ func (m *MockRewindSource) Subscribe(ctx api.StreamContext, ingest api.TupleInge
 func TestMockRewind(t *testing.T) {
 	notify := make(chan struct{})
 	m := &MockRewindSource{
-		notify: notify,
+		notify:   notify,
+		ingested: make(chan struct{}),
 	}
 	var sc api.TupleSource = m
 	ctx := mockContext.NewMockContext("rule1", "src1")
@@ -428,9 +436,365 @@ func TestMockRewind(t *testing.T) {
 	notify <- struct{}{}
 	data := <-result
 	require.Equal(t, map[string]interface{}{"key": 10}, map[string]interface{}(data.(*xsql.Tuple).Message))
+	<-m.ingested
 	notify <- struct{}{}
 	data = <-result
 	require.Equal(t, map[string]interface{}{"key": 11}, map[string]interface{}(data.(*xsql.Tuple).Message))
+	<-m.ingested
 	v, _ := ctx.GetState(OffsetKey)
-	require.Equal(t, 11, v)
+	require.Equal(t, 12, v)
 }
+
+func TestSourceOffsetIsOwnedByContext(t *testing.T) {
+	offset := map[string]any{
+		"partition": map[string]any{"position": 10},
+	}
+	source := &MutableRewindSource{MockRewindSource: MockRewindSource{}, offset: offset}
+	node := &SourceNode{s: source}
+	ctx := mockContext.NewMockContext("rule1", "src1")
+
+	require.NoError(t, node.updateState(ctx))
+	offset["partition"].(map[string]any)["position"] = 20
+
+	saved, err := ctx.GetState(OffsetKey)
+	require.NoError(t, err)
+	require.Equal(t, 10, saved.(map[string]any)["partition"].(map[string]any)["position"])
+}
+
+func TestImmutableSourceOffsetUsesDirectOwnershipTransfer(t *testing.T) {
+	type immutableOffset struct {
+		position int
+	}
+	offset := &immutableOffset{position: 10}
+	source := &ImmutableRewindSource{offset: offset}
+	node := &SourceNode{s: source}
+	ctx := mockContext.NewMockContext("rule1", "src1")
+
+	require.NoError(t, node.updateState(ctx))
+	saved, err := ctx.GetState(OffsetKey)
+	require.NoError(t, err)
+	require.Same(t, offset, saved)
+}
+
+func BenchmarkSourceOffsetUpdate(b *testing.B) {
+	for _, size := range []int{1, 10_000} {
+		offset := make(map[string]any, size)
+		for i := range size {
+			offset[fmt.Sprintf("partition-%d", i)] = int64(i)
+		}
+		sources := map[string]api.Rewindable{
+			"Mutable":   &MutableRewindSource{offset: offset},
+			"Immutable": &ImmutableRewindSource{offset: offset},
+		}
+		for name, source := range sources {
+			b.Run(fmt.Sprintf("%s/%d", name, size), func(b *testing.B) {
+				ctx := mockContext.NewMockContext("rule1", "src1")
+				node := &SourceNode{s: source.(api.Source)}
+				b.ReportAllocs()
+				for b.Loop() {
+					if err := node.updateState(ctx); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestSourceCheckpointErrorClearsAfterOffsetRecovery(t *testing.T) {
+	offsetErr := errors.New("offset unavailable")
+	source := &MutableRewindSource{
+		MockRewindSource: MockRewindSource{},
+		offset:           map[string]any{"position": 10},
+		offsetErr:        offsetErr,
+	}
+	node := &SourceNode{s: source}
+	ctx := mockContext.NewMockContext("rule1", "src1")
+
+	node.checkpointMu.Lock()
+	err := node.refreshCheckpointState(ctx)
+	require.ErrorIs(t, err, offsetErr)
+	require.ErrorIs(t, node.CheckpointError(), offsetErr)
+	node.checkpointMu.Unlock()
+
+	source.offsetErr = nil
+	node.checkpointMu.Lock()
+	require.NoError(t, node.refreshCheckpointState(ctx))
+	require.NoError(t, node.CheckpointError())
+	node.checkpointMu.Unlock()
+
+	saved, err := ctx.GetState(OffsetKey)
+	require.NoError(t, err)
+	require.Equal(t, source.offset, saved)
+}
+
+func TestSourceCheckpointWaitsForOffsetCaptureAndRecovers(t *testing.T) {
+	offsetErr := errors.New("offset unavailable")
+	source := &controlledCheckpointSource{offset: 10}
+	node, ctx, store, output := newCheckpointSourceNode(t, source)
+
+	node.ingestAnyTuple(ctx, map[string]any{"value": 10}, nil, time.Now())
+	require.IsType(t, &xsql.Tuple{}, receiveCheckpointOutput(t, output))
+
+	offsetEntered, offsetRelease := source.blockNextOffset(20, offsetErr)
+	var releaseOnce sync.Once
+	releaseOffset := func() {
+		releaseOnce.Do(func() {
+			close(offsetRelease)
+		})
+	}
+	defer releaseOffset()
+	ingestDone := make(chan struct{})
+	go func() {
+		defer close(ingestDone)
+		node.ingestAnyTuple(ctx, map[string]any{"value": 20}, nil, time.Now())
+	}()
+	waitCheckpointStep(t, offsetEntered, "GetOffset to block")
+	require.IsType(t, &xsql.Tuple{}, receiveCheckpointOutput(t, output))
+
+	signals := make(chan *checkpoint.Signal, 2)
+	lockAttempted := make(chan struct{})
+	responder := checkpoint.NewResponderExecutor(signals, &checkpointSourceTask{
+		SourceNode:    node,
+		lockAttempted: lockAttempted,
+	})
+	triggerDone := make(chan error, 1)
+	go func() {
+		triggerDone <- responder.TriggerCheckpoint(1)
+	}()
+	waitCheckpointStep(t, lockAttempted, "checkpoint to attempt the source lock")
+
+	select {
+	case err := <-triggerDone:
+		t.Fatalf("checkpoint completed while GetOffset was blocked: %v", err)
+	default:
+	}
+	select {
+	case item := <-output:
+		t.Fatalf("barrier was emitted while GetOffset was blocked: %#v", item)
+	default:
+	}
+	select {
+	case signal := <-signals:
+		t.Fatalf("checkpoint terminated while GetOffset was blocked: %#v", signal)
+	default:
+	}
+
+	releaseOffset()
+	waitCheckpointStep(t, ingestDone, "source ingest to finish")
+	require.ErrorIs(t, receiveCheckpointError(t, triggerDone), offsetErr)
+	barrier := receiveCheckpointOutput(t, output)
+	require.Equal(t, int64(1), barrier.(*checkpoint.Barrier).CheckpointId)
+	signal := receiveCheckpointSignal(t, signals)
+	require.Equal(t, checkpoint.DEC, signal.Message)
+	require.Equal(t, int64(1), signal.CheckpointId)
+	require.Empty(t, signals, "failed source checkpoint must not emit ACK")
+	staleOffset, err := ctx.GetState(OffsetKey)
+	require.NoError(t, err)
+	require.Equal(t, 10, staleOffset)
+	_, saved := store.frozen.Load(int64(1))
+	require.False(t, saved, "failed source checkpoint must not save the stale offset")
+
+	source.setOffset(30, nil)
+	node.ingestAnyTuple(ctx, map[string]any{"value": 30}, nil, time.Now())
+	require.IsType(t, &xsql.Tuple{}, receiveCheckpointOutput(t, output))
+
+	recoverySignals := make(chan *checkpoint.Signal, 1)
+	recoveryResponder := checkpoint.NewResponderExecutor(recoverySignals, &checkpointSourceTask{
+		SourceNode:    node,
+		lockAttempted: make(chan struct{}),
+	})
+	require.NoError(t, recoveryResponder.TriggerCheckpoint(2))
+	barrier = receiveCheckpointOutput(t, output)
+	require.Equal(t, int64(2), barrier.(*checkpoint.Barrier).CheckpointId)
+	signal = receiveCheckpointSignal(t, recoverySignals)
+	require.Equal(t, checkpoint.ACK, signal.Message)
+	require.Equal(t, int64(2), signal.CheckpointId)
+
+	frozen, saved := store.frozen.Load(int64(2))
+	require.True(t, saved, "recovered source checkpoint was not saved")
+	snapshot, err := checkpoint.DecodeState(frozen.([]byte))
+	require.NoError(t, err)
+	require.Equal(t, 30, snapshot[OffsetKey])
+}
+
+func TestSourceCheckpointRejectsUnsupportedGobOffset(t *testing.T) {
+	source := &controlledCheckpointSource{offset: make(chan int)}
+	node, ctx, store, output := newCheckpointSourceNode(t, source)
+
+	node.ingestAnyTuple(ctx, map[string]any{"value": 1}, nil, time.Now())
+	require.IsType(t, &xsql.Tuple{}, receiveCheckpointOutput(t, output))
+
+	signals := make(chan *checkpoint.Signal, 2)
+	responder := checkpoint.NewResponderExecutor(signals, &checkpointSourceTask{
+		SourceNode:    node,
+		lockAttempted: make(chan struct{}),
+	})
+	require.ErrorContains(t, responder.TriggerCheckpoint(3), "gob")
+	barrier := receiveCheckpointOutput(t, output)
+	require.Equal(t, int64(3), barrier.(*checkpoint.Barrier).CheckpointId)
+	signal := receiveCheckpointSignal(t, signals)
+	require.Equal(t, checkpoint.DEC, signal.Message)
+	require.Equal(t, int64(3), signal.CheckpointId)
+	require.Empty(t, signals, "unsupported offset checkpoint must not emit ACK")
+	_, saved := store.frozen.Load(int64(3))
+	require.False(t, saved, "unsupported offset checkpoint must not save state")
+}
+
+func newCheckpointSourceNode(
+	t *testing.T,
+	source api.Source,
+) (*SourceNode, api.StreamContext, *sourceCheckpointCaptureStore, chan any) {
+	t.Helper()
+	store := &sourceCheckpointCaptureStore{}
+	ctx := topoContext.Background().WithMeta("checkpoint_rule", "checkpoint_source", store)
+	node, err := NewSourceNode(
+		ctx,
+		"checkpoint_source",
+		source,
+		map[string]any{"datasource": "test"},
+		&def.RuleOption{BufferLength: 16},
+	)
+	require.NoError(t, err)
+	node.prepareExec(ctx, make(chan error, 1), "source")
+	node.SetQos(def.AtLeastOnce)
+	output := make(chan any, 16)
+	require.NoError(t, node.AddOutput(output, "test"))
+	return node, ctx, store, output
+}
+
+func receiveCheckpointOutput(t *testing.T, output <-chan any) any {
+	t.Helper()
+	select {
+	case item := <-output:
+		if wrapped, ok := item.(*checkpoint.BufferOrEvent); ok {
+			return wrapped.Data
+		}
+		return item
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for source output")
+		return nil
+	}
+}
+
+func receiveCheckpointSignal(t *testing.T, signals <-chan *checkpoint.Signal) *checkpoint.Signal {
+	t.Helper()
+	select {
+	case signal := <-signals:
+		return signal
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for checkpoint signal")
+		return nil
+	}
+}
+
+func receiveCheckpointError(t *testing.T, errors <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-errors:
+		return err
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for checkpoint result")
+		return nil
+	}
+}
+
+func waitCheckpointStep(t *testing.T, done <-chan struct{}, step string) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", step)
+	}
+}
+
+type checkpointSourceTask struct {
+	*SourceNode
+	lockAttempted chan struct{}
+}
+
+func (t *checkpointSourceTask) LockCheckpoint() {
+	close(t.lockAttempted)
+	t.SourceNode.LockCheckpoint()
+}
+
+type controlledCheckpointSource struct {
+	MockRewindSource
+
+	mu            sync.Mutex
+	offset        any
+	offsetErr     error
+	offsetEntered chan struct{}
+	offsetRelease chan struct{}
+}
+
+func (s *controlledCheckpointSource) GetOffset() (any, error) {
+	s.mu.Lock()
+	offset := s.offset
+	offsetErr := s.offsetErr
+	entered := s.offsetEntered
+	release := s.offsetRelease
+	s.offsetEntered = nil
+	s.offsetRelease = nil
+	s.mu.Unlock()
+	if entered != nil {
+		close(entered)
+		<-release
+	}
+	return offset, offsetErr
+}
+
+func (s *controlledCheckpointSource) setOffset(offset any, offsetErr error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.offset = offset
+	s.offsetErr = offsetErr
+}
+
+func (s *controlledCheckpointSource) blockNextOffset(offset any, offsetErr error) (<-chan struct{}, chan struct{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.offset = offset
+	s.offsetErr = offsetErr
+	s.offsetEntered = make(chan struct{})
+	s.offsetRelease = make(chan struct{})
+	return s.offsetEntered, s.offsetRelease
+}
+
+type sourceCheckpointCaptureStore struct {
+	state.MemoryStore
+	frozen sync.Map
+}
+
+func (s *sourceCheckpointCaptureStore) SaveFrozenState(checkpointID int64, _ string, frozen []byte) error {
+	s.frozen.Store(checkpointID, append([]byte(nil), frozen...))
+	return nil
+}
+
+type MutableRewindSource struct {
+	MockRewindSource
+	offset    map[string]any
+	offsetErr error
+}
+
+func (m *MutableRewindSource) GetOffset() (any, error) {
+	return m.offset, m.offsetErr
+}
+
+func (m *MutableRewindSource) Rewind(offset any) error {
+	m.offset = offset.(map[string]any)
+	return nil
+}
+
+type ImmutableRewindSource struct {
+	MockRewindSource
+	offset any
+}
+
+func (m *ImmutableRewindSource) GetOffset() (any, error) {
+	return m.offset, nil
+}
+
+func (m *ImmutableRewindSource) CheckpointOffsetIsImmutable() {}
+
+var _ checkpoint.ImmutableOffsetProvider = (*ImmutableRewindSource)(nil)

--- a/internal/topo/node/source_node_test.go
+++ b/internal/topo/node/source_node_test.go
@@ -476,6 +476,19 @@ func TestImmutableSourceOffsetUsesDirectOwnershipTransfer(t *testing.T) {
 	require.Same(t, offset, saved)
 }
 
+func TestSourcePrepareCheckpointRefreshesOffsetWithoutAnotherIngest(t *testing.T) {
+	source := &ImmutableRewindSource{offset: int64(10)}
+	ctx := mockContext.NewMockContext("rule1", "src1")
+	node := &SourceNode{s: source, defaultNode: &defaultNode{ctx: ctx}}
+	require.NoError(t, node.refreshCheckpointState(ctx))
+
+	source.offset = int64(20)
+	require.NoError(t, node.PrepareCheckpoint())
+	saved, err := ctx.GetState(OffsetKey)
+	require.NoError(t, err)
+	require.Equal(t, int64(20), saved)
+}
+
 func BenchmarkSourceOffsetUpdate(b *testing.B) {
 	for _, size := range []int{1, 10_000} {
 		offset := make(map[string]any, size)

--- a/internal/topo/node/source_node_test.go
+++ b/internal/topo/node/source_node_test.go
@@ -797,4 +797,4 @@ func (m *ImmutableRewindSource) GetOffset() (any, error) {
 
 func (m *ImmutableRewindSource) CheckpointOffsetIsImmutable() {}
 
-var _ checkpoint.ImmutableOffsetProvider = (*ImmutableRewindSource)(nil)
+var _ immutableOffsetProvider = (*ImmutableRewindSource)(nil)

--- a/internal/topo/node/transform_op.go
+++ b/internal/topo/node/transform_op.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 EMQ Technologies Co., Ltd.
+// Copyright 2024-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -224,11 +224,15 @@ func toSinkTuple(_, spanCtx api.StreamContext, bs any, props map[string]string) 
 	case []byte:
 		return &xsql.RawTuple{Ctx: spanCtx, Rawdata: bt, Props: props, Timestamp: timex.GetNow()}
 	case map[string]any:
-		return &xsql.Tuple{Ctx: spanCtx, Message: bt, Timestamp: timex.GetNow(), Props: props}
+		tuple := &xsql.Tuple{Message: bt, Timestamp: timex.GetNow(), Props: props}
+		tuple.SetTracerCtx(spanCtx)
+		return tuple
 	case []map[string]any:
 		tuples := make([]api.MessageTuple, 0, len(bt))
 		for _, m := range bt {
-			tuples = append(tuples, &xsql.Tuple{Ctx: spanCtx, Message: m, Timestamp: timex.GetNow()})
+			tuple := &xsql.Tuple{Message: m, Timestamp: timex.GetNow()}
+			tuple.SetTracerCtx(spanCtx)
+			tuples = append(tuples, tuple)
 		}
 		return &xsql.TransformedTupleList{Ctx: spanCtx, Content: tuples, Maps: bt, Props: props}
 	default:

--- a/internal/topo/node/window_inc_agg_checkpoint_test.go
+++ b/internal/topo/node/window_inc_agg_checkpoint_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"testing"
+	"time"
+
+	topoContext "github.com/lf-edge/ekuiper/v2/internal/topo/context"
+)
+
+func TestHoppingIncAggOverdueCloseDoesNotEnqueueToFullTaskChannel(t *testing.T) {
+	now := time.Now()
+	window := &IncAggWindow{StartTime: now.Add(-2 * time.Second)}
+	op := &HoppingWindowIncAggOp{
+		Length: time.Second,
+		taskCh: make(chan *IncAggOpTask, 1),
+		HoppingWindowIncAggOpState: HoppingWindowIncAggOpState{
+			CurrWindowList: []*IncAggWindow{},
+		},
+	}
+	op.taskCh <- &IncAggOpTask{}
+	done := make(chan struct{})
+	go func() {
+		op.scheduleWindowClose(topoContext.Background(), make(chan error, 1), window, now)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("overdue window close blocked on its own full task channel")
+	}
+}

--- a/internal/topo/node/window_inc_agg_event_op.go
+++ b/internal/topo/node/window_inc_agg_event_op.go
@@ -184,11 +184,11 @@ func (so *SlidingWindowIncAggEventOp) RestoreFromState(ctx api.StreamContext) er
 	}
 	so.SlidingWindowIncAggEventOpState = soState
 	for index, window := range so.CurrWindowList {
-		window.GenerateAllFunctionState()
+		window.restoreState(ctx)
 		so.CurrWindowList[index] = window
 	}
 	for index, window := range so.EmitList {
-		window.GenerateAllFunctionState()
+		window.restoreState(ctx)
 		so.EmitList[index] = window
 	}
 	return nil

--- a/internal/topo/node/window_inc_agg_op.go
+++ b/internal/topo/node/window_inc_agg_op.go
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 EMQ Technologies Co., Ltd.
+// Copyright 2024-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/gob"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -47,7 +48,10 @@ func init() {
 	gob.Register(CountWindowIncAggOpState{})
 	gob.Register(TumblingWindowIncAggOpState{})
 	gob.Register(SlidingWindowIncAggOpState{})
+	gob.Register(HoppingWindowIncAggOpState{})
+	gob.Register(HoppingWindowIncAggEventOpState{})
 	gob.Register(SlidingWindowIncAggEventOpState{})
+	gob.Register(CountWindowIncAggEventOpState{})
 }
 
 type WindowIncAggOperator struct {
@@ -373,14 +377,14 @@ func (co *CountWindowIncAggOp) emit(ctx api.StreamContext, errCh chan<- error) {
 
 type TumblingWindowIncAggOp struct {
 	*WindowIncAggOperator
-	ticker     *clock.Ticker
 	FirstTimer *clock.Timer
 	Interval   time.Duration
 	TumblingWindowIncAggOpState
 }
 
 type TumblingWindowIncAggOpState struct {
-	CurrWindow *IncAggWindow
+	CurrWindow      *IncAggWindow
+	NextTriggerTime time.Time
 }
 
 func NewTumblingWindowIncAggOp(o *WindowIncAggOperator) *TumblingWindowIncAggOp {
@@ -419,64 +423,20 @@ func (to *TumblingWindowIncAggOp) exec(ctx api.StreamContext, errCh chan<- error
 		return
 	}
 	defer func() {
-		if to.ticker != nil {
-			to.ticker.Stop()
+		if to.FirstTimer != nil {
+			to.FirstTimer.Stop()
 		}
 	}()
-	now := timex.GetNow()
-	if !EnableAlignWindow {
-		to.ticker = timex.GetTicker(to.Interval)
-	} else {
-		_, to.FirstTimer = getFirstTimer(ctx, to.windowConfig.RawInterval, to.windowConfig.TimeUnit)
-		if to.FirstTimer != nil {
-			to.markFirstTimerCreated()
-		}
-		if to.CurrWindow == nil {
-			to.CurrWindow = newIncAggWindow(ctx, now)
-		}
+	if err := to.restoreTimer(ctx, errCh); err != nil {
+		errCh <- err
+		return
 	}
 	fv, _ := xsql.NewFunctionValuersForOp(ctx)
-	if to.FirstTimer != nil {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case done := <-to.putStateReqCh:
-				to.PutState(ctx)
-				done <- nil
-			case done := <-to.restoreReqCh:
-				done <- to.RestoreFromState(ctx)
-			case now := <-to.FirstTimer.C:
-				to.FirstTimer.Stop()
-				to.FirstTimer = nil
-				if to.CurrWindow != nil {
-					to.emit(ctx, errCh, now)
-				}
-				to.ticker = timex.GetTicker(to.Interval)
-				to.PutState(ctx)
-				goto outer
-			case input := <-to.input:
-				now := timex.GetNow()
-				data, processed := to.commonIngest(ctx, input)
-				if processed {
-					continue
-				}
-				to.onProcessStart(ctx, input)
-				switch row := data.(type) {
-				case *xsql.Tuple:
-					if to.CurrWindow == nil {
-						to.CurrWindow = newIncAggWindow(ctx, now)
-					}
-					name := calDimension(fv, to.Dimensions, row)
-					incAggCal(ctx, name, row, to.CurrWindow, to.aggFields)
-				}
-				to.PutState(ctx)
-				to.onProcessEnd(ctx)
-			}
-		}
-	}
-outer:
 	for {
+		var timerC <-chan time.Time
+		if to.FirstTimer != nil {
+			timerC = to.FirstTimer.C
+		}
 		select {
 		case <-ctx.Done():
 			return
@@ -484,7 +444,11 @@ outer:
 			to.PutState(ctx)
 			done <- nil
 		case done := <-to.restoreReqCh:
-			done <- to.RestoreFromState(ctx)
+			err := to.RestoreFromState(ctx)
+			if err == nil {
+				err = to.restoreTimer(ctx, errCh)
+			}
+			done <- err
 		case input := <-to.input:
 			now := timex.GetNow()
 			data, processed := to.commonIngest(ctx, input)
@@ -502,12 +466,60 @@ outer:
 			}
 			to.PutState(ctx)
 			to.onProcessEnd(ctx)
-		case now := <-to.ticker.C:
-			if to.CurrWindow != nil {
-				to.emit(ctx, errCh, now)
-			}
-			to.PutState(ctx)
+		case <-timerC:
+			to.fireTimer(ctx, errCh, timex.GetNow())
 		}
+	}
+}
+
+func (to *TumblingWindowIncAggOp) restoreTimer(ctx api.StreamContext, errCh chan<- error) error {
+	if to.Interval <= 0 {
+		return fmt.Errorf("invalid tumbling window interval %v", to.Interval)
+	}
+	if to.FirstTimer != nil {
+		to.FirstTimer.Stop()
+		to.FirstTimer = nil
+	}
+	now := timex.GetNow()
+	if to.NextTriggerTime.IsZero() {
+		if EnableAlignWindow {
+			to.NextTriggerTime = getAlignedWindowEndTime(now, to.windowConfig.RawInterval, to.windowConfig.TimeUnit)
+			if to.CurrWindow == nil {
+				to.CurrWindow = newIncAggWindow(ctx, now)
+			}
+		} else {
+			to.NextTriggerTime = now.Add(to.Interval)
+		}
+	}
+	if !to.NextTriggerTime.After(now) {
+		to.fireTimer(ctx, errCh, now)
+		return nil
+	}
+	to.scheduleTimer()
+	to.PutState(ctx)
+	return nil
+}
+
+func (to *TumblingWindowIncAggOp) fireTimer(ctx api.StreamContext, errCh chan<- error, now time.Time) {
+	fireAt := to.NextTriggerTime
+	if to.CurrWindow != nil {
+		to.emit(ctx, errCh, fireAt)
+	}
+	if !to.NextTriggerTime.After(now) {
+		missed := now.Sub(to.NextTriggerTime) / to.Interval
+		to.NextTriggerTime = to.NextTriggerTime.Add(missed * to.Interval)
+	}
+	if !to.NextTriggerTime.After(now) {
+		to.NextTriggerTime = to.NextTriggerTime.Add(to.Interval)
+	}
+	to.scheduleTimer()
+	to.PutState(ctx)
+}
+
+func (to *TumblingWindowIncAggOp) scheduleTimer() {
+	to.FirstTimer = timex.GetTimerByTime(to.NextTriggerTime)
+	if EnableAlignWindow {
+		to.markFirstTimerCreated()
 	}
 }
 
@@ -532,16 +544,25 @@ type SlidingWindowIncAggOp struct {
 	triggerCondition ast.Expr
 	Length           time.Duration
 	Delay            time.Duration
-	taskCh           chan *IncAggOpTask
+	delayTimer       *clock.Timer
 	SlidingWindowIncAggOpState
 }
 
 type SlidingWindowIncAggOpState struct {
 	CurrWindowList []*IncAggWindow
+	// Pending is ordered by FireAt and then ID. Processing-time deadlines are
+	// absolute, so downtime counts toward Delay.
+	Pending       []PendingSlidingIncAggTask
+	NextPendingID uint64
 }
 
 type IncAggOpTask struct {
 	window *IncAggWindow
+}
+
+type PendingSlidingIncAggTask struct {
+	ID     uint64
+	FireAt time.Time
 }
 
 func NewSlidingWindowIncAggOp(o *WindowIncAggOperator) *SlidingWindowIncAggOp {
@@ -550,9 +571,9 @@ func NewSlidingWindowIncAggOp(o *WindowIncAggOperator) *SlidingWindowIncAggOp {
 		triggerCondition:     o.windowConfig.TriggerCondition,
 		Length:               o.windowConfig.Length,
 		Delay:                o.windowConfig.Delay,
-		taskCh:               make(chan *IncAggOpTask, 1024),
 	}
 	op.SlidingWindowIncAggOpState.CurrWindowList = make([]*IncAggWindow, 0)
+	op.SlidingWindowIncAggOpState.Pending = make([]PendingSlidingIncAggTask, 0)
 	return op
 }
 
@@ -577,12 +598,20 @@ func (so *SlidingWindowIncAggOp) RestoreFromState(ctx api.StreamContext) error {
 		return fmt.Errorf("not SlidingWindowIncAggOpState")
 	}
 	so.SlidingWindowIncAggOpState = soState
+	if so.delayTimer != nil {
+		so.delayTimer.Stop()
+		so.delayTimer = nil
+	}
+	if so.Pending == nil {
+		so.Pending = make([]PendingSlidingIncAggTask, 0)
+	}
 	for index, window := range so.CurrWindowList {
-		window.GenerateAllFunctionState()
+		window.restoreState(ctx)
 		so.CurrWindowList[index] = window
 	}
-	now := timex.GetNow()
-	so.CurrWindowList = gcIncAggWindow(so.CurrWindowList, so.Length, now)
+	sort.SliceStable(so.Pending, func(i, j int) bool {
+		return pendingSlidingTaskBefore(so.Pending[i], so.Pending[j])
+	})
 	return nil
 }
 
@@ -591,18 +620,40 @@ func (so *SlidingWindowIncAggOp) exec(ctx api.StreamContext, errCh chan<- error)
 		errCh <- err
 		return
 	}
+	so.drainDuePendingTasks(ctx, errCh, timex.GetNow())
+	so.resetPendingTimer()
+	defer func() {
+		if so.delayTimer != nil {
+			so.delayTimer.Stop()
+		}
+	}()
 	fv, _ := xsql.NewFunctionValuersForOp(ctx)
 	for {
+		var delayTimerC <-chan time.Time
+		if so.delayTimer != nil {
+			delayTimerC = so.delayTimer.C
+		}
 		select {
 		case <-ctx.Done():
 			return
 		case done := <-so.putStateReqCh:
+			if so.drainDuePendingTasks(ctx, errCh, timex.GetNow()) {
+				so.resetPendingTimer()
+			}
 			so.PutState(ctx)
 			done <- nil
 		case done := <-so.restoreReqCh:
-			done <- so.RestoreFromState(ctx)
+			err := so.RestoreFromState(ctx)
+			if err == nil {
+				so.drainDuePendingTasks(ctx, errCh, timex.GetNow())
+				so.resetPendingTimer()
+			}
+			done <- err
 		case input := <-so.input:
 			now := timex.GetNow()
+			if so.drainDuePendingTasks(ctx, errCh, now) {
+				so.resetPendingTimer()
+			}
 			data, processed := so.commonIngest(ctx, input)
 			if processed {
 				continue
@@ -610,20 +661,18 @@ func (so *SlidingWindowIncAggOp) exec(ctx api.StreamContext, errCh chan<- error)
 			so.onProcessStart(ctx, input)
 			switch row := data.(type) {
 			case *xsql.Tuple:
-				so.CurrWindowList = gcIncAggWindow(so.CurrWindowList, so.Length+so.Delay, now)
+				so.gcWindows(now)
 				so.appendIncAggWindow(ctx, errCh, fv, row, now)
 				if so.isMatchCondition(ctx, fv, row) {
 					if so.Delay > 0 {
-						t := &IncAggOpTask{}
-						go func(task *IncAggOpTask) {
-							after := timex.After(so.Delay)
-							select {
-							case <-ctx.Done():
-								return
-							case <-after:
-								so.taskCh <- task
-							}
-						}(t)
+						pending := PendingSlidingIncAggTask{
+							ID:     so.NextPendingID,
+							FireAt: now.Add(so.Delay),
+						}
+						so.NextPendingID++
+						if so.insertPendingTask(pending) {
+							so.resetPendingTimer()
+						}
 					} else {
 						so.emit(ctx, errCh, so.CurrWindowList[0], now)
 					}
@@ -631,15 +680,79 @@ func (so *SlidingWindowIncAggOp) exec(ctx api.StreamContext, errCh chan<- error)
 				so.PutState(ctx)
 			}
 			so.onProcessEnd(ctx)
-		case <-so.taskCh:
-			now := timex.GetNow()
-			so.CurrWindowList = gcIncAggWindow(so.CurrWindowList, so.Length+so.Delay, now)
-			if len(so.CurrWindowList) > 0 {
-				so.emit(ctx, errCh, so.CurrWindowList[0], now)
-			}
-			so.PutState(ctx)
+		case <-delayTimerC:
+			so.delayTimer = nil
+			so.drainDuePendingTasks(ctx, errCh, timex.GetNow())
+			so.resetPendingTimer()
 		}
 	}
+}
+
+func (so *SlidingWindowIncAggOp) drainDuePendingTasks(ctx api.StreamContext, errCh chan<- error, now time.Time) bool {
+	drained := false
+	for len(so.Pending) > 0 && !so.Pending[0].FireAt.After(now) {
+		pending := so.Pending[0]
+		so.Pending = so.Pending[1:]
+		so.emitPendingTask(ctx, errCh, pending)
+		drained = true
+	}
+	if drained {
+		so.gcWindows(now)
+		so.PutState(ctx)
+	}
+	return drained
+}
+
+func (so *SlidingWindowIncAggOp) emitPendingTask(ctx api.StreamContext, errCh chan<- error, pending PendingSlidingIncAggTask) {
+	cutoff := pending.FireAt.Add(-so.Delay).Add(-so.Length)
+	for _, window := range so.CurrWindowList {
+		if window.StartTime.After(cutoff) {
+			so.emit(ctx, errCh, window, pending.FireAt)
+			break
+		}
+	}
+}
+
+// insertPendingTask returns true when the earliest deadline changed.
+func (so *SlidingWindowIncAggOp) insertPendingTask(pending PendingSlidingIncAggTask) bool {
+	count := len(so.Pending)
+	if count == 0 || !pendingSlidingTaskBefore(pending, so.Pending[count-1]) {
+		so.Pending = append(so.Pending, pending)
+		return count == 0
+	}
+	index := sort.Search(count, func(i int) bool {
+		return !pendingSlidingTaskBefore(so.Pending[i], pending)
+	})
+	so.Pending = append(so.Pending, PendingSlidingIncAggTask{})
+	copy(so.Pending[index+1:], so.Pending[index:])
+	so.Pending[index] = pending
+	return index == 0
+}
+
+func pendingSlidingTaskBefore(left, right PendingSlidingIncAggTask) bool {
+	if left.FireAt.Equal(right.FireAt) {
+		return left.ID < right.ID
+	}
+	return left.FireAt.Before(right.FireAt)
+}
+
+func (so *SlidingWindowIncAggOp) gcWindows(now time.Time) {
+	gcAt := now
+	if len(so.Pending) > 0 && so.Pending[0].FireAt.Before(gcAt) {
+		gcAt = so.Pending[0].FireAt
+	}
+	so.CurrWindowList = gcIncAggWindow(so.CurrWindowList, so.Length+so.Delay, gcAt)
+}
+
+func (so *SlidingWindowIncAggOp) resetPendingTimer() {
+	if so.delayTimer != nil {
+		so.delayTimer.Stop()
+		so.delayTimer = nil
+	}
+	if len(so.Pending) == 0 {
+		return
+	}
+	so.delayTimer = timex.GetTimerByTime(so.Pending[0].FireAt)
 }
 
 func (so *SlidingWindowIncAggOp) appendIncAggWindow(ctx api.StreamContext, errCh chan<- error, fv *xsql.FunctionValuer, row *xsql.Tuple, now time.Time) {
@@ -692,7 +805,6 @@ func (so *SlidingWindowIncAggOp) isMatchCondition(ctx api.StreamContext, fv *xsq
 type HoppingWindowIncAggOp struct {
 	*WindowIncAggOperator
 	FirstTimer *clock.Timer
-	ticker     *clock.Ticker
 	Length     time.Duration
 	Interval   time.Duration
 	taskCh     chan *IncAggOpTask
@@ -701,6 +813,7 @@ type HoppingWindowIncAggOp struct {
 
 type HoppingWindowIncAggOpState struct {
 	CurrWindowList []*IncAggWindow
+	NextWindowTime time.Time
 }
 
 func NewHoppingWindowIncAggOp(o *WindowIncAggOperator) *HoppingWindowIncAggOp {
@@ -739,19 +852,6 @@ func (ho *HoppingWindowIncAggOp) RestoreFromState(ctx api.StreamContext) error {
 		window.restoreState(ctx)
 		ho.CurrWindowList[index] = window
 	}
-	now := time.Now()
-	ho.CurrWindowList = gcIncAggWindow(ho.CurrWindowList, ho.Length, now)
-	for _, window := range ho.CurrWindowList {
-		go func(restoreWindow *IncAggWindow) {
-			after := timex.After(now.Sub(restoreWindow.StartTime))
-			select {
-			case <-ctx.Done():
-				return
-			case <-after:
-				ho.taskCh <- &IncAggOpTask{window: restoreWindow}
-			}
-		}(window)
-	}
 	return nil
 }
 
@@ -761,23 +861,20 @@ func (ho *HoppingWindowIncAggOp) exec(ctx api.StreamContext, errCh chan<- error)
 		return
 	}
 	defer func() {
-		if ho.ticker != nil {
-			ho.ticker.Stop()
+		if ho.FirstTimer != nil {
+			ho.FirstTimer.Stop()
 		}
 	}()
-	now := timex.GetNow()
-	if !EnableAlignWindow {
-		ho.ticker = timex.GetTicker(ho.Interval)
-		ho.newIncWindow(ctx, now)
-	} else {
-		_, ho.FirstTimer = getFirstTimer(ctx, ho.windowConfig.RawInterval, ho.windowConfig.TimeUnit)
-		if ho.FirstTimer != nil {
-			ho.markFirstTimerCreated()
-		}
-		ho.CurrWindowList = append(ho.CurrWindowList, newIncAggWindow(ctx, now))
+	if err := ho.restoreTimers(ctx, errCh); err != nil {
+		errCh <- err
+		return
 	}
 	fv, _ := xsql.NewFunctionValuersForOp(ctx)
 	for {
+		var timerC <-chan time.Time
+		if ho.FirstTimer != nil {
+			timerC = ho.FirstTimer.C
+		}
 		select {
 		case <-ctx.Done():
 			return
@@ -785,12 +882,13 @@ func (ho *HoppingWindowIncAggOp) exec(ctx api.StreamContext, errCh chan<- error)
 			ho.PutState(ctx)
 			done <- nil
 		case done := <-ho.restoreReqCh:
-			done <- ho.RestoreFromState(ctx)
+			err := ho.RestoreFromState(ctx)
+			if err == nil {
+				err = ho.restoreTimers(ctx, errCh)
+			}
+			done <- err
 		case task := <-ho.taskCh:
-			now := timex.GetNow()
-			ho.emit(ctx, errCh, task.window, now)
-			ho.CurrWindowList = gcIncAggWindow(ho.CurrWindowList, ho.Length, now)
-			ho.PutState(ctx)
+			ho.handleWindowTask(ctx, errCh, task)
 		case input := <-ho.input:
 			now := timex.GetNow()
 			data, processed := ho.commonIngest(ctx, input)
@@ -800,37 +898,14 @@ func (ho *HoppingWindowIncAggOp) exec(ctx api.StreamContext, errCh chan<- error)
 			ho.onProcessStart(ctx, input)
 			switch row := data.(type) {
 			case *xsql.Tuple:
-				ho.CurrWindowList = gcIncAggWindow(ho.CurrWindowList, ho.Length, now)
 				ho.calIncAggWindow(ctx, fv, row, now)
 			}
 			ho.PutState(ctx)
-		default:
-		}
-		if ho.FirstTimer != nil {
-			select {
-			case <-ctx.Done():
-				return
-			case now := <-ho.FirstTimer.C:
-				ho.FirstTimer.Stop()
-				ho.FirstTimer = nil
-				ho.CurrWindowList = gcIncAggWindow(ho.CurrWindowList, ho.Length, now)
-				ho.newIncWindow(ctx, now)
-				ho.CurrWindowList = gcIncAggWindow(ho.CurrWindowList, ho.Length, now)
-				ho.ticker = timex.GetTicker(ho.Interval)
-				ho.PutState(ctx)
-			default:
-			}
-		}
-		if ho.ticker != nil {
-			select {
-			case <-ctx.Done():
-				return
-			case now := <-ho.ticker.C:
-				ho.CurrWindowList = gcIncAggWindow(ho.CurrWindowList, ho.Length, now)
-				ho.newIncWindow(ctx, now)
-				ho.PutState(ctx)
-			default:
-			}
+			ho.onProcessEnd(ctx)
+		case <-timerC:
+			ho.openDueWindows(ctx, timex.GetNow())
+			ho.scheduleWindowTimer()
+			ho.PutState(ctx)
 		}
 	}
 }
@@ -838,15 +913,104 @@ func (ho *HoppingWindowIncAggOp) exec(ctx api.StreamContext, errCh chan<- error)
 func (ho *HoppingWindowIncAggOp) newIncWindow(ctx api.StreamContext, now time.Time) {
 	newWindow := newIncAggWindow(ctx, now)
 	ho.CurrWindowList = append(ho.CurrWindowList, newWindow)
+	ho.scheduleWindowClose(ctx, newWindow, timex.GetNow())
+}
+
+func (ho *HoppingWindowIncAggOp) restoreTimers(ctx api.StreamContext, errCh chan<- error) error {
+	if ho.Length <= 0 || ho.Interval <= 0 {
+		return fmt.Errorf("invalid hopping window length %v or interval %v", ho.Length, ho.Interval)
+	}
+	if ho.FirstTimer != nil {
+		ho.FirstTimer.Stop()
+		ho.FirstTimer = nil
+	}
+	now := timex.GetNow()
+	var lastStart time.Time
+	if len(ho.CurrWindowList) > 0 {
+		lastStart = ho.CurrWindowList[len(ho.CurrWindowList)-1].StartTime
+	}
+	for _, window := range append([]*IncAggWindow(nil), ho.CurrWindowList...) {
+		fireAt := window.StartTime.Add(ho.Length)
+		if !fireAt.After(now) {
+			ho.handleWindowTask(ctx, errCh, &IncAggOpTask{window: window})
+		} else {
+			ho.scheduleWindowClose(ctx, window, now)
+		}
+	}
+	if ho.NextWindowTime.IsZero() {
+		switch {
+		case !lastStart.IsZero():
+			ho.NextWindowTime = lastStart.Add(ho.Interval)
+		case EnableAlignWindow:
+			ho.newIncWindow(ctx, now)
+			ho.NextWindowTime = getAlignedWindowEndTime(now, ho.windowConfig.RawInterval, ho.windowConfig.TimeUnit)
+		default:
+			ho.newIncWindow(ctx, now)
+			ho.NextWindowTime = now.Add(ho.Interval)
+		}
+	}
+	ho.openDueWindows(ctx, now)
+	ho.scheduleWindowTimer()
+	if EnableAlignWindow && ho.FirstTimer != nil {
+		ho.markFirstTimerCreated()
+	}
+	ho.PutState(ctx)
+	return nil
+}
+
+func (ho *HoppingWindowIncAggOp) openDueWindows(ctx api.StreamContext, now time.Time) {
+	activeCutoff := now.Add(-ho.Length)
+	if !ho.NextWindowTime.After(activeCutoff) {
+		missed := activeCutoff.Sub(ho.NextWindowTime) / ho.Interval
+		ho.NextWindowTime = ho.NextWindowTime.Add(missed * ho.Interval)
+		if !ho.NextWindowTime.After(activeCutoff) {
+			ho.NextWindowTime = ho.NextWindowTime.Add(ho.Interval)
+		}
+	}
+	for !ho.NextWindowTime.After(now) {
+		start := ho.NextWindowTime
+		ho.newIncWindow(ctx, start)
+		ho.NextWindowTime = ho.NextWindowTime.Add(ho.Interval)
+	}
+}
+
+func (ho *HoppingWindowIncAggOp) scheduleWindowTimer() {
+	if ho.FirstTimer != nil {
+		ho.FirstTimer.Stop()
+	}
+	ho.FirstTimer = timex.GetTimerByTime(ho.NextWindowTime)
+}
+
+func (ho *HoppingWindowIncAggOp) scheduleWindowClose(ctx api.StreamContext, window *IncAggWindow, now time.Time) {
+	fireAt := window.StartTime.Add(ho.Length)
+	if !fireAt.After(now) {
+		ho.taskCh <- &IncAggOpTask{window: window}
+		return
+	}
+	after := timex.After(fireAt.Sub(now))
 	go func() {
-		after := timex.After(ho.Length)
 		select {
 		case <-ctx.Done():
 			return
 		case <-after:
-			ho.taskCh <- &IncAggOpTask{window: newWindow}
+			select {
+			case <-ctx.Done():
+			case ho.taskCh <- &IncAggOpTask{window: window}:
+			}
 		}
 	}()
+}
+
+func (ho *HoppingWindowIncAggOp) handleWindowTask(ctx api.StreamContext, errCh chan<- error, task *IncAggOpTask) {
+	for index, window := range ho.CurrWindowList {
+		if window != task.window {
+			continue
+		}
+		ho.CurrWindowList = append(ho.CurrWindowList[:index], ho.CurrWindowList[index+1:]...)
+		ho.emit(ctx, errCh, window, window.StartTime.Add(ho.Length))
+		ho.PutState(ctx)
+		return
+	}
 }
 
 func (ho *HoppingWindowIncAggOp) emit(ctx api.StreamContext, errCh chan<- error, window *IncAggWindow, now time.Time) {

--- a/internal/topo/node/window_inc_agg_op.go
+++ b/internal/topo/node/window_inc_agg_op.go
@@ -340,24 +340,6 @@ func (co *CountWindowIncAggOp) setIncAggWindow(ctx api.StreamContext) {
 	}
 }
 
-func (co *CountWindowIncAggOp) incAggCal(ctx api.StreamContext, dimension string, row *xsql.Tuple, incAggWindow *IncAggWindow) {
-	dimensionsRange, ok := incAggWindow.DimensionsIncAggRange[dimension]
-	if !ok {
-		dimensionsRange = newIncAggRange(ctx)
-		incAggWindow.DimensionsIncAggRange[dimension] = dimensionsRange
-	}
-	ve := &xsql.ValuerEval{Valuer: xsql.MultiValuer(dimensionsRange.fv, row, &xsql.WildcardValuer{Data: row})}
-	dimensionsRange.LastRow = row
-	for _, aggField := range co.aggFields {
-		vi := ve.Eval(aggField.Expr)
-		colName := aggField.Name
-		if len(aggField.AName) > 0 {
-			colName = aggField.AName
-		}
-		dimensionsRange.Fields[colName] = vi
-	}
-}
-
 func (co *CountWindowIncAggOp) emit(ctx api.StreamContext, errCh chan<- error) {
 	results := &xsql.WindowTuples{
 		Content: make([]xsql.Row, 0),
@@ -903,17 +885,17 @@ func (ho *HoppingWindowIncAggOp) exec(ctx api.StreamContext, errCh chan<- error)
 			ho.PutState(ctx)
 			ho.onProcessEnd(ctx)
 		case <-timerC:
-			ho.openDueWindows(ctx, timex.GetNow())
+			ho.openDueWindows(ctx, errCh, timex.GetNow())
 			ho.scheduleWindowTimer()
 			ho.PutState(ctx)
 		}
 	}
 }
 
-func (ho *HoppingWindowIncAggOp) newIncWindow(ctx api.StreamContext, now time.Time) {
+func (ho *HoppingWindowIncAggOp) newIncWindow(ctx api.StreamContext, errCh chan<- error, now time.Time) {
 	newWindow := newIncAggWindow(ctx, now)
 	ho.CurrWindowList = append(ho.CurrWindowList, newWindow)
-	ho.scheduleWindowClose(ctx, newWindow, timex.GetNow())
+	ho.scheduleWindowClose(ctx, errCh, newWindow, timex.GetNow())
 }
 
 func (ho *HoppingWindowIncAggOp) restoreTimers(ctx api.StreamContext, errCh chan<- error) error {
@@ -934,7 +916,7 @@ func (ho *HoppingWindowIncAggOp) restoreTimers(ctx api.StreamContext, errCh chan
 		if !fireAt.After(now) {
 			ho.handleWindowTask(ctx, errCh, &IncAggOpTask{window: window})
 		} else {
-			ho.scheduleWindowClose(ctx, window, now)
+			ho.scheduleWindowClose(ctx, errCh, window, now)
 		}
 	}
 	if ho.NextWindowTime.IsZero() {
@@ -942,14 +924,14 @@ func (ho *HoppingWindowIncAggOp) restoreTimers(ctx api.StreamContext, errCh chan
 		case !lastStart.IsZero():
 			ho.NextWindowTime = lastStart.Add(ho.Interval)
 		case EnableAlignWindow:
-			ho.newIncWindow(ctx, now)
+			ho.newIncWindow(ctx, errCh, now)
 			ho.NextWindowTime = getAlignedWindowEndTime(now, ho.windowConfig.RawInterval, ho.windowConfig.TimeUnit)
 		default:
-			ho.newIncWindow(ctx, now)
+			ho.newIncWindow(ctx, errCh, now)
 			ho.NextWindowTime = now.Add(ho.Interval)
 		}
 	}
-	ho.openDueWindows(ctx, now)
+	ho.openDueWindows(ctx, errCh, now)
 	ho.scheduleWindowTimer()
 	if EnableAlignWindow && ho.FirstTimer != nil {
 		ho.markFirstTimerCreated()
@@ -958,7 +940,7 @@ func (ho *HoppingWindowIncAggOp) restoreTimers(ctx api.StreamContext, errCh chan
 	return nil
 }
 
-func (ho *HoppingWindowIncAggOp) openDueWindows(ctx api.StreamContext, now time.Time) {
+func (ho *HoppingWindowIncAggOp) openDueWindows(ctx api.StreamContext, errCh chan<- error, now time.Time) {
 	activeCutoff := now.Add(-ho.Length)
 	if !ho.NextWindowTime.After(activeCutoff) {
 		missed := activeCutoff.Sub(ho.NextWindowTime) / ho.Interval
@@ -969,7 +951,7 @@ func (ho *HoppingWindowIncAggOp) openDueWindows(ctx api.StreamContext, now time.
 	}
 	for !ho.NextWindowTime.After(now) {
 		start := ho.NextWindowTime
-		ho.newIncWindow(ctx, start)
+		ho.newIncWindow(ctx, errCh, start)
 		ho.NextWindowTime = ho.NextWindowTime.Add(ho.Interval)
 	}
 }
@@ -981,10 +963,10 @@ func (ho *HoppingWindowIncAggOp) scheduleWindowTimer() {
 	ho.FirstTimer = timex.GetTimerByTime(ho.NextWindowTime)
 }
 
-func (ho *HoppingWindowIncAggOp) scheduleWindowClose(ctx api.StreamContext, window *IncAggWindow, now time.Time) {
+func (ho *HoppingWindowIncAggOp) scheduleWindowClose(ctx api.StreamContext, errCh chan<- error, window *IncAggWindow, now time.Time) {
 	fireAt := window.StartTime.Add(ho.Length)
 	if !fireAt.After(now) {
-		ho.taskCh <- &IncAggOpTask{window: window}
+		ho.handleWindowTask(ctx, errCh, &IncAggOpTask{window: window})
 		return
 	}
 	after := timex.After(fireAt.Sub(now))

--- a/internal/topo/node/window_op_test.go
+++ b/internal/topo/node/window_op_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2024 EMQ Technologies Co., Ltd.
+// Copyright 2021-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,9 +22,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/lf-edge/ekuiper/v2/internal/topo/checkpoint"
 	"github.com/lf-edge/ekuiper/v2/internal/topo/context"
 	"github.com/lf-edge/ekuiper/v2/internal/xsql"
 	"github.com/lf-edge/ekuiper/v2/pkg/ast"
+	"github.com/lf-edge/ekuiper/v2/pkg/model"
 )
 
 var fivet = []xsql.EventRow{
@@ -53,6 +55,40 @@ var fivet = []xsql.EventRow{
 			"f5": "v5",
 		},
 	},
+}
+
+func TestWindowCheckpointEventRowRoundTrip(t *testing.T) {
+	tuple := &xsql.Tuple{
+		Emitter:   "map-source",
+		Message:   xsql.Message{"id": int64(1)},
+		Timestamp: time.UnixMilli(100),
+	}
+	tuple.SetTracerCtx(context.Background())
+	sliceTuple := &xsql.SliceTuple{
+		SourceContent: model.SliceVal{int64(2), "value"},
+		Timestamp:     time.UnixMilli(200),
+	}
+	live := []xsql.EventRow{tuple, sliceTuple}
+
+	frozen, err := checkpoint.EncodeState(map[string]interface{}{WindowInputsKey: live})
+	require.NoError(t, err)
+	tuple.Message["id"] = int64(99)
+	sliceTuple.SourceContent[0] = int64(99)
+
+	restored, err := checkpoint.DecodeState(frozen)
+	require.NoError(t, err)
+	rows := restored[WindowInputsKey].([]xsql.EventRow)
+	require.Len(t, rows, 2)
+
+	restoredTuple, ok := rows[0].(*xsql.Tuple)
+	require.True(t, ok)
+	require.Nil(t, restoredTuple.GetTracerCtx())
+	require.Equal(t, int64(1), restoredTuple.Message["id"])
+
+	restoredSlice, ok := rows[1].(*xsql.SliceTuple)
+	require.True(t, ok)
+	require.Nil(t, restoredSlice.GetTracerCtx())
+	require.Equal(t, model.SliceVal{int64(2), "value"}, restoredSlice.SourceContent)
 }
 
 func TestTime(t *testing.T) {

--- a/internal/topo/node/window_v2_benchmark_test.go
+++ b/internal/topo/node/window_v2_benchmark_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package node
+
+import (
+	"testing"
+
+	topoContext "github.com/lf-edge/ekuiper/v2/internal/topo/context"
+	"github.com/lf-edge/ekuiper/v2/internal/topo/state"
+)
+
+// BenchmarkWindowV2InitialStatePublication measures the one-time context
+// publication done when an operator starts or restores. Tuple processing
+// mutates this published state in place and does not call PutState.
+func BenchmarkWindowV2InitialStatePublication(b *testing.B) {
+	ctx := topoContext.Background().WithMeta("benchmark", "window", &state.MemoryStore{})
+	windowState := &SlidingWindowV2State{
+		Scanner: &WindowScanner{},
+	}
+	if err := ctx.PutState(V2WindowInputsKey, windowState); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if err := ctx.PutState(V2WindowInputsKey, windowState); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/topo/node/window_v2_event_op.go
+++ b/internal/topo/node/window_v2_event_op.go
@@ -1,4 +1,4 @@
-// Copyright 2025 EMQ Technologies Co., Ltd.
+// Copyright 2025-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 package node
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/lf-edge/ekuiper/contract/v2/api"
@@ -29,7 +30,14 @@ type EventSlidingWindowOp struct {
 	Length           time.Duration
 	stateFuncs       []*ast.Call
 	triggerCondition ast.Expr
-	delayTS          []time.Time
+	state            *EventSlidingWindowV2State
+}
+
+// EventSlidingWindowV2State is published once, mutated only by the operator
+// goroutine, and frozen by the checkpoint barrier.
+type EventSlidingWindowV2State struct {
+	Scanner *WindowScanner
+	DelayTS []time.Time
 }
 
 func NewEventSlidingWindowOp(o *WindowV2Operator) *EventSlidingWindowOp {
@@ -39,11 +47,18 @@ func NewEventSlidingWindowOp(o *WindowV2Operator) *EventSlidingWindowOp {
 		Length:           o.windowConfig.Length,
 		stateFuncs:       o.windowConfig.StateFuncs,
 		triggerCondition: o.windowConfig.TriggerCondition,
-		delayTS:          make([]time.Time, 0),
+		state: &EventSlidingWindowV2State{
+			Scanner: o.scanner,
+			DelayTS: make([]time.Time, 0),
+		},
 	}
 }
 
 func (s *EventSlidingWindowOp) exec(ctx api.StreamContext, errCh chan<- error) {
+	if err := s.restoreState(ctx); err != nil {
+		errCh <- err
+		return
+	}
 	fv, _ := xsql.NewFunctionValuersForOp(ctx)
 	for {
 		select {
@@ -57,19 +72,19 @@ func (s *EventSlidingWindowOp) exec(ctx api.StreamContext, errCh chan<- error) {
 			switch tuple := data.(type) {
 			case *xsql.WatermarkTuple:
 				now := tuple.GetTimestamp()
-				newIndex := -1
-				for i, delayTs := range s.delayTS {
+				consumed := 0
+				for _, delayTs := range s.state.DelayTS {
 					if delayTs.Before(now) || delayTs.Equal(now) {
 						windowStart := delayTs.Add(-s.Length).Add(-s.Delay)
 						windowEnd := now
 						s.emitWindow(ctx, windowStart, windowEnd)
+						consumed++
 					} else {
-						newIndex = i
 						break
 					}
 				}
-				if newIndex != -1 {
-					s.delayTS = s.delayTS[newIndex:]
+				if consumed > 0 {
+					s.state.DelayTS = s.state.DelayTS[consumed:]
 				}
 				s.scanner.gc(now.Add(-s.Length).Add(-s.Delay))
 			case *xsql.Tuple:
@@ -82,7 +97,7 @@ func (s *EventSlidingWindowOp) exec(ctx api.StreamContext, errCh chan<- error) {
 					sendWindow = isMatchCondition(ctx, s.triggerCondition, fv, tuple, s.stateFuncs)
 				}
 				if s.Delay > 0 && sendWindow {
-					s.delayTS = append(s.delayTS, tuple.Timestamp.Add(s.Delay))
+					s.state.DelayTS = append(s.state.DelayTS, tuple.Timestamp.Add(s.Delay))
 					sendWindow = false
 				}
 				if sendWindow {
@@ -92,6 +107,25 @@ func (s *EventSlidingWindowOp) exec(ctx api.StreamContext, errCh chan<- error) {
 			}
 		}
 	}
+}
+
+func (s *EventSlidingWindowOp) restoreState(ctx api.StreamContext) error {
+	v, err := ctx.GetState(V2WindowInputsKey)
+	if err != nil {
+		return err
+	}
+	if v != nil {
+		state, ok := v.(*EventSlidingWindowV2State)
+		if !ok {
+			return fmt.Errorf("restore window V2 event sliding state %T error, invalid type", v)
+		}
+		if state.Scanner == nil {
+			state.Scanner = &WindowScanner{Tuples: make([]*xsql.Tuple, 0)}
+		}
+		s.state = state
+		s.scanner = state.Scanner
+	}
+	return ctx.PutState(V2WindowInputsKey, s.state)
 }
 
 func (o *WindowV2Operator) ingest(ctx api.StreamContext, item any) (any, bool) {

--- a/internal/topo/node/window_v2_op.go
+++ b/internal/topo/node/window_v2_op.go
@@ -1,4 +1,4 @@
-// Copyright 2025 EMQ Technologies Co., Ltd.
+// Copyright 2025-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,6 +40,8 @@ func init() {
 	gob.Register(time.Time{})
 	gob.Register(&StateWindowStatus{})
 	gob.Register(map[string]*StateWindowStatus{})
+	gob.Register(&SlidingWindowV2State{})
+	gob.Register(&EventSlidingWindowV2State{})
 }
 
 type WindowV2Operator struct {
@@ -165,11 +167,21 @@ func calPartition(fv *xsql.FunctionValuer, partitionExpr *ast.PartitionExpr, row
 
 func (s *StateWindowOp) exec(ctx api.StreamContext, errCh chan<- error) {
 	v, err := ctx.GetState(V2WindowInputsKey)
-	if err == nil && v != nil {
+	if err != nil {
+		infra.DrainError(ctx, err, errCh)
+		return
+	}
+	if v != nil {
 		preStatus, ok := v.(map[string]*StateWindowStatus)
-		if ok {
-			s.status = preStatus
+		if !ok {
+			infra.DrainError(ctx, fmt.Errorf("restore window V2 state %T error, invalid type", v), errCh)
+			return
 		}
+		s.status = preStatus
+	}
+	if err := ctx.PutState(V2WindowInputsKey, s.status); err != nil {
+		infra.DrainError(ctx, err, errCh)
+		return
 	}
 	fv, _ := xsql.NewFunctionValuersForOp(ctx)
 	for {
@@ -198,7 +210,6 @@ func (s *StateWindowOp) exec(ctx api.StreamContext, errCh chan<- error) {
 					s.handleTupleWithSingleCondition(ctx, fv, row, status)
 				}
 			}
-			ctx.PutState(V2WindowInputsKey, s.status)
 			s.onProcessEnd(ctx)
 		}
 	}
@@ -253,7 +264,30 @@ type SlidingWindowOp struct {
 	Length           time.Duration
 	stateFuncs       []*ast.Call
 	triggerCondition ast.Expr
-	delayNotify      chan time.Time
+	state            *SlidingWindowV2State
+	delayNotify      chan uint64
+}
+
+// SlidingWindowV2State is published once and then owned by the operator
+// goroutine. The checkpoint barrier performs the only deep freeze.
+type SlidingWindowV2State struct {
+	Scanner *WindowScanner
+	// Pending is ordered by trigger time. WindowScanner already requires
+	// timestamp-ordered input, so the first item also has the earliest
+	// window start needed by GC.
+	Pending           []PendingSlidingWindow
+	NextPendingID     uint64
+	LatestWindowStart time.Time
+}
+
+type PendingSlidingWindow struct {
+	ID uint64
+	// FireAt is an absolute processing-time deadline, so downtime counts
+	// toward Delay and an overdue window fires immediately after restore.
+	FireAt time.Time
+	// WindowEnd preserves the tuple-timestamp-based range used by the
+	// original execution, independently of the processing clock.
+	WindowEnd time.Time
 }
 
 func NewSlidingWindowOp(o *WindowV2Operator) *SlidingWindowOp {
@@ -263,20 +297,26 @@ func NewSlidingWindowOp(o *WindowV2Operator) *SlidingWindowOp {
 		Length:           o.windowConfig.Length,
 		stateFuncs:       o.windowConfig.StateFuncs,
 		triggerCondition: o.windowConfig.TriggerCondition,
-		delayNotify:      make(chan time.Time, 1024),
+		state: &SlidingWindowV2State{
+			Scanner: o.scanner,
+			Pending: make([]PendingSlidingWindow, 0),
+		},
+		delayNotify: make(chan uint64, 1024),
 	}
 }
 
 func (s *SlidingWindowOp) exec(ctx api.StreamContext, errCh chan<- error) {
+	if err := s.restoreState(ctx); err != nil {
+		infra.DrainError(ctx, err, errCh)
+		return
+	}
 	fv, _ := xsql.NewFunctionValuersForOp(ctx)
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case delayTs := <-s.delayNotify:
-			windowEnd := delayTs
-			windowStart := delayTs.Add(-s.Delay).Add(-s.Length)
-			s.emitWindow(ctx, windowStart, windowEnd)
+		case pendingID := <-s.delayNotify:
+			s.emitPendingWindow(ctx, pendingID)
 		case input := <-s.input:
 			data, processed := s.commonIngest(ctx, input)
 			if processed {
@@ -287,7 +327,8 @@ func (s *SlidingWindowOp) exec(ctx api.StreamContext, errCh chan<- error) {
 			case *xsql.Tuple:
 				windowEnd := row.Timestamp
 				windowStart := windowEnd.Add(-s.Length)
-				s.scanner.gc(windowStart)
+				s.state.LatestWindowStart = windowStart
+				s.gcScanner()
 				s.scanner.addTuple(row)
 				sendWindow := true
 				if s.triggerCondition != nil {
@@ -295,15 +336,14 @@ func (s *SlidingWindowOp) exec(ctx api.StreamContext, errCh chan<- error) {
 				}
 				if s.Delay > 0 && sendWindow {
 					sendWindow = false
-					go func(ts time.Time) {
-						after := timex.After(s.Delay)
-						select {
-						case <-ctx.Done():
-							return
-						case <-after:
-							s.delayNotify <- ts
-						}
-					}(windowEnd.Add(s.Delay))
+					pending := PendingSlidingWindow{
+						ID:        s.state.NextPendingID,
+						FireAt:    timex.GetNow().Add(s.Delay),
+						WindowEnd: windowEnd.Add(s.Delay),
+					}
+					s.state.NextPendingID++
+					s.state.Pending = append(s.state.Pending, pending)
+					s.schedulePendingWindow(ctx, pending)
 				}
 				if sendWindow {
 					s.emitWindow(ctx, windowStart, windowEnd)
@@ -312,6 +352,86 @@ func (s *SlidingWindowOp) exec(ctx api.StreamContext, errCh chan<- error) {
 			s.onProcessEnd(ctx)
 		}
 	}
+}
+
+func (s *SlidingWindowOp) restoreState(ctx api.StreamContext) error {
+	v, err := ctx.GetState(V2WindowInputsKey)
+	if err != nil {
+		return err
+	}
+	if v != nil {
+		state, ok := v.(*SlidingWindowV2State)
+		if !ok {
+			return fmt.Errorf("restore window V2 sliding state %T error, invalid type", v)
+		}
+		if state.Scanner == nil {
+			state.Scanner = &WindowScanner{Tuples: make([]*xsql.Tuple, 0)}
+		}
+		s.state = state
+		s.scanner = state.Scanner
+	}
+	now := timex.GetNow()
+	pending := append([]PendingSlidingWindow(nil), s.state.Pending...)
+	for _, item := range pending {
+		if item.FireAt.After(now) {
+			s.schedulePendingWindow(ctx, item)
+		} else {
+			s.emitPendingWindow(ctx, item.ID)
+		}
+	}
+	return ctx.PutState(V2WindowInputsKey, s.state)
+}
+
+func (s *SlidingWindowOp) schedulePendingWindow(ctx api.StreamContext, pending PendingSlidingWindow) {
+	after := timex.After(pending.FireAt.Sub(timex.GetNow()))
+	go func() {
+		select {
+		case <-ctx.Done():
+			return
+		case <-after:
+			select {
+			case <-ctx.Done():
+			case s.delayNotify <- pending.ID:
+			}
+		}
+	}()
+}
+
+func (s *SlidingWindowOp) emitPendingWindow(ctx api.StreamContext, pendingID uint64) {
+	if len(s.state.Pending) > 0 && s.state.Pending[0].ID == pendingID {
+		pending := s.state.Pending[0]
+		s.state.Pending = s.state.Pending[1:]
+		s.emitPending(ctx, pending)
+		return
+	}
+	for i, pending := range s.state.Pending {
+		if pending.ID != pendingID {
+			continue
+		}
+		s.state.Pending = append(s.state.Pending[:i], s.state.Pending[i+1:]...)
+		s.emitPending(ctx, pending)
+		break
+	}
+}
+
+func (s *SlidingWindowOp) emitPending(ctx api.StreamContext, pending PendingSlidingWindow) {
+	windowStart := pending.WindowEnd.Add(-s.Delay).Add(-s.Length)
+	s.emitWindow(ctx, windowStart, pending.WindowEnd)
+	s.gcScanner()
+}
+
+func (s *SlidingWindowOp) gcScanner() {
+	gcTime := s.state.LatestWindowStart
+	if gcTime.IsZero() {
+		return
+	}
+	if len(s.state.Pending) > 0 {
+		pendingStart := s.state.Pending[0].WindowEnd.Add(-s.Delay).Add(-s.Length)
+		if pendingStart.Before(gcTime) {
+			gcTime = pendingStart
+		}
+	}
+	s.scanner.gc(gcTime)
 }
 
 func isMatchCondition(ctx api.StreamContext, condition ast.Expr, fv *xsql.FunctionValuer, d *xsql.Tuple, stateFuncs []*ast.Call) bool {

--- a/internal/topo/node/window_v2_op.go
+++ b/internal/topo/node/window_v2_op.go
@@ -91,7 +91,7 @@ func (o *WindowV2Operator) Exec(ctx api.StreamContext, errCh chan<- error) {
 func (o *WindowV2Operator) emitWindow(ctx api.StreamContext, startTime, endTime time.Time) {
 	tuples := o.scanner.scanWindow(startTime, endTime)
 	results := &xsql.WindowTuples{
-		Content: make([]xsql.Row, 0),
+		Content: make([]xsql.Row, 0, len(tuples)),
 	}
 	for _, tuple := range tuples {
 		results.Content = append(results.Content, tuple)

--- a/internal/topo/node/window_v2_op.go
+++ b/internal/topo/node/window_v2_op.go
@@ -35,7 +35,6 @@ const (
 var InfTime = time.Unix(1<<63-62135596801, 999999999)
 
 func init() {
-	gob.Register([]*xsql.Tuple{})
 	gob.Register(&WindowScanner{})
 	gob.Register(time.Time{})
 	gob.Register(&StateWindowStatus{})

--- a/internal/topo/state/kv_store.go
+++ b/internal/topo/state/kv_store.go
@@ -1,4 +1,4 @@
-// Copyright 2021 EMQ Technologies Co., Ltd.
+// Copyright 2021-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,6 +27,58 @@ import (
 	"github.com/lf-edge/ekuiper/v2/pkg/store"
 )
 
+const (
+	checkpointFormat        = "ekuiper-checkpoint"
+	checkpointFormatVersion = uint16(2)
+)
+
+type checkpointEnvelope struct {
+	Format    string
+	Version   uint16
+	Operators map[string][]byte
+}
+
+// restoredOperatorState retains the persisted snapshot while transferring the
+// eagerly decoded object graph to at most one live operator context.
+type restoredOperatorState struct {
+	mu      sync.Mutex
+	frozen  []byte
+	decoded *sync.Map
+}
+
+func newRestoredOperatorState(frozen []byte) (*restoredOperatorState, error) {
+	decoded, err := checkpoint.DecodeState(frozen)
+	if err != nil {
+		return nil, err
+	}
+	return newRestoredOperatorStateFromDecoded(frozen, decoded), nil
+}
+
+func newRestoredOperatorStateFromDecoded(frozen []byte, decoded map[string]interface{}) *restoredOperatorState {
+	return &restoredOperatorState{
+		frozen:  frozen,
+		decoded: cast.MapToSyncMap(decoded),
+	}
+}
+
+func (s *restoredOperatorState) take() (*sync.Map, error) {
+	s.mu.Lock()
+	if s.decoded != nil {
+		decoded := s.decoded
+		s.decoded = nil
+		s.mu.Unlock()
+		return decoded, nil
+	}
+	frozen := s.frozen
+	s.mu.Unlock()
+
+	decoded, err := checkpoint.DecodeState(frozen)
+	if err != nil {
+		return nil, err
+	}
+	return cast.MapToSyncMap(decoded), nil
+}
+
 func init() {
 	gob.Register(map[string]interface{}{})
 	gob.Register(checkpoint.BufferOrEvent{})
@@ -41,9 +93,14 @@ func init() {
 type KVStore struct {
 	db          ts2.Tskv
 	mapStore    *sync.Map // The current root store of a rule
-	checkpoints []int64
-	max         int
-	ruleId      string
+	lifecycleMu sync.RWMutex
+	// discardedThrough is a monotonic tombstone. A canceled checkpoint and
+	// every older checkpoint remain invalid without retaining one map entry
+	// per cancellation.
+	discardedThrough int64
+	checkpoints      []int64
+	max              int
+	ruleId           string
 }
 
 // Store in path ./data/checkpoint/$ruleId
@@ -65,14 +122,54 @@ func getKVStore(ruleId string) (*KVStore, error) {
 }
 
 func (s *KVStore) restore() error {
-	var m map[string]interface{}
-	k, err := s.db.Last(&m)
-	if err != nil {
-		return err
+	var envelope checkpointEnvelope
+	k, envelopeErr := s.db.Last(&envelope)
+	if envelopeErr == nil && k == 0 {
+		return nil
 	}
-	if k > 0 {
+	if envelopeErr == nil && envelope.Format == checkpointFormat {
+		if envelope.Version != checkpointFormatVersion {
+			return fmt.Errorf("unsupported checkpoint format version %d", envelope.Version)
+		}
+		if envelope.Operators == nil {
+			return fmt.Errorf("invalid checkpoint %d: operators must not be nil", k)
+		}
+		cstore := &sync.Map{}
+		for opID, state := range envelope.Operators {
+			restored, err := newRestoredOperatorState(state)
+			if err != nil {
+				return fmt.Errorf("restore checkpoint %d state for operator %s: %w", k, opID, err)
+			}
+			cstore.Store(opID, restored)
+		}
 		s.checkpoints = []int64{k}
-		s.mapStore.Store(k, cast.MapToSyncMap(m))
+		s.mapStore.Store(k, cstore)
+		return nil
+	}
+
+	var legacy map[string]interface{}
+	legacyKey, legacyErr := s.db.Last(&legacy)
+	if legacyErr != nil {
+		if envelopeErr != nil {
+			return fmt.Errorf("decode checkpoint as version %d: %v; decode as legacy: %w", checkpointFormatVersion, envelopeErr, legacyErr)
+		}
+		return legacyErr
+	}
+	if legacyKey > 0 {
+		cstore := &sync.Map{}
+		for opID, value := range legacy {
+			operatorState, ok := value.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("restore legacy checkpoint %d state for operator %s: invalid type %T", legacyKey, opID, value)
+			}
+			frozen, err := checkpoint.EncodeState(operatorState)
+			if err != nil {
+				return fmt.Errorf("restore legacy checkpoint %d state for operator %s: %w", legacyKey, opID, err)
+			}
+			cstore.Store(opID, newRestoredOperatorStateFromDecoded(frozen, operatorState))
+		}
+		s.checkpoints = []int64{legacyKey}
+		s.mapStore.Store(legacyKey, cstore)
 	}
 	return nil
 }
@@ -80,36 +177,97 @@ func (s *KVStore) restore() error {
 func (s *KVStore) SaveState(checkpointId int64, opId string, state map[string]interface{}) error {
 	logger := conf.Log
 	logger.Debugf("Save state for checkpoint %d, op %s, value %v", checkpointId, opId, state)
-	var cstore *sync.Map
-	if v, ok := s.mapStore.Load(checkpointId); !ok {
-		cstore = &sync.Map{}
-		s.mapStore.Store(checkpointId, cstore)
-	} else {
-		if cstore, ok = v.(*sync.Map); !ok {
-			return fmt.Errorf("invalid KVStore for checkpointId %d with value %v: should be *sync.Map type", checkpointId, v)
-		}
+	frozen, err := checkpoint.EncodeState(state)
+	if err != nil {
+		return err
 	}
-	cstore.Store(opId, state)
+	return s.SaveFrozenState(checkpointId, opId, frozen)
+}
+
+func (s *KVStore) SaveFrozenState(checkpointID int64, opID string, state []byte) error {
+	s.lifecycleMu.RLock()
+	defer s.lifecycleMu.RUnlock()
+	if checkpointID <= s.discardedThrough {
+		return fmt.Errorf("checkpoint %d was discarded", checkpointID)
+	}
+	cstore, err := s.loadOrCreateCheckpoint(checkpointID)
+	if err != nil {
+		return err
+	}
+	if _, loaded := cstore.LoadOrStore(opID, state); loaded {
+		return fmt.Errorf("state for checkpoint %d operator %s already exists", checkpointID, opID)
+	}
 	return nil
 }
 
+func (s *KVStore) DiscardFrozenState(checkpointID int64) {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+	for _, completedID := range s.checkpoints {
+		if completedID == checkpointID {
+			return
+		}
+	}
+	if checkpointID > s.discardedThrough {
+		s.discardedThrough = checkpointID
+	}
+	s.mapStore.Delete(checkpointID)
+}
+
+func (s *KVStore) loadOrCreateCheckpoint(checkpointID int64) (*sync.Map, error) {
+	candidate := &sync.Map{}
+	actual, _ := s.mapStore.LoadOrStore(checkpointID, candidate)
+	cstore, ok := actual.(*sync.Map)
+	if !ok {
+		return nil, fmt.Errorf("invalid KVStore for checkpointId %d with value %v: should be *sync.Map type", checkpointID, actual)
+	}
+	return cstore, nil
+}
+
 func (s *KVStore) SaveCheckpoint(checkpointId int64) error {
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+	if checkpointId <= s.discardedThrough {
+		return fmt.Errorf("checkpoint %d was discarded", checkpointId)
+	}
 	if v, ok := s.mapStore.Load(checkpointId); !ok {
 		return fmt.Errorf("store for checkpoint %d not found", checkpointId)
 	} else {
 		if m, ok := v.(*sync.Map); !ok {
 			return fmt.Errorf("invalid KVStore for checkpointId %d with value %v: should be *sync.Map type", checkpointId, v)
 		} else {
+			operators := make(map[string][]byte)
+			var rangeErr error
+			m.Range(func(key, value interface{}) bool {
+				opID, keyOK := key.(string)
+				state, valueOK := value.([]byte)
+				if !keyOK || !valueOK {
+					rangeErr = fmt.Errorf("invalid frozen state for checkpoint %d: operator %v has type %T", checkpointId, key, value)
+					return false
+				}
+				operators[opID] = state
+				return true
+			})
+			if rangeErr != nil {
+				return rangeErr
+			}
+			envelope := checkpointEnvelope{
+				Format:    checkpointFormat,
+				Version:   checkpointFormatVersion,
+				Operators: operators,
+			}
+			inserted, err := s.db.Set(checkpointId, envelope)
+			if err != nil {
+				return fmt.Errorf("save checkpoint err: %v", err)
+			}
+			if !inserted {
+				return fmt.Errorf("checkpoint %d was not inserted", checkpointId)
+			}
 			s.checkpoints = append(s.checkpoints, checkpointId)
-			// TODO is the order promised?
 			for len(s.checkpoints) > s.max {
 				cp := s.checkpoints[0]
 				s.checkpoints = s.checkpoints[1:]
 				s.mapStore.Delete(cp)
-			}
-			_, err := s.db.Set(checkpointId, cast.SyncMapToMap(m))
-			if err != nil {
-				return fmt.Errorf("save checkpoint err: %v", err)
 			}
 		}
 	}
@@ -118,6 +276,8 @@ func (s *KVStore) SaveCheckpoint(checkpointId int64) error {
 
 // GetOpState Only run in the initialization
 func (s *KVStore) GetOpState(opId string) (*sync.Map, error) {
+	s.lifecycleMu.RLock()
+	defer s.lifecycleMu.RUnlock()
 	if len(s.checkpoints) > 0 {
 		if v, ok := s.mapStore.Load(s.checkpoints[len(s.checkpoints)-1]); ok {
 			if cstore, ok := v.(*sync.Map); !ok {
@@ -125,6 +285,18 @@ func (s *KVStore) GetOpState(opId string) (*sync.Map, error) {
 			} else {
 				if sm, ok := cstore.Load(opId); ok {
 					switch m := sm.(type) {
+					case []byte:
+						state, err := checkpoint.DecodeState(m)
+						if err != nil {
+							return nil, fmt.Errorf("restore state for operator %s: %w", opId, err)
+						}
+						return cast.MapToSyncMap(state), nil
+					case *restoredOperatorState:
+						state, err := m.take()
+						if err != nil {
+							return nil, fmt.Errorf("restore state for operator %s: %w", opId, err)
+						}
+						return state, nil
 					case *sync.Map:
 						return m, nil
 					case map[string]interface{}:
@@ -142,5 +314,10 @@ func (s *KVStore) GetOpState(opId string) (*sync.Map, error) {
 }
 
 func (s *KVStore) Clean() error {
+	s.lifecycleMu.RLock()
+	defer s.lifecycleMu.RUnlock()
+	if len(s.checkpoints) == 0 {
+		return nil
+	}
 	return s.db.DeleteBefore(s.checkpoints[0])
 }

--- a/internal/topo/state/kv_store_test.go
+++ b/internal/topo/state/kv_store_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 EMQ Technologies Co., Ltd.
+// Copyright 2021-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,16 +15,20 @@
 package state
 
 import (
+	"bytes"
+	"encoding/gob"
 	"fmt"
 	"log"
 	"os"
 	"path"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 
 	"github.com/lf-edge/ekuiper/v2/internal/conf"
 	"github.com/lf-edge/ekuiper/v2/internal/pkg/store"
+	"github.com/lf-edge/ekuiper/v2/internal/topo/checkpoint"
 	"github.com/lf-edge/ekuiper/v2/pkg/cast"
 )
 
@@ -171,11 +175,11 @@ func TestLifecycle(t *testing.T) {
 		// Save for all checkpoints
 		for i, cid := range checkpointIds {
 			for j, opId := range opIds {
-				err := store.SaveState(cid, opId, map[string]interface{}{
+				err := store.SaveFrozenState(cid, opId, mustEncodeState(t, map[string]interface{}{
 					"op": opId,
 					"oi": j,
 					"ci": i,
-				})
+				}))
 				if err != nil {
 					t.Errorf("Save state for rule %s op %s error: %s", ruleId, opId, err)
 					return
@@ -197,20 +201,20 @@ func TestLifecycle(t *testing.T) {
 			t.Errorf("%d.Save checkpoint\n\nresult mismatch:\n\nexp=%#v\n\ngot=%#v\n\n", i, r, result)
 		}
 		// Save additional state but not serialized in checkpoint
-		err = store.SaveState(10000, opIds[1], map[string]interface{}{
+		err = store.SaveFrozenState(10000, opIds[1], mustEncodeState(t, map[string]interface{}{
 			"op": opIds[1],
 			"oi": 1,
 			"ci": 10000,
-		})
+		}))
 		if err != nil {
 			t.Errorf("Save state for rule %s op %s error: %s", ruleId, opIds[1], err)
 			return
 		}
-		err = store.SaveState(10000, opIds[2], map[string]interface{}{
+		err = store.SaveFrozenState(10000, opIds[2], mustEncodeState(t, map[string]interface{}{
 			"op": opIds[2],
 			"oi": 2,
 			"ci": 10000,
-		})
+		}))
 		if err != nil {
 			t.Errorf("Save state for rule %s op %s error: %s", ruleId, opIds[2], err)
 			return
@@ -259,18 +263,492 @@ func TestLifecycle(t *testing.T) {
 	}()
 }
 
+func TestRestoreLegacyCheckpointAndWriteVersion2(t *testing.T) {
+	const (
+		legacyID     = int64(100)
+		checkpointID = int64(101)
+		opID         = "op1"
+	)
+	legacyState := map[string]interface{}{"count": 42, "name": "legacy"}
+	db := &memoryTSKV{}
+	inserted, err := db.Set(legacyID, map[string]interface{}{opID: legacyState})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !inserted {
+		t.Fatal("legacy checkpoint was not inserted")
+	}
+
+	restored := &KVStore{db: db, max: 3, mapStore: &sync.Map{}}
+	if err := restored.restore(); err != nil {
+		t.Fatal(err)
+	}
+	gotState, err := restored.GetOpState(opID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := cast.SyncMapToMap(gotState); !reflect.DeepEqual(legacyState, got) {
+		t.Fatalf("legacy state mismatch: want %#v, got %#v", legacyState, got)
+	}
+
+	nextState := map[string]interface{}{"count": 43, "name": "version2"}
+	if err := restored.SaveFrozenState(checkpointID, opID, mustEncodeState(t, nextState)); err != nil {
+		t.Fatal(err)
+	}
+	if err := restored.SaveCheckpoint(checkpointID); err != nil {
+		t.Fatal(err)
+	}
+	var envelope checkpointEnvelope
+	key, err := restored.db.Last(&envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key != checkpointID {
+		t.Fatalf("checkpoint ID mismatch: want %d, got %d", checkpointID, key)
+	}
+	if envelope.Format != checkpointFormat || envelope.Version != checkpointFormatVersion {
+		t.Fatalf("unexpected envelope: %#v", envelope)
+	}
+	frozen, ok := envelope.Operators[opID]
+	if !ok {
+		t.Fatalf("operator %s not found in envelope", opID)
+	}
+	decoded, err := checkpoint.DecodeState(frozen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(nextState, decoded) {
+		t.Fatalf("version 2 state mismatch: want %#v, got %#v", nextState, decoded)
+	}
+}
+
+func TestLegacyRestoredOperatorStateIsolatedAcrossGetOpState(t *testing.T) {
+	const (
+		checkpointID = int64(102)
+		opID         = "op1"
+	)
+	db := &memoryTSKV{}
+	legacyState := map[string]interface{}{
+		"nested": map[string]interface{}{"count": 1},
+	}
+	inserted, err := db.Set(checkpointID, map[string]interface{}{opID: legacyState})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !inserted {
+		t.Fatal("legacy checkpoint was not inserted")
+	}
+
+	restored := &KVStore{db: db, max: 3, mapStore: &sync.Map{}}
+	if err := restored.restore(); err != nil {
+		t.Fatal(err)
+	}
+	first, err := restored.GetOpState(opID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstNested, _ := first.Load("nested")
+	firstNested.(map[string]interface{})["count"] = 2
+
+	second, err := restored.GetOpState(opID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondNested, _ := second.Load("nested")
+	if got := secondNested.(map[string]interface{})["count"]; got != 1 {
+		t.Fatalf("legacy restore shared nested live state: got %v", got)
+	}
+}
+
+type memoryTSKV struct {
+	last       int64
+	data       map[int64][]byte
+	setStarted chan struct{}
+	allowSet   chan struct{}
+}
+
+func (m *memoryTSKV) Set(key int64, value interface{}) (bool, error) {
+	if m.setStarted != nil {
+		m.setStarted <- struct{}{}
+		<-m.allowSet
+	}
+	if key <= m.last {
+		return false, nil
+	}
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(value); err != nil {
+		return false, err
+	}
+	if m.data == nil {
+		m.data = make(map[int64][]byte)
+	}
+	m.data[key] = buf.Bytes()
+	m.last = key
+	return true, nil
+}
+
+func (m *memoryTSKV) Get(key int64, value interface{}) (bool, error) {
+	data, ok := m.data[key]
+	if !ok {
+		return false, nil
+	}
+	return true, gob.NewDecoder(bytes.NewReader(data)).Decode(value)
+}
+
+func (m *memoryTSKV) Last(value interface{}) (int64, error) {
+	if m.last == 0 {
+		return 0, nil
+	}
+	_, err := m.Get(m.last, value)
+	return m.last, err
+}
+
+func (m *memoryTSKV) Delete(key int64) error {
+	delete(m.data, key)
+	return nil
+}
+
+func (m *memoryTSKV) DeleteBefore(key int64) error {
+	for candidate := range m.data {
+		if candidate < key {
+			delete(m.data, candidate)
+		}
+	}
+	return nil
+}
+
+func (m *memoryTSKV) Close() error {
+	return nil
+}
+
+func (m *memoryTSKV) Drop() error {
+	m.data = nil
+	m.last = 0
+	return nil
+}
+
+func TestSaveFrozenStateConcurrentFirstWriters(t *testing.T) {
+	s := &KVStore{mapStore: &sync.Map{}}
+	const operatorCount = 100
+	errCh := make(chan error, operatorCount)
+	var wg sync.WaitGroup
+	for i := 0; i < operatorCount; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			opID := fmt.Sprintf("op-%d", index)
+			errCh <- s.SaveFrozenState(1, opID, []byte{byte(index)})
+		}(i)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	raw, ok := s.mapStore.Load(int64(1))
+	if !ok {
+		t.Fatal("checkpoint store was not created")
+	}
+	cstore := raw.(*sync.Map)
+	count := 0
+	cstore.Range(func(_, _ interface{}) bool {
+		count++
+		return true
+	})
+	if count != operatorCount {
+		t.Fatalf("operator count mismatch: want %d, got %d", operatorCount, count)
+	}
+	if err := s.SaveFrozenState(1, "op-0", []byte("replacement")); err == nil {
+		t.Fatal("duplicate operator state must be rejected")
+	}
+	original, ok := cstore.Load("op-0")
+	if !ok || !bytes.Equal(original.([]byte), []byte{0}) {
+		t.Fatal("duplicate operator state changed the original snapshot")
+	}
+}
+
+func TestGetOpStateRejectsCorruptFrozenState(t *testing.T) {
+	cstore := &sync.Map{}
+	cstore.Store("op1", []byte("not-gob"))
+	s := &KVStore{
+		mapStore:    &sync.Map{},
+		checkpoints: []int64{1},
+	}
+	s.mapStore.Store(int64(1), cstore)
+	if _, err := s.GetOpState("op1"); err == nil {
+		t.Fatal("corrupt frozen state must fail")
+	}
+}
+
+func TestRestoreRejectsCorruptVersion2OperatorState(t *testing.T) {
+	const (
+		checkpointID = int64(7)
+		opID         = "op1"
+	)
+	db := &memoryTSKV{}
+	inserted, err := db.Set(checkpointID, checkpointEnvelope{
+		Format:  checkpointFormat,
+		Version: checkpointFormatVersion,
+		Operators: map[string][]byte{
+			opID: []byte("not-gob"),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !inserted {
+		t.Fatal("test envelope was not inserted")
+	}
+
+	s := &KVStore{db: db, max: 3, mapStore: &sync.Map{}}
+	err = s.restore()
+	if err == nil {
+		t.Fatal("corrupt operator state must fail restore")
+	}
+	if !strings.Contains(err.Error(), "checkpoint 7") || !strings.Contains(err.Error(), "operator op1") {
+		t.Fatalf("restore error lacks checkpoint/operator context: %v", err)
+	}
+	if len(s.checkpoints) != 0 {
+		t.Fatalf("failed restore published checkpoints: %v", s.checkpoints)
+	}
+	if _, ok := s.mapStore.Load(checkpointID); ok {
+		t.Fatal("failed restore published corrupt checkpoint state")
+	}
+}
+
+func TestRestoredOperatorStateIsolatedAcrossGetOpState(t *testing.T) {
+	const (
+		checkpointID = int64(8)
+		opID         = "op1"
+	)
+	original := map[string]interface{}{
+		"nested": map[string]interface{}{
+			"count": 1,
+		},
+	}
+	db := &memoryTSKV{}
+	inserted, err := db.Set(checkpointID, checkpointEnvelope{
+		Format:  checkpointFormat,
+		Version: checkpointFormatVersion,
+		Operators: map[string][]byte{
+			opID: mustEncodeState(t, original),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !inserted {
+		t.Fatal("test envelope was not inserted")
+	}
+
+	s := &KVStore{db: db, max: 3, mapStore: &sync.Map{}}
+	if err := s.restore(); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := s.GetOpState(opID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstNested, ok := first.Load("nested")
+	if !ok {
+		t.Fatal("first restored state lacks nested value")
+	}
+	firstNested.(map[string]interface{})["count"] = 2
+
+	second, err := s.GetOpState(opID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondNested, ok := second.Load("nested")
+	if !ok {
+		t.Fatal("second restored state lacks nested value")
+	}
+	if got := secondNested.(map[string]interface{})["count"]; got != 1 {
+		t.Fatalf("second restored state observed first context mutation: got %v", got)
+	}
+	secondNested.(map[string]interface{})["count"] = 3
+
+	third, err := s.GetOpState(opID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	thirdNested, ok := third.Load("nested")
+	if !ok {
+		t.Fatal("third restored state lacks nested value")
+	}
+	if got := thirdNested.(map[string]interface{})["count"]; got != 1 {
+		t.Fatalf("third restored state observed earlier context mutation: got %v", got)
+	}
+}
+
+func TestRestoreRejectsInvalidVersion2Envelope(t *testing.T) {
+	tests := []struct {
+		name     string
+		envelope checkpointEnvelope
+	}{
+		{
+			name: "unknown version",
+			envelope: checkpointEnvelope{
+				Format:    checkpointFormat,
+				Version:   checkpointFormatVersion + 1,
+				Operators: map[string][]byte{},
+			},
+		},
+		{
+			name: "nil operators",
+			envelope: checkpointEnvelope{
+				Format:  checkpointFormat,
+				Version: checkpointFormatVersion,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db := &memoryTSKV{}
+			inserted, err := db.Set(1, test.envelope)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !inserted {
+				t.Fatal("test envelope was not inserted")
+			}
+			s := &KVStore{db: db, max: 3, mapStore: &sync.Map{}}
+			if err := s.restore(); err == nil {
+				t.Fatal("invalid version 2 envelope must fail")
+			}
+		})
+	}
+}
+
+func TestSaveCheckpointRejectsDuplicateID(t *testing.T) {
+	db := &memoryTSKV{}
+	s := &KVStore{db: db, max: 3, mapStore: &sync.Map{}}
+	state := mustEncodeState(t, map[string]interface{}{"count": 1})
+	if err := s.SaveFrozenState(1, "op", state); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SaveCheckpoint(1); err != nil {
+		t.Fatal(err)
+	}
+
+	s.mapStore.Delete(int64(1))
+	if err := s.SaveFrozenState(1, "op", state); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SaveCheckpoint(1); err == nil {
+		t.Fatal("duplicate checkpoint ID must fail")
+	}
+}
+
+func TestDiscardFrozenStateRejectsLateSnapshot(t *testing.T) {
+	s := &KVStore{db: &memoryTSKV{}, max: 3, mapStore: &sync.Map{}}
+	if err := s.SaveFrozenState(1, "op1", []byte("first")); err != nil {
+		t.Fatal(err)
+	}
+	s.DiscardFrozenState(1)
+	if _, ok := s.mapStore.Load(int64(1)); ok {
+		t.Fatal("discarded checkpoint remained in memory")
+	}
+	if err := s.SaveFrozenState(1, "op2", []byte("late")); err == nil {
+		t.Fatal("late snapshot for discarded checkpoint must fail")
+	}
+	if _, ok := s.mapStore.Load(int64(1)); ok {
+		t.Fatal("late snapshot recreated a discarded checkpoint")
+	}
+	if err := s.SaveCheckpoint(1); err == nil {
+		t.Fatal("discarded checkpoint must not be persisted")
+	}
+	if s.discardedThrough != 1 {
+		t.Fatalf("discard watermark mismatch: got %d", s.discardedThrough)
+	}
+	if err := s.SaveFrozenState(0, "older", []byte("older")); err == nil {
+		t.Fatal("discard watermark must reject older checkpoints")
+	}
+	if err := s.SaveFrozenState(2, "newer", []byte("newer")); err != nil {
+		t.Fatalf("discard watermark rejected newer checkpoint: %v", err)
+	}
+}
+
+func TestSaveCheckpointAndDiscardAreSerialized(t *testing.T) {
+	db := &memoryTSKV{
+		setStarted: make(chan struct{}),
+		allowSet:   make(chan struct{}),
+	}
+	s := &KVStore{db: db, max: 3, mapStore: &sync.Map{}}
+	if err := s.SaveFrozenState(1, "op", mustEncodeState(t, map[string]interface{}{"count": 1})); err != nil {
+		t.Fatal(err)
+	}
+
+	saveDone := make(chan error, 1)
+	go func() {
+		saveDone <- s.SaveCheckpoint(1)
+	}()
+	<-db.setStarted
+
+	discardStarted := make(chan struct{})
+	discardDone := make(chan struct{})
+	go func() {
+		close(discardStarted)
+		s.DiscardFrozenState(1)
+		close(discardDone)
+	}()
+	<-discardStarted
+	select {
+	case <-discardDone:
+		t.Fatal("discard completed while SaveCheckpoint held the lifecycle lock")
+	default:
+	}
+
+	close(db.allowSet)
+	if err := <-saveDone; err != nil {
+		t.Fatal(err)
+	}
+	<-discardDone
+	if s.discardedThrough != 0 {
+		t.Fatal("discard invalidated a checkpoint that completed first")
+	}
+	if _, ok := s.mapStore.Load(int64(1)); !ok {
+		t.Fatal("discard removed a checkpoint that completed first")
+	}
+}
+
 func mapStoreToMap(sm *sync.Map) map[string]interface{} {
 	m := make(map[string]interface{})
 	sm.Range(func(k interface{}, v interface{}) bool {
 		switch t := v.(type) {
 		case *sync.Map:
 			m[fmt.Sprintf("%v", k)] = mapStoreToMap(t)
+		case *restoredOperatorState:
+			state, err := checkpoint.DecodeState(t.frozen)
+			if err != nil {
+				panic(err)
+			}
+			m[fmt.Sprintf("%v", k)] = state
+		case []byte:
+			state, err := checkpoint.DecodeState(t)
+			if err != nil {
+				panic(err)
+			}
+			m[fmt.Sprintf("%v", k)] = state
 		default:
 			m[fmt.Sprintf("%v", k)] = t
 		}
 		return true
 	})
 	return m
+}
+
+func mustEncodeState(t *testing.T, state map[string]interface{}) []byte {
+	t.Helper()
+	result, err := checkpoint.EncodeState(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
 }
 
 func cleanStateData() {

--- a/internal/topo/state/memory_store.go
+++ b/internal/topo/state/memory_store.go
@@ -1,4 +1,4 @@
-// Copyright 2021 EMQ Technologies Co., Ltd.
+// Copyright 2021-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,6 +27,15 @@ func newMemoryStore() *MemoryStore {
 func (s *MemoryStore) SaveState(_ int64, _ string, _ map[string]interface{}) error {
 	// do nothing
 	return nil
+}
+
+func (s *MemoryStore) SaveFrozenState(_ int64, _ string, _ []byte) error {
+	// do nothing
+	return nil
+}
+
+func (s *MemoryStore) DiscardFrozenState(_ int64) {
+	// do nothing
 }
 
 func (s *MemoryStore) SaveCheckpoint(_ int64) error {

--- a/internal/xsql/collection.go
+++ b/internal/xsql/collection.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 EMQ Technologies Co., Ltd.
+// Copyright 2022-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -215,8 +215,14 @@ func (w *WindowTuples) AddTuple(tuple Row) *WindowTuples {
 
 func (w *WindowTuples) AggregateEval(expr ast.Expr, v CallValuer) []interface{} {
 	var result []interface{}
+	aliases := &transientAliasValuer{}
+	wildcard := &WildcardValuer{}
+	valuers := MultiValuerList{aliases, nil, &WindowRangeValuer{WindowRange: w.WindowRange}, v, wildcard}
 	for _, t := range w.Content {
-		result = append(result, Eval(expr, MultiValuer(t, &WindowRangeValuer{WindowRange: w.WindowRange}, v, &WildcardValuer{t})))
+		aliases.reset()
+		valuers[1] = t
+		wildcard.Data = t
+		result = append(result, Eval(expr, valuers))
 	}
 	return result
 }
@@ -328,8 +334,14 @@ func (s *JoinTuples) Index(i int) Row { return s.Content[i] }
 
 func (s *JoinTuples) AggregateEval(expr ast.Expr, v CallValuer) []interface{} {
 	var result []interface{}
+	aliases := &transientAliasValuer{}
+	wildcard := &WildcardValuer{}
+	valuers := MultiValuerList{aliases, nil, &WindowRangeValuer{WindowRange: s.WindowRange}, v, wildcard}
 	for _, t := range s.Content {
-		result = append(result, Eval(expr, MultiValuer(t, &WindowRangeValuer{WindowRange: s.WindowRange}, v, &WildcardValuer{t})))
+		aliases.reset()
+		valuers[1] = t
+		wildcard.Data = t
+		result = append(result, Eval(expr, valuers))
 	}
 	return result
 }

--- a/internal/xsql/collection_test.go
+++ b/internal/xsql/collection_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 EMQ Technologies Co., Ltd.
+// Copyright 2022-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,8 +21,36 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/lf-edge/ekuiper/v2/pkg/ast"
 	"github.com/lf-edge/ekuiper/v2/pkg/timex"
 )
+
+func TestAggregateEvalDoesNotMutateInputAliasState(t *testing.T) {
+	tuple := &Tuple{Message: Message{"value": 1}}
+	window := &WindowTuples{Content: []Row{tuple}}
+	expr := &ast.FieldRef{
+		Name:       "derived",
+		StreamName: ast.AliasStream,
+		AliasRef: &ast.AliasRef{
+			Expression: &ast.IntegerLiteral{Val: 42},
+		},
+	}
+
+	result := window.AggregateEval(expr, nil)
+	if !reflect.DeepEqual([]interface{}{int64(42)}, result) {
+		t.Fatalf("unexpected aggregate result: %#v", result)
+	}
+	if _, ok := tuple.AliasValue("derived"); ok {
+		t.Fatal("aggregate evaluation cached an alias on the input tuple")
+	}
+
+	tuple.AppendAlias("existing", int64(7))
+	expr.Name = "existing"
+	result = window.AggregateEval(expr, nil)
+	if !reflect.DeepEqual([]interface{}{int64(7)}, result) {
+		t.Fatalf("existing input alias was hidden by transient cache: %#v", result)
+	}
+}
 
 func TestCollectionAgg(t *testing.T) {
 	// broadcast -> range func -> broadcast -> group aggregate -> map

--- a/internal/xsql/gob_register.go
+++ b/internal/xsql/gob_register.go
@@ -1,4 +1,4 @@
-// Copyright 2023 EMQ Technologies Co., Ltd.
+// Copyright 2023-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,4 +28,5 @@ func init() {
 	gob.Register(&JoinTuple{})
 	gob.Register([]any{})
 	gob.Register(&RawTuple{})
+	gob.Register(&SliceTuple{})
 }

--- a/internal/xsql/gob_register_test.go
+++ b/internal/xsql/gob_register_test.go
@@ -1,0 +1,83 @@
+// Copyright 2026 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xsql
+
+import (
+	"bytes"
+	"encoding/gob"
+	"testing"
+	"time"
+
+	"github.com/lf-edge/ekuiper/contract/v2/api"
+	"github.com/stretchr/testify/require"
+
+	topoContext "github.com/lf-edge/ekuiper/v2/internal/topo/context"
+)
+
+// legacyTupleWire mirrors the exported Tuple fields before its tracing context
+// became transient checkpoint state.
+type legacyTupleWire struct {
+	Ctx       api.StreamContext
+	Emitter   string
+	Message   Message
+	Timestamp time.Time
+	Metadata  Metadata
+	Props     map[string]string
+
+	AffiliateRow
+}
+
+func TestTupleGobLegacyCompatibility(t *testing.T) {
+	timestamp := time.UnixMilli(123456789)
+	legacy := &legacyTupleWire{
+		Emitter:   "source",
+		Message:   Message{"id": int64(1)},
+		Timestamp: timestamp,
+		Metadata:  Metadata{"topic": "demo"},
+		Props:     map[string]string{"format": "json"},
+		AffiliateRow: AffiliateRow{
+			CalCols:  map[string]interface{}{"calculated": int64(2)},
+			AliasMap: map[string]interface{}{"alias": "value"},
+		},
+	}
+
+	var legacyBytes bytes.Buffer
+	require.NoError(t, gob.NewEncoder(&legacyBytes).Encode(legacy))
+	var current Tuple
+	require.NoError(t, gob.NewDecoder(&legacyBytes).Decode(&current))
+	require.Nil(t, current.GetTracerCtx())
+	require.Equal(t, legacy.Emitter, current.Emitter)
+	require.Equal(t, legacy.Message, current.Message)
+	require.Equal(t, legacy.Timestamp, current.Timestamp)
+	require.Equal(t, legacy.Metadata, current.Metadata)
+	require.Equal(t, legacy.Props, current.Props)
+	require.Equal(t, legacy.CalCols, current.CalCols)
+	require.Equal(t, legacy.AliasMap, current.AliasMap)
+
+	traceCtx := topoContext.Background()
+	current.SetTracerCtx(traceCtx)
+	var currentBytes bytes.Buffer
+	require.NoError(t, gob.NewEncoder(&currentBytes).Encode(&current))
+	var decodedLegacy legacyTupleWire
+	require.NoError(t, gob.NewDecoder(&currentBytes).Decode(&decodedLegacy))
+	require.Nil(t, decodedLegacy.Ctx)
+	require.Equal(t, current.Emitter, decodedLegacy.Emitter)
+	require.Equal(t, current.Message, decodedLegacy.Message)
+	require.Equal(t, current.Timestamp, decodedLegacy.Timestamp)
+	require.Equal(t, current.Metadata, decodedLegacy.Metadata)
+	require.Equal(t, current.Props, decodedLegacy.Props)
+	require.Equal(t, current.CalCols, decodedLegacy.CalCols)
+	require.Equal(t, current.AliasMap, decodedLegacy.AliasMap)
+}

--- a/internal/xsql/row.go
+++ b/internal/xsql/row.go
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 EMQ Technologies Co., Ltd.
+// Copyright 2022-2026 EMQ Technologies Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -331,7 +331,7 @@ var (
 
 // Tuple The input row, produced by the source
 type Tuple struct {
-	Ctx       api.StreamContext
+	ctx       api.StreamContext
 	Emitter   string
 	Message   Message // the original pointer is immutable & big; may be cloned.
 	Timestamp time.Time
@@ -344,11 +344,11 @@ type Tuple struct {
 }
 
 func (t *Tuple) GetTracerCtx() api.StreamContext {
-	return t.Ctx
+	return t.ctx
 }
 
 func (t *Tuple) SetTracerCtx(ctx api.StreamContext) {
-	t.Ctx = ctx
+	t.ctx = ctx
 }
 
 func (t *Tuple) Created() time.Time {
@@ -535,7 +535,7 @@ func (t *Tuple) AllProps() map[string]string {
 }
 
 func (t *Tuple) AggregateEval(expr ast.Expr, v CallValuer) []interface{} {
-	return []interface{}{Eval(expr, MultiValuer(t, v, &WildcardValuer{t}))}
+	return []interface{}{Eval(expr, MultiValuer(&transientAliasValuer{}, t, v, &WildcardValuer{t}))}
 }
 
 func (t *Tuple) GetTimestamp() time.Time {
@@ -727,15 +727,21 @@ func (jt *JoinTuple) Pick(allWildcard bool, cols [][]string, wildcardEmitters ma
 }
 
 func (jt *JoinTuple) AggregateEval(expr ast.Expr, v CallValuer) []interface{} {
-	return []interface{}{Eval(expr, MultiValuer(jt, v, &WildcardValuer{jt}))}
+	return []interface{}{Eval(expr, MultiValuer(&transientAliasValuer{}, jt, v, &WildcardValuer{jt}))}
 }
 
 // GroupedTuple implementation
 
 func (s *GroupedTuples) AggregateEval(expr ast.Expr, v CallValuer) []interface{} {
 	var result []interface{}
+	aliases := &transientAliasValuer{}
+	wildcard := &WildcardValuer{}
+	valuers := MultiValuerList{aliases, nil, &WindowRangeValuer{WindowRange: s.WindowRange}, v, wildcard}
 	for _, t := range s.Content {
-		result = append(result, Eval(expr, MultiValuer(t, &WindowRangeValuer{WindowRange: s.WindowRange}, v, &WildcardValuer{t})))
+		aliases.reset()
+		valuers[1] = t
+		wildcard.Data = t
+		result = append(result, Eval(expr, valuers))
 	}
 	return result
 }

--- a/internal/xsql/valuer.go
+++ b/internal/xsql/valuer.go
@@ -180,10 +180,47 @@ func (a MultiValuerList) AppendAlias(key string, value interface{}) bool {
 func (a MultiValuerList) AliasValue(key string) (interface{}, bool) {
 	for _, valuer := range a {
 		if vv, ok := valuer.(AliasValuer); ok {
-			return vv.AliasValue(key)
+			if value, found := vv.AliasValue(key); found {
+				return value, true
+			}
 		}
 	}
 	return nil, false
+}
+
+// transientAliasValuer keeps expression aliases local to one evaluation. An
+// aggregate may evaluate rows that are still owned by an upstream window, so
+// caching an alias on those rows would mutate state across task boundaries.
+type transientAliasValuer struct {
+	aliases map[string]interface{}
+}
+
+func (v *transientAliasValuer) Value(key, table string) (interface{}, bool) {
+	if table != "" {
+		return nil, false
+	}
+	return v.AliasValue(key)
+}
+
+func (v *transientAliasValuer) Meta(string, string) (interface{}, bool) {
+	return nil, false
+}
+
+func (v *transientAliasValuer) AliasValue(key string) (interface{}, bool) {
+	value, ok := v.aliases[key]
+	return value, ok
+}
+
+func (v *transientAliasValuer) AppendAlias(key string, value interface{}) bool {
+	if v.aliases == nil {
+		v.aliases = make(map[string]interface{})
+	}
+	v.aliases[key] = value
+	return true
+}
+
+func (v *transientAliasValuer) reset() {
+	clear(v.aliases)
 }
 
 func (a MultiValuerList) FuncValue(key string) (interface{}, bool) {


### PR DESCRIPTION
## Summary
- Capture checkpoint state synchronously at the barrier and persist versioned frozen bytes.
- Isolate restored operator, source, window, and function state object graphs from prior runs.
- Make cancellation and force-save lifecycle handling race-safe without adding per-tuple clones to processor hot paths.

## Why
- Checkpoint encoding previously ran asynchronously against mutable live state, allowing post-barrier mutations to change the snapshot or race with serialization.
- This implements the v2.5 checkpoint snapshot-isolation design tracked in the internal ekwiki plan `issues/ekuiper-checkpoint-state-race/DESIGN-20260724-checkpoint-state-snapshot-isolation.md`.
- The design freezes each task once at its barrier, keeps persistence byte-oriented, and makes ownership explicit at source and operator boundaries.

## Changes In This PR
- Add a versioned checkpoint envelope with legacy checkpoint restore support and independent restored object graphs.
- Freeze task state synchronously, persist frozen bytes asynchronously, and propagate capture/storage failures through DEC terminal signals.
- Serialize source ingestion with barrier capture and reject checkpoints while a source offset is invalid.
- Add an immutable source-offset fast path; random dedup uses append-only or outer-slice copy-on-write state instead of an O(state-size) gob round trip per tuple.
- Preserve window and incremental-window state, timers, pending outputs, and function state across restore without sharing mutable rows.
- Serialize save/discard lifecycle operations, use a bounded discard watermark, and bind force-save completion to its own checkpoint ID.
- Add race, restore, compatibility, lifecycle, and performance regression coverage.

## Notes
- This is a v2.5 breaking storage-format change: v2.5 reads legacy checkpoints, but v2.4 and earlier cannot read a checkpoint after v2.5 has replaced it.
- Normal processor paths do not clone tuples or window rows. Mutable source offsets retain defensive cloning; repository-owned immutable offsets can publish in approximately 70-110 ns with 64 B and 2 allocations, independent of offset size.
- Validation includes targeted race suites and `go test -race -p 1 -tags test ./internal/topo/topotest -count=1`.
