### PR TITLE
fix(conn): clean up when removing connections

### DIFF
--- a/pkg/connection/cancel_test.go
+++ b/pkg/connection/cancel_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 EMQ Technologies Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package connection
+
+import (
+	stdContext "context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lf-edge/ekuiper/contract/v2/api"
+	"github.com/stretchr/testify/require"
+
+	"github.com/lf-edge/ekuiper/v2/internal/topo/context"
+	"github.com/lf-edge/ekuiper/v2/pkg/errorx"
+	"github.com/lf-edge/ekuiper/v2/pkg/modules"
+)
+
+type pendingConnection struct {
+	mockConnection
+	started chan struct{}
+	release chan struct{}
+	closed  chan struct{}
+	once    sync.Once
+	retry   bool
+}
+
+func (c *pendingConnection) Dial(ctx api.StreamContext) error {
+	c.once.Do(func() { close(c.started) })
+	if c.retry {
+		return errorx.NewIOErr("not available")
+	}
+	<-c.release
+	return nil
+}
+
+func (c *pendingConnection) Close(ctx api.StreamContext) error {
+	close(c.closed)
+	return nil
+}
+
+func TestRemovePendingNamedConnection(t *testing.T) {
+	for _, operation := range []string{"drop", "update"} {
+		for _, retry := range []bool{true, false} {
+			name := "inflight"
+			if retry {
+				name = "retry"
+			}
+			t.Run(operation+"/"+name, func(t *testing.T) {
+				require.NoError(t, InitConnectionManager4Test())
+				ctx, cancel := context.Background().WithCancel()
+				defer cancel()
+				conn := &pendingConnection{
+					started: make(chan struct{}), release: make(chan struct{}),
+					closed: make(chan struct{}), retry: retry,
+				}
+				modules.RegisterConnection("pending", func(api.StreamContext) modules.Connection { return conn })
+				cw, err := CreateNamedConnection(ctx, "pending", "pending", nil)
+				require.NoError(t, err)
+				select {
+				case <-conn.started:
+				case <-time.After(2 * time.Second):
+					t.Fatal("connection did not start")
+				}
+				require.False(t, cw.IsInitialized())
+				if operation == "update" {
+					replacement, err := UpdateConnection(ctx, "pending", "mock", nil)
+					require.NoError(t, err)
+					_, err = replacement.Wait(ctx)
+					require.NoError(t, err)
+					require.True(t, checkConn("pending"))
+					require.NoError(t, DropNameConnection(ctx, "pending"))
+				} else {
+					require.NoError(t, DropNameConnection(ctx, "pending"))
+				}
+				close(conn.release)
+				require.False(t, checkConn("pending"))
+				select {
+				case <-conn.closed:
+				case <-time.After(2 * time.Second):
+					t.Fatal("deleted connection was not closed")
+				}
+				_, err = cw.Wait(ctx)
+				require.ErrorIs(t, err, stdContext.Canceled)
+				require.NoError(t, ctx.Err())
+			})
+		}
+	}
+}

--- a/pkg/connection/conn.go
+++ b/pkg/connection/conn.go
@@ -38,24 +38,29 @@ type ConnWrapper struct {
 	cancel      stdContext.CancelFunc
 }
 
