### PR TITLE
fix(pkg/cast): avoid panic on trailing quote

### DIFF
--- a/pkg/cast/time.go
+++ b/pkg/cast/time.go
@@ -349,7 +349,7 @@ func convertFormat(f string) (string, error) {
 		case '\'': // ' (text delimiter)  or '' (real quote)
 
 			// real quote
-			if formatRune[i+1] == r {
+			if i+1 < lenFormat && formatRune[i+1] == r {
 				out += "'"
 				i = i + 1
 				continue

--- a/pkg/cast/time_test.go
+++ b/pkg/cast/time_test.go
@@ -297,6 +297,25 @@ func TestConvertFormat(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "2006-01-02 15:04:05.0000000-0700", s)
 
+	// a single quote at the end of the format is an unterminated text
+	// delimiter: consume it like an unterminated mid-format quote instead
+	// of panicking (matches the lenient behavior of "yyyy'abc" -> "2006abc")
+	s, err = convertFormat("yyyy'")
+	require.NoError(t, err)
+	require.Equal(t, "2006", s)
+
+	s, err = convertFormat("'day 'yyyy")
+	require.NoError(t, err)
+	require.Equal(t, "day 2006", s)
+
+	s, err = convertFormat("yyyy''")
+	require.NoError(t, err)
+	require.Equal(t, "2006'", s)
+
+	s, err = convertFormat("yyyy'abc")
+	require.NoError(t, err)
+	require.Equal(t, "2006abc", s)
+
 	d, err := time.Parse("2006-01-02 15:04:05.0000000-0700", `2024-06-10 05:54:39.6574979-0700`)
 	require.NoError(t, err)
 	require.Equal(t, int64(1718024079657497900), d.UnixNano())


### PR DESCRIPTION
## Description

A time format string ending with a single quote made `convertFormat` panic:

```
convertFormat("yyyy'")
panic: runtime error: index out of range [5] with length 5
```

`convertFormat` is the converter behind `format_time(now(), fmt)` (the format argument is a user string literal) and the SQL sink's datetime format option, so a malformed format string currently crashes the rule instead of producing an error.

## Root cause

In the quote case of `pkg/cast/time.go`, the real-quote lookahead reads `formatRune[i+1]` without checking `i+1 < lenFormat`:

```go
case '\'': // ' (text delimiter)  or '' (real quote)
    // real quote
    if formatRune[i+1] == r {   // panics when the quote is the last rune
```

Every other case in the function bounds-checks its lookahead (`i+j < lenFormat`); only this one does not. When the quote is the last character of the format, `i+1` is out of range.

## Changes

- Add the missing `i+1 < lenFormat` bound check. A trailing single quote now falls through to the text-delimiter branch and is consumed as an unterminated delimiter — the same lenient behavior the function already applies to unterminated quotes in the middle of a format (e.g. `"yyyy'abc"` → `"2006abc"`, matching Java `SimpleDateFormat` semantics this converter mimics).
- Extend `TestConvertFormat` with quote cases: trailing quote (no panic, consumed), quoted text `'day 'yyyy`, escaped quote `yyyy''`, and unterminated mid-format quote.

## How has this been tested?

Fail-before / pass-after (master @ 7a27fb57):

```
$ go test ./pkg/cast/ -run TestConvertFormat -count=1
# before fix:
--- FAIL: TestConvertFormat (0.00s)
panic: runtime error: index out of range [5] with length 5
# after fix:
ok      github.com/lf-edge/ekuiper/v2/pkg/cast
```

Full package after the fix:

```
$ go test ./pkg/cast/... -count=1
ok      github.com/lf-edge/ekuiper/v2/pkg/cast
```

`go vet ./pkg/cast/` and `go fmt` clean.

## Behavior change

None for valid formats. A format ending in a single quote changes from panic to being treated like any other unterminated quote (consumed), instead of crashing the calling rule.

## AI assistance disclosure

This change was prepared with the assistance of an AI coding agent; the bug, reproduction, fix, and test were all verified locally by me as described above.
