### PR TITLE
fix(logger): emit bootstrap errors to stderr

### DIFF
--- a/internal/conf/logger/logger.go
+++ b/internal/conf/logger/logger.go
@@ -15,7 +15,6 @@
 package logger
 
 import (
-	"io"
 	"os"
 	"strings"
 
@@ -40,7 +39,7 @@ func InitLogger() {
 		return
 	}
 	Log = logrus.New()
-	Log.SetOutput(io.Discard)
+	Log.SetOutput(os.Stderr)
 	filenameHook := filename.NewHook()
 	filenameHook.Field = "file"
 	Log.AddHook(filenameHook)

--- a/internal/conf/logger/logger_test.go
+++ b/internal/conf/logger/logger_test.go
@@ -1,0 +1,27 @@
+// Copyright 2026 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logger
+
+import (
+	"os"
+	"testing"
+)
+
+func TestBootstrapLoggerWritesToStderr(t *testing.T) {
+	InitLogger()
+	if Log.Out != os.Stderr {
+		t.Fatalf("bootstrap logger output is %v, expected os.Stderr", Log.Out)
+	}
+}


### PR DESCRIPTION
## Summary
- Send bootstrap logger output to stderr instead of discarding it
- Preserve early startup errors, such as permission failures while loading kuiper.yaml
- Add a regression test for the bootstrap logger output

## Why
- The bootstrap logger currently discards all output, so failures that happen before the full logger is configured never appear
- Operators then cannot see early errors such as permission failures while loading kuiper.yaml
- Writing bootstrap logs to stderr keeps those errors visible without changing later file/syslog logging

## Changes In This PR
- `internal/conf/logger/logger.go`: set the bootstrap logger output to `os.Stderr`
- `internal/conf/logger/logger_test.go`: assert the bootstrap logger writes to stderr

## Notes
- Behavior change is limited to bootstrap-time log destination. After logger initialization completes, existing file/syslog configuration is unchanged.
