### PR TITLE
fix(xsql): reset escape after escaped quote

### DIFF
--- a/internal/xsql/lexical.go
+++ b/internal/xsql/lexical.go
@@ -284,6 +284,8 @@ func (s *Scanner) ScanString(isSingle bool) (tok ast.Token, lit string) {
 			escape = true
 			nextCh := s.read()
 			if nextCh == '\'' && isSingle {
+				// the escaped quote is consumed here, so the escape is complete
+				escape = false
 				s.buf.WriteRune(nextCh)
 			} else {
 				s.buf.WriteRune(ch)

--- a/internal/xsql/parser_test.go
+++ b/internal/xsql/parser_test.go
@@ -3293,6 +3293,19 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		},
 		{
+			s: `SELECT 'a\'' FROM tbl`,
+			stmt: &ast.SelectStatement{
+				Fields: []ast.Field{
+					{
+						Expr:  &ast.StringLiteral{Val: `a'`},
+						Name:  "kuiper_field_0",
+						AName: "",
+					},
+				},
+				Sources: []ast.Source{&ast.Table{Name: "tbl"}},
+			},
+		},
+		{
 			s:    `SELECT "abc' FROM tbl`,
 			stmt: nil,
 			err:  `found "\"abc' FROM tbl", expected expression.`,


### PR DESCRIPTION
## Description

A single-quoted SQL string that ends right after an escaped quote fails to parse:

```sql
SELECT 'a\'' FROM tbl
```

Expected: a string literal `a'`. Actual: the lexer never recognizes the closing quote, consumes the rest of the input, and returns `BADSTRING` at EOF, so the statement fails to parse.

The existing test `SELECT 'a"b\'c' FROM tbl` (string literal `a"b'c`) only works because a plain character follows the escaped quote and resets the escape flag through the default branch.

## Root cause

In `Scanner.ScanString` (`internal/xsql/lexical.go`), the inline handling of an escaped single quote consumes both the backslash and the quote but leaves the `escape` flag set:

```go
} else if ch == '\\' && !escape {
    escape = true
    nextCh := s.read()
    if nextCh == '\'' && isSingle {
        s.buf.WriteRune(nextCh)   // escape stays true here
    } else {
        s.buf.WriteRune(ch)
        s.unread()
    }
}
```

On the next iteration the closing quote is rejected by the `ch == '\'' && !escape` condition, gets written as string content, and the string never terminates.

The flag is needed only while the escape is pending; in this branch both characters of the escape have already been consumed, so the escape is complete.

## Changes

- Reset `escape = false` in the inline escaped-quote branch of `ScanString`.
- Add a parser regression case `SELECT 'a\'' FROM tbl` next to the existing escaped-quote case in `internal/xsql/parser_test.go`.

## How has this been tested?

Fail-before / pass-after (master @ 7a27fb57):

```
$ go test ./internal/xsql/ -run TestParser_ParseStatement -count=1
# before fix:
    --- FAIL: TestParser_ParseStatement/SELECT_'a\''_FROM_tbl
# after fix:
ok      github.com/lf-edge/ekuiper/v2/internal/xsql
```

Full relevant packages after the fix:

```
$ TZ=UTC go test ./internal/xsql/... ./internal/processor/... -count=1
ok      github.com/lf-edge/ekuiper/v2/internal/xsql
ok      github.com/lf-edge/ekuiper/v2/internal/processor/... (all packages)
```

Note: `TestComparison` in `internal/xsql` fails on this machine regardless of this change when the local timezone is not UTC (it compares against UTC-rendered times); verified on clean master with `TZ=Asia/Shanghai`, passes with `TZ=UTC` (matching CI).

`gofmt` clean for the touched files. (`go vet ./internal/xsql/` reports a pre-existing, unrelated copylocks finding in `row.go:187` that also appears on clean master.)

## AI assistance disclosure

This change was prepared with the assistance of an AI coding agent; the bug, reproduction, fix, and test were all verified locally by me as described above.
