### PR TITLE
chore(ci): pin gocovmerge for go1.25

### DIFF
--- a/.github/workflows/run_test_case.yaml
+++ b/.github/workflows/run_test_case.yaml
@@ -64,7 +64,13 @@ jobs:
           sudo ./install.sh
 
       - name: Install Merge Tool
-        run: go install github.com/wadey/gocovmerge@latest
+        env:
+          GOWORK: off
+        run: |
+          mkdir -p /tmp/gocovmerge && cd /tmp/gocovmerge
+          go mod init tmpinstall 2>/dev/null || true
+          go get github.com/wadey/gocovmerge@v0.0.0-20160331181800-b5bfa59ec0ad golang.org/x/tools@v0.49.0
+          GOBIN=$HOME/go/bin go install github.com/wadey/gocovmerge
 
       - name: Run test case
         run: |


### PR DESCRIPTION
## Summary
- Pin gocovmerge install to a fixed commit and golang.org/x/tools to v0.49.0.
- Run the install outside the workspace (GOWORK=off) via a temp module.

## Why
- Fixes CI failure in run_unit_tests / Install Merge Tool (actions run 34230763521).
- `go install github.com/wadey/gocovmerge@latest` now resolves x/tools to v0.50.0, which requires go >= 1.26.0 while CI runs go 1.25.4, so the step exits 1.
- v0.49.0 is the last x/tools release supporting go 1.25.

## Changes In This PR
- Updated `.github/workflows/run_test_case.yaml`: replaced floating `@latest` install with pinned temp-module install.
- Installs binary to $HOME/go/bin/gocovmerge as before, no change to later merge step.

## Notes
- Verified YAML parses and the pinned install builds gocovmerge successfully.
- No runtime code change, CI only.