### PR TITLE
fix(pkg/cast): range check string to int casts

### DIFF
--- a/pkg/cast/cast.go
+++ b/pkg/cast/cast.go
@@ -188,7 +188,7 @@ func ToInt8(input interface{}, sn Strictness) (int8, error) {
 		if sn == CONVERT_ALL {
 			v, err := strconv.ParseInt(s, 0, 0)
 			if err == nil {
-				if v > math.MaxInt8 {
+				if v > math.MaxInt8 || v < math.MinInt8 {
 					return 0, fmt.Errorf("value %d is out of int8 range", v)
 				}
 				return int8(v), nil
@@ -243,8 +243,8 @@ func ToInt16(input interface{}, sn Strictness) (int16, error) {
 		if sn == CONVERT_ALL {
 			v, err := strconv.ParseInt(s, 0, 0)
 			if err == nil {
-				if v > math.MaxInt16 {
-					return 0, fmt.Errorf("value %d is out of int32 range", v)
+				if v > math.MaxInt16 || v < math.MinInt16 {
+					return 0, fmt.Errorf("value %d is out of int16 range", v)
 				}
 				return int16(v), nil
 			}
@@ -298,7 +298,7 @@ func ToInt32(input interface{}, sn Strictness) (int32, error) {
 		if sn == CONVERT_ALL {
 			v, err := strconv.ParseInt(s, 0, 0)
 			if err == nil {
-				if v > math.MaxInt32 {
+				if v > math.MaxInt32 || v < math.MinInt32 {
 					return 0, fmt.Errorf("value %d is out of int32 range", v)
 				}
 				return int32(v), nil
@@ -739,6 +739,9 @@ func ToUint32(i interface{}, sn Strictness) (uint32, error) {
 		if sn == CONVERT_ALL {
 			v, err := strconv.ParseUint(s, 0, 64)
 			if err == nil {
+				if v > math.MaxUint32 {
+					return 0, fmt.Errorf("value %d is out of uint32 range", v)
+				}
 				return uint32(v), nil
 			}
 		}

--- a/pkg/cast/cast_test.go
+++ b/pkg/cast/cast_test.go
@@ -283,6 +283,26 @@ func TestToIntResult(t *testing.T) {
 	}
 }
 
+func TestToSmallIntRangeCheck(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{"ToInt8 below range", func() error { _, err := ToInt8("-200", CONVERT_ALL); return err }},
+		{"ToInt8 above range", func() error { _, err := ToInt8("200", CONVERT_ALL); return err }},
+		{"ToInt16 below range", func() error { _, err := ToInt16("-40000", CONVERT_ALL); return err }},
+		{"ToInt16 above range", func() error { _, err := ToInt16("40000", CONVERT_ALL); return err }},
+		{"ToInt32 below range", func() error { _, err := ToInt32("-3000000000", CONVERT_ALL); return err }},
+		{"ToInt32 above range", func() error { _, err := ToInt32("3000000000", CONVERT_ALL); return err }},
+		{"ToUint32 above range", func() error { _, err := ToUint32("5000000000", CONVERT_ALL); return err }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Error(t, tt.run(), "expected an out of range error")
+		})
+	}
+}
+
 func TestToFloatResult(t *testing.T) {
 	tests := []struct {
 		input any


### PR DESCRIPTION
## Description

The `CONVERT_ALL` string paths of the small-integer cast functions in `pkg/cast` silently wrap out-of-range values:

- `ToInt8`, `ToInt16`, `ToInt32` reject values **above** the target type's upper bound but not values **below** the lower bound, so e.g. `ToInt8("-200", CONVERT_ALL)` returned `56` (wrap) and `ToInt16("-40000", ...)` returned `25536`, instead of an error.
- `ToUint32` had **no** range check at all — while its siblings `ToUint8` and `ToUint16` do check — so `ToUint32("5000000000", CONVERT_ALL)` returned `705032704` instead of an error.

Concrete impact: these helpers back data ingestion conversions (e.g. Edgex sink, the tflite/onnx function plugins), where a typo'd or corrupted field value is currently accepted as a wrapped number instead of producing a conversion error.

(Note: the message in `ToInt16` also said "out of int32 range"; corrected to `int16` since that line is touched by this change.)

## Changes

- `pkg/cast/cast.go`: add the missing `v < math.MinIntN` lower-bound checks to `ToInt8`/`ToInt16`/`ToInt32` and the missing `v > math.MaxUint32` upper-bound check to `ToUint32` (string paths only, matching the existing checks' shape).
- `pkg/cast/cast_test.go`: add `TestToSmallIntRangeCheck` covering below-range, above-range, and the previously unchecked `ToUint32` overflow.

## How has this been tested?

Fail-before / pass-after (master @ 7a27fb57):

```
$ go test ./pkg/cast/ -run TestToSmallIntRangeCheck -count=1 -v
# before fix, these subtests FAIL (no error returned):
    --- FAIL: TestToSmallIntRangeCheck/ToInt8_below_range
    --- FAIL: TestToSmallIntRangeCheck/ToInt16_below_range
    --- FAIL: TestToSmallIntRangeCheck/ToInt32_below_range
    --- FAIL: TestToSmallIntRangeCheck/ToUint32_above_range
# after fix:
ok      github.com/lf-edge/ekuiper/v2/pkg/cast
```

Full relevant packages after the fix:

```
$ go test ./pkg/cast/... ./internal/io/edgex/... -count=1
ok      github.com/lf-edge/ekuiper/v2/pkg/cast            1.341s
ok      github.com/lf-edge/ekuiper/v2/internal/io/edgex    0.559s
ok      github.com/lf-edge/ekuiper/v2/internal/io/edgex/client 1.015s
```

`go vet ./pkg/cast/` and `go fmt` clean.

## Behavior change

Out-of-range string inputs to these four functions now return an error (`value %d is out of <type> range`) instead of silently wrapping. Callers already treat a non-nil error from these functions as a conversion failure, so no caller changes are needed.

## AI assistance disclosure

This change was prepared with the assistance of an AI coding agent; the bug, reproduction, fix, and test were all verified locally by me as described above.
