### PR TITLE
fix(sql): retry connections after fail (#4128)

### DIFF
--- a/extensions/impl/sql/client/client.go
+++ b/extensions/impl/sql/client/client.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/lf-edge/ekuiper/contract/v2/api"
 
+	"github.com/lf-edge/ekuiper/v2/pkg/errorx"
 	"github.com/lf-edge/ekuiper/v2/pkg/modules"
 )
 
@@ -64,17 +65,16 @@ func (s *SQLConnection) Dial(ctx api.StreamContext) error {
 func (s *SQLConnection) Reconnect() error {
 	s.Lock()
 	defer s.Unlock()
-	if err := s.db.Ping(); err == nil {
-		return nil
+	if s.db != nil {
+		if err := s.db.Ping(); err == nil {
+			return nil
+		}
+		_ = s.db.Close()
 	}
-	oldDB := s.db
-	oldDB.Close()
-	db, err := openDB(s.url)
-	if err != nil {
+	if err := s.dial(nil); err != nil {
 		return fmt.Errorf("reconnect sql err:%v", err)
 	}
-	s.db = db
-	return s.db.Ping()
+	return nil
 }
 
 func (s *SQLConnection) GetDB() *sql.DB {
@@ -106,7 +106,9 @@ func (s *SQLConnection) Close(ctx api.StreamContext) error {
 		return nil
 	}
 	ctx.GetLogger().Infof("close db with url:%v", s.url)
-	s.db.Close()
+	if s.db != nil {
+		_ = s.db.Close()
+	}
 	s.closed = true
 	return nil
 }
@@ -120,6 +122,12 @@ func (s *SQLConnection) dial(ctx api.StreamContext) error {
 	if err != nil {
 		return fmt.Errorf("create connection err:%v", err)
 	}
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		// A database URL can be syntactically valid while the database is
+		// temporarily unreachable. Let the connection pool retry this case.
+		return errorx.NewIOErr(fmt.Sprintf("create connection err:%v", err))
+	}
 	s.db = db
-	return s.db.Ping()
+	return nil
 }

--- a/extensions/impl/sql/client/client_test.go
+++ b/extensions/impl/sql/client/client_test.go
@@ -51,3 +51,29 @@ func TestSQLClient(t *testing.T) {
 	require.NoError(t, conn.Ping(ctx))
 	conn.Close(ctx)
 }
+
+func TestSQLReconnectFailureKeepsDBHandle(t *testing.T) {
+	serverPort := 33063
+	s, err := testx.SetupEmbeddedMysqlServer(address, serverPort)
+	require.NoError(t, err)
+	defer s.Close()
+
+	ctx := mockContext.NewMockContext("1", "2")
+	conn := CreateConnection(ctx)
+	require.NoError(t, conn.Provision(ctx, "test", map[string]any{
+		"dburl": fmt.Sprintf("mysql://root:@%v:%v/test", address, serverPort),
+	}))
+	require.NoError(t, conn.Dial(ctx))
+	sconn := conn.(*SQLConnection)
+
+	// Simulate a runtime disconnect and make the replacement endpoint fail.
+	// The second consumer shares the same SQLConnection instance.
+	_ = sconn.db.Close()
+	sconn.url = fmt.Sprintf("mysql://root:@%v:%v/test", address, serverPort+1)
+
+	require.Error(t, sconn.Reconnect())
+	sharedDB := sconn.GetDB()
+	require.NotNil(t, sharedDB)
+	_, err = sharedDB.Query("select 1")
+	require.Error(t, err)
+}

--- a/extensions/impl/sql/source_test.go
+++ b/extensions/impl/sql/source_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/lf-edge/ekuiper/v2/extensions/impl/sql/testx"
 	"github.com/lf-edge/ekuiper/v2/internal/topo/context"
 	"github.com/lf-edge/ekuiper/v2/pkg/connection"
+	"github.com/lf-edge/ekuiper/v2/pkg/errorx"
 	mockContext "github.com/lf-edge/ekuiper/v2/pkg/mock/context"
 	"github.com/lf-edge/ekuiper/v2/pkg/modules"
 	"github.com/lf-edge/ekuiper/v2/pkg/store"
@@ -155,8 +156,7 @@ func TestSQLConnectionConnect(t *testing.T) {
 	sqlSource.Close(ctx)
 }
 
-func TestSQLConnectionErr(t *testing.T) {
-	connection.InitConnectionManager4Test()
+func TestSQLConnectionNetworkErrorIsRetryable(t *testing.T) {
 	ctx := mockContext.NewMockContext("1", "2")
 	props := map[string]interface{}{
 		"interval": "1s",
@@ -165,11 +165,52 @@ func TestSQLConnectionErr(t *testing.T) {
 			"templateSql": "select a,b from t",
 		},
 	}
-	sqlSource := GetSource()
-	require.NoError(t, sqlSource.Provision(ctx, props))
-	require.Error(t, sqlSource.Connect(ctx, func(status string, message string) {
-		// do nothing
-	}))
+	conn := client.CreateConnection(ctx)
+	require.NoError(t, conn.Provision(ctx, "sql-network-error", props))
+	err := conn.Dial(ctx)
+	require.Error(t, err)
+	require.True(t, errorx.IsIOError(err))
+	require.Nil(t, conn.(*client.SQLConnection).GetDB())
+}
+
+func TestSQLNamedConnectionReconnectAfterStartupFailure(t *testing.T) {
+	connection.InitConnectionManager4Test()
+	ctx := mockContext.NewMockContext("1", "2")
+	port := 33062
+	props := map[string]any{
+		"dburl": fmt.Sprintf("mysql://root:@%v:%v/test", address, port),
+	}
+
+	cw, err := connection.CreateNamedConnection(ctx, "sql-reconnect", "sql", props)
+	require.NoError(t, err)
+
+	// Ensure the first dial observes the unavailable database before it is
+	// started. The connection wrapper must remain retryable instead of caching
+	// the failed result.
+	time.Sleep(200 * time.Millisecond)
+	s, err := testx.SetupEmbeddedMysqlServer(address, port)
+	require.NoError(t, err)
+	defer func() {
+		s.Close()
+		require.NoError(t, connection.DropNameConnection(ctx, "sql-reconnect"))
+	}()
+
+	connected := make(chan error, 1)
+	go func() {
+		conn, err := cw.Wait(ctx)
+		if conn == nil {
+			connected <- err
+			return
+		}
+		connected <- conn.Ping(ctx)
+	}()
+
+	select {
+	case err := <-connected:
+		require.NoError(t, err)
+	case <-time.After(15 * time.Second):
+		t.Fatal("named SQL connection did not reconnect after database recovery")
+	}
 }
 
 func TestSQLSourceRewind(t *testing.T) {

--- a/extensions/impl/sql/source_test.go
+++ b/extensions/impl/sql/source_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dolthub/go-mysql-server/server"
 	"github.com/lf-edge/ekuiper/contract/v2/api"
 	"github.com/pingcap/failpoint"
 	"github.com/stretchr/testify/require"
@@ -310,24 +311,32 @@ func TestSQLReconnect(t *testing.T) {
 	}
 	sqlSource := GetSource()
 	require.NoError(t, sqlSource.Provision(ctx, props))
-	require.Error(t, sqlSource.Connect(ctx, func(status string, message string) {
+
+	// SQL connections now retry initial network failures in the connection
+	// pool. Start the database after Connect begins and verify that Connect
+	// returns once the connection is recovered.
+	serverReady := make(chan struct {
+		server *server.Server
+		err    error
+	}, 1)
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		s, err := testx.SetupEmbeddedMysqlServer(address, port)
+		serverReady <- struct {
+			server *server.Server
+			err    error
+		}{server: s, err: err}
+	}()
+
+	require.NoError(t, sqlSource.Connect(ctx, func(status string, message string) {
 		// do nothing
 	}))
+	result := <-serverReady
+	require.NoError(t, result.err)
+	defer result.server.Close()
+
 	sqlConnector, ok := sqlSource.(*SQLSourceConnector)
 	require.True(t, ok)
-	sqlConnector.queryData(ctx, time.Now(), func(ctx api.StreamContext, data any, meta map[string]any, ts time.Time) {}, func(ctx api.StreamContext, err error) {})
-	require.True(t, sqlConnector.needReconnect)
-
-	sqlConnector.queryData(ctx, time.Now(), func(ctx api.StreamContext, data any, meta map[string]any, ts time.Time) {}, func(ctx api.StreamContext, err error) {
-		require.Error(t, err)
-	})
-	require.True(t, sqlConnector.needReconnect)
-
-	// start server then reconnect
-	s, err := testx.SetupEmbeddedMysqlServer(address, port)
-	require.NoError(t, err)
-	defer s.Close()
-	sqlConnector.queryData(ctx, time.Now(), func(ctx api.StreamContext, data any, meta map[string]any, ts time.Time) {}, func(ctx api.StreamContext, err error) {})
 	require.False(t, sqlConnector.needReconnect)
 }
 


### PR DESCRIPTION
## Problem

When the database referenced by a SQL `connectionSelector` is temporarily unreachable during rule startup, the initial SQL connection attempt returns the raw database driver
  error.

The connection pool only retries errors marked as `errorx.IOErr`, so the failure is treated as permanent. The failed result is then cached in the `ConnWrapper`, causing subsequent
requests using the same connection ID to return the same error. Creating a new connection is currently required to recover.

  ## Fix

- Mark SQL connection and ping failures as retryable `errorx.IOErr` errors.
  - Close failed `sql.DB` instances instead of retaining them.
  - Improve nil safety in SQL `Reconnect()` and `Close()`.
- Update the existing network error test to verify retryable error handling.
- Add an embedded MySQL integration test to verify that the same named connection ID automatically reconnects after the database becomes available.

  ## Tests

  ```bash
  go test ./extensions/impl/sql/...

  go test -tags=mysql_integration_test ./extensions/impl/sql \
-run
'TestSQLConnectionNetworkErrorIsRetryable|TestSQLNamedConnectionReconnectAfterStartupFailure'

  The integration test verifies that:

1. A named SQL connection is created while the database is unavailable.
  2. The initial connection attempt fails.
  3. The embedded MySQL server is started.
4. The original connection automatically reconnects without creating a new connection.

---------