-// close cancels pending retries and also closes a connection whose Dial finishes
-// after it has been removed from the pool.
-func (cw *ConnWrapper) close(ctx api.StreamContext) {
+// cancelAndClose cancels pending retries and closes the connection once Dial returns.
+// Dial must honor context cancellation for prompt cleanup; otherwise cleanup waits
+// for the in-flight call to finish.
+func (cw *ConnWrapper) cancelAndClose(ctx api.StreamContext) {
 	cw.cancel()
 	cleanup := func() {
-		<-cw.readCh
 		cw.l.RLock()
 		conn := cw.conn
 		cw.l.RUnlock()
 		if conn != nil {
-			conn.Close(ctx)
+			if err := conn.Close(ctx); err != nil {
+				ctx.GetLogger().Warnf("failed to close connection %s: %v", cw.ID, err)
+			}
 		}
 	}
 	select {
 	case <-cw.readCh:
 		cleanup()
 	default:
-		go cleanup()
+		go func() {
+			<-cw.readCh
+			cleanup()
+		}()
 	}
 }
 

--- a/pkg/connection/conn.go
+++ b/pkg/connection/conn.go
@@ -15,6 +15,7 @@
 package connection
 
 import (
+	stdContext "context"
 	"sync"
 	"sync/atomic"
 
@@ -34,6 +35,28 @@ type ConnWrapper struct {
 	l           syncx.RWMutex
 	readCh      chan struct{}
 	detachCh    chan struct{}
+	cancel      stdContext.CancelFunc
+}
+
+// close cancels pending retries and also closes a connection whose Dial finishes
+// after it has been removed from the pool.
+func (cw *ConnWrapper) close(ctx api.StreamContext) {
+	cw.cancel()
+	cleanup := func() {
+		<-cw.readCh
+		cw.l.RLock()
+		conn := cw.conn
+		cw.l.RUnlock()
+		if conn != nil {
+			conn.Close(ctx)
+		}
+	}
+	select {
+	case <-cw.readCh:
+		cleanup()
+	default:
+		go cleanup()
+	}
 }
 
 func (cw *ConnWrapper) setConn(conn modules.Connection, err error) {
@@ -63,10 +86,12 @@ func (cw *ConnWrapper) IsInitialized() bool {
 }
 
 func newConnWrapper(ctx api.StreamContext, meta *Meta) *ConnWrapper {
+	ctx, cancel := ctx.WithCancel()
 	cw := &ConnWrapper{
 		ID:       meta.ID,
 		readCh:   make(chan struct{}),
 		detachCh: make(chan struct{}),
+		cancel:   cancel,
 	}
 	go func() {
 		conn, err := createConnection(ctx, meta)

--- a/pkg/connection/pool.go
+++ b/pkg/connection/pool.go
@@ -263,12 +263,7 @@ func dropNameConnection(ctx api.StreamContext, selId string) error {
 	if err != nil {
 		return fmt.Errorf("drop connection %s failed, err:%v", selId, err)
 	}
-	if meta.cw.IsInitialized() {
-		conn, err := meta.cw.Wait(ctx)
-		if conn != nil && err == nil {
-			conn.Close(ctx)
-		}
-	}
+	meta.cw.close(ctx)
 	delete(globalConnectionManager.connectionPool, selId)
 	return nil
 }
@@ -397,7 +392,7 @@ func createConnection(connCtx api.StreamContext, meta *Meta) (modules.Connection
 	err = backoff.Retry(func() error {
 		select {
 		case <-connCtx.Done():
-			return nil
+			return backoff.Permanent(connCtx.Err())
 		default:
 		}
 		meta.NotifyStatus(api.ConnectionConnecting, "")
@@ -421,7 +416,10 @@ func createConnection(connCtx api.StreamContext, meta *Meta) (modules.Connection
 			return err
 		}
 		return backoff.Permanent(err)
-	}, NewExponentialBackOff())
+	}, backoff.WithContext(NewExponentialBackOff(), connCtx))
+	if connCtx.Err() != nil {
+		return conn, connCtx.Err()
+	}
 	return conn, err
 }
 

--- a/pkg/connection/pool.go
+++ b/pkg/connection/pool.go
@@ -263,7 +263,7 @@ func dropNameConnection(ctx api.StreamContext, selId string) error {
 	if err != nil {
 		return fmt.Errorf("drop connection %s failed, err:%v", selId, err)
 	}
-	meta.cw.close(ctx)
+	meta.cw.cancelAndClose(ctx)
 	delete(globalConnectionManager.connectionPool, selId)
 	return nil
 }
@@ -362,6 +362,7 @@ func detachConnection(ctx api.StreamContext, conId string) error {
 		if conId != refId {
 			conf.Log.Infof("action=close_connection connId=%s type=%s connectionKey=%s rule=%s op=%s reason=zero_ref", conId, meta.Typ, conId, ctx.GetRuleId(), ctx.GetOpId())
 		}
+		// TODO: cancel pending retries on anonymous connections as well.
 		close(meta.cw.detachCh)
 		conn, err := meta.cw.Wait(ctx)
 		if conn != nil && err == nil {


### PR DESCRIPTION
Fixes #4130.

Deleting or updating a named connection while its initial Dial is retrying removes it from the pool but leaves the retry running. A later successful Dial then creates an orphan connection.

Give each wrapper a cancellable context and cancel it on removal. The backoff now observes cancellation, and cleanup closes the connection even when an in-flight Dial finishes after removal. Cancellation is returned as an error; the parent context and replacement connection remain usable.

Tests cover deletion and replacement during retries and during a Dial that succeeds after removal. The original two deletion cases fail before the fix. With failpoints enabled, `go test -race ./pkg/connection -count=1` passes; the four regression cases also pass with `-race -count=20`. `go vet ./pkg/connection` passes. Tested on Windows with Go 1.27.1; full-repository lint and Linux FVT were not run.