### PR TITLE
fix(log): avoid oversized rule parse errors

### DIFF
--- a/internal/processor/rule.go
+++ b/internal/processor/rule.go
@@ -16,6 +16,7 @@ package processor
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -165,8 +166,14 @@ func (p *RuleProcessor) GetRuleByJsonValidated(id, ruleJson string) (*def.Rule, 
 		Options:   clone(opt),
 		Id:        id,
 	}
-	if err := json.Unmarshal(cast.StringToBytes(ruleJson), &rule); err != nil {
-		return nil, fmt.Errorf("Parse rule %s error : %s.", ruleJson, err)
+	ruleBytes := cast.StringToBytes(ruleJson)
+	if err := json.Unmarshal(ruleBytes, &rule); err != nil {
+		fingerprint := fmt.Sprintf("bytes=%d, sha256=%x", len(ruleBytes), sha256.Sum256(ruleBytes))
+		var syntaxErr *json.SyntaxError
+		if errors.As(err, &syntaxErr) {
+			fingerprint += fmt.Sprintf(", offset=%d", syntaxErr.Offset)
+		}
+		return nil, fmt.Errorf("Parse rule %s error (%s): %s.", id, fingerprint, err)
 	}
 	if rule.Options == nil {
 		rule.Options = &opt

--- a/internal/processor/rule_test.go
+++ b/internal/processor/rule_test.go
@@ -15,6 +15,9 @@
 package processor
 
 import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -221,6 +224,17 @@ func TestRuleValidation(t *testing.T) {
 			require.EqualError(t, e, tt.err)
 		})
 	}
+}
+
+func TestParseLargeRuleDoesNotIncludeInputInError(t *testing.T) {
+	ruleJSON := `{"id":"cold","sql":"` + strings.Repeat("field,", 50_000) + "\x02" + `"}`
+	p := NewRuleProcessor()
+	_, err := p.GetRuleByJsonValidated("cold", ruleJSON)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("bytes=%d, sha256=%x", len(ruleJSON), sha256.Sum256([]byte(ruleJSON))))
+	require.Contains(t, err.Error(), "offset=")
+	require.NotContains(t, err.Error(), strings.Repeat("field,", 10))
+	require.Less(t, len(err.Error()), 1024)
 }
 
 func TestAllRules(t *testing.T) {

--- a/internal/server/rule_manager_test.go
+++ b/internal/server/rule_manager_test.go
@@ -15,6 +15,8 @@
 package server
 
 import (
+	"crypto/sha256"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,7 +33,7 @@ import (
 func TestErrors(t *testing.T) {
 	// update invalid rule
 	err := registry.UpsertRule("test", "selectabc")
-	assert.EqualError(t, err, "Invalid rule json: Parse rule selectabc error : invalid character 's' looking for beginning of value.")
+	assert.EqualError(t, err, fmt.Sprintf("Invalid rule json: Parse rule test error (bytes=9, sha256=%x, offset=1): invalid character 's' looking for beginning of value.", sha256.Sum256([]byte("selectabc"))))
 	err = registry.UpsertRule("test", `{"id":"test","sql":"SELECT * FROM demo","actions":[{"log":{}}]}`)
 	assert.EqualError(t, err, "fail to get stream demo, please check if stream is created")
 	// delete rule, no id

--- a/internal/xsql/stmtx.go
+++ b/internal/xsql/stmtx.go
@@ -15,6 +15,7 @@
 package xsql
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -50,10 +51,10 @@ func GetStatementFromSql(sql string) (stmt *ast.SelectStatement, err error) {
 	}()
 	parser := NewParser(strings.NewReader(sql))
 	if stmt, err := Language.Parse(parser); err != nil {
-		return nil, fmt.Errorf("Parse SQL %s error: %s.", sql, err)
+		return nil, fmt.Errorf("Parse SQL error (bytes=%d, sha256=%x): %s.", len(sql), sha256.Sum256(cast.StringToBytes(sql)), err)
 	} else {
 		if r, ok := stmt.(*ast.SelectStatement); !ok {
-			return nil, fmt.Errorf("SQL %s is not a select statement.", sql)
+			return nil, fmt.Errorf("SQL is not a select statement (bytes=%d, sha256=%x).", len(sql), sha256.Sum256(cast.StringToBytes(sql)))
 		} else {
 			return r, nil
 		}

--- a/internal/xsql/stmtx_test.go
+++ b/internal/xsql/stmtx_test.go
@@ -1,0 +1,33 @@
+// Copyright 2026 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xsql
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseLargeSQLDoesNotIncludeInputInError(t *testing.T) {
+	sql := "SELECT " + strings.Repeat("field,", 50_000) + " FROM"
+	_, err := GetStatementFromSql(sql)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("bytes=%d, sha256=%x", len(sql), sha256.Sum256([]byte(sql))))
+	require.NotContains(t, err.Error(), strings.Repeat("field,", 10))
+	require.Less(t, len(err.Error()), 1024)
+}


### PR DESCRIPTION
## Summary
- Stop embedding complete SQL and rule JSON payloads in parser errors.
- Report input byte length and SHA-256 fingerprint while preserving the parser cause.
- Report the JSON syntax error offset when available.
- Add regression tests with cold-rule-sized invalid inputs.

## Why
- Large cold rules can contain hundreds of KB of SQL. Embedding the complete input in an error can exceed the Unix datagram limit, causing syslog to drop the only log that contains the startup failure reason.
- A compact fingerprint keeps errors actionable and allows persisted content to be compared with the module definition without sending the full rule through syslog.

## Changes In This PR
- Update SQL parse and non-SELECT errors in `internal/xsql/stmtx.go` to include only byte length, SHA-256, and the parser cause.
- Update rule JSON parse errors in `internal/processor/rule.go` to include rule ID, byte length, SHA-256, JSON offset, and the decoder cause.
- Add large-input regression tests and update the affected server error assertion.

## Example
For this malformed SQL:

```sql
SELECT temperature, humidity
FROM spi_1000ms_stream
WHERE
```

Before this PR, the complete SQL was embedded in the log:

```text
<3>2026-09-09 16:54:48 +0800 UTC localhost kuiper: level=error msg="Rule cold start failed: Parse SQL SELECT temperature, humidity\nFROM spi_1000ms_stream\nWHERE error: found \"EOF\", expected expression.." file="server/rule_manager.go:214"
```

After this PR, the same failure is logged as:

```text
<3>2026-09-09 16:54:48 +0800 UTC localhost kuiper: level=error msg="Rule cold start failed: Parse SQL error (bytes=57, sha256=9f97f7a59d79e27f86dad6fac66802d11720f1a2c55dde20ef181c5606eded06): found \"EOF\", expected expression.." file="server/rule_manager.go:214"
```

For a cold rule containing hundreds of KB of SQL, the old format grows by the full SQL size and can exceed the Unix datagram limit. The new format stays bounded while retaining the parser cause and a fingerprint of the exact input.

## Notes
- No storage, planner, state-machine, or syslog behavior changes are included.
- Validation: `TZ=UTC go test ./internal/xsql`; `TZ=UTC go test ./internal/processor`; `TZ=UTC go test ./internal/server -run ^TestErrors$ -count=1`.