### PR TITLE
fix(xsql): guard empty join lookup

### DIFF
--- a/internal/xsql/row.go
+++ b/internal/xsql/row.go
@@ -601,6 +601,9 @@ func (jt *JoinTuple) AddTuples(tuples []Row) {
 
 func (jt *JoinTuple) doGetValue(key, table string, isVal bool) (interface{}, bool) {
 	tuples := jt.Tuples
+	if len(tuples) == 0 {
+		return nil, false
+	}
 	if table == "" {
 		if len(tuples) > 1 {
 			for _, tuple := range tuples { // TODO support key without modifier?

--- a/internal/xsql/row_test.go
+++ b/internal/xsql/row_test.go
@@ -24,6 +24,32 @@ import (
 	"github.com/lf-edge/ekuiper/v2/pkg/timex"
 )
 
+func TestJoinTupleLookupAfterPick(t *testing.T) {
+	jt := &JoinTuple{Tuples: []Row{
+		&Tuple{Emitter: "sensor", Message: Message{"temperature": 20}},
+	}}
+	jt.Set("selected", 1)
+	jt.Pick(false, [][]string{{"selected", ""}}, nil, nil, false)
+	if len(jt.Tuples) != 0 {
+		t.Fatal("projection should retain only the calculated field")
+	}
+	if value, ok := jt.Value("selected", ""); !ok || value != 1 {
+		t.Fatalf("calculated field = %v, %v; want 1, true", value, ok)
+	}
+	for _, table := range []string{"", "sensor"} {
+		t.Run("value/"+table, func(t *testing.T) {
+			if value, ok := jt.Value("temperature", table); ok || value != nil {
+				t.Fatalf("discarded field = %v, %v; want nil, false", value, ok)
+			}
+		})
+		t.Run("metadata/"+table, func(t *testing.T) {
+			if value, ok := jt.Meta("topic", table); ok || value != nil {
+				t.Fatalf("missing metadata = %v, %v; want nil, false", value, ok)
+			}
+		})
+	}
+}
+
 // Row valuer, wildcarder test
 // WindowTuples, JoinTuples, GroupTuples are collectionRow
 func TestCollectionRow(t *testing.T) {


### PR DESCRIPTION
A projection that retains only a calculated field empties `JoinTuple.Tuples`. A subsequent unqualified lookup of a discarded field then indexes `tuples[0]` and panics. Return `(nil, false)` when there are no source tuples, while preserving calculated-field lookups.

The regression exercises `Pick` followed by value and metadata lookups, with and without a stream qualifier. It reproduces the panic before the fix. Related to the crash reported in #4095; this does not address the separate Redis lookup/projection result reported there.

Validation on Windows, Go 1.27.1: `go test -race ./internal/xsql -skip '^TestComparison$' -count=1` passes. The full package run fails only `TestComparison` because it expects UTC in formatted errors; the same test fails on the baseline in this machine's CST timezone. `go vet ./internal/xsql` reports the existing copied-lock warning at `row.go:187` on both versions.