### PR TITLE
chore: pin Bullseye APT snapshot

### DIFF
--- a/.github/dockerfile/Dockerfile.debian
+++ b/.github/dockerfile/Dockerfile.debian
@@ -17,10 +17,19 @@ FROM debian:bullseye
 
 ARG GO_VERSION
 ARG DEBIAN_FRONTEND="noninteractive"
+ARG DEBIAN_SNAPSHOT="20260831T000000Z"
 
-RUN apt-get update -y \
+## Bullseye reached EOL on 2026-08-31. Pin APT to its final snapshot so that
+## package indexes and package files cannot get out of sync as mirrors retire it.
+RUN printf '%s\n' \
+        "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/ bullseye main" \
+        "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/${DEBIAN_SNAPSHOT}/ bullseye-updates main" \
+        "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/${DEBIAN_SNAPSHOT}/ bullseye-security main" \
+        > /etc/apt/sources.list \
+    && apt-get update -y \
     && apt-get install -y make cmake wget git curl procps zip libucl-dev zlib1g-dev \
-    pkg-config libczmq-dev build-essential debhelper jq zip
+        pkg-config libczmq-dev build-essential debhelper jq zip \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN case $(dpkg --print-architecture) in \
         arm|armhf|armv7) \


### PR DESCRIPTION
## Summary
- Pin Debian Bullseye APT repositories to the final pre-EOL snapshot.
- Keep the Bullseye/glibc build baseline while making package installation reproducible.
- Remove downloaded APT indexes after dependency installation.

## Why
- The scheduled base-image workflow failed because Bullseye security indexes referenced package files that had already been removed from the live mirror: https://github.com/lf-edge/ekuiper/actions/runs/34068821474
- Bullseye reached end of LTS on 2026-08-31, so the live repositories can no longer be relied on for consistent package availability. A dated Debian Snapshot keeps the indexes and packages aligned.

## Changes In This PR
- Add `DEBIAN_SNAPSHOT=20260831T000000Z` to `.github/dockerfile/Dockerfile.debian`.
- Replace the live Bullseye, Bullseye updates, and Bullseye security sources with their matching Snapshot URLs.
- Disable `Valid-Until` checking for the immutable archived metadata.

## Notes
- The base image remains Debian Bullseye to preserve the existing glibc compatibility baseline.
- Snapshot packages are immutable and will not receive newer Debian security updates.
- Remote multi-architecture validation: https://github.com/lf-edge/ekuiper/actions/runs/34071216042