### PR TITLE
fix(planner): binding for direct field aliases

### DIFF
--- a/internal/topo/planner/analyzer.go
+++ b/internal/topo/planner/analyzer.go
@@ -82,6 +82,7 @@ func decorateStmt(s *ast.SelectStatement, opt *def.RuleOption, isTemp bool) ([]*
 	var (
 		walkErr            error
 		aliasFields        []*ast.Field
+		precedingAliasRefs = make(map[*ast.FieldRef]struct{})
 		analyticFieldFuncs []*ast.Call
 		analyticFuncs      []*ast.Call
 	)
@@ -121,8 +122,13 @@ func decorateStmt(s *ast.SelectStatement, opt *def.RuleOption, isTemp bool) ([]*
 			case *ast.FieldRef:
 				skipBind := false
 				for j := 0; j < i; j++ {
-					if s.Fields[j].AName == nf.Name {
+					if s.Fields[j].AName == nf.Name && (nf.StreamName == "" || nf.StreamName == ast.DefaultStream) {
 						skipBind = true
+						// The alias expression is not available until the next pass.
+						// Remember the reference so direct field aliases in schemaless
+						// streams do not depend on matching a bound stream name.
+						precedingAliasRefs[nf] = struct{}{}
+						break
 					}
 				}
 				if !skipBind {
@@ -163,7 +169,8 @@ func decorateStmt(s *ast.SelectStatement, opt *def.RuleOption, isTemp bool) ([]*
 					ast.WalkFunc(&subF, func(node ast.Node) bool {
 						switch fr := node.(type) {
 						case *ast.FieldRef:
-							if fr.Name == f.AName && fr.StreamName == streamName {
+							_, isPrecedingAlias := precedingAliasRefs[fr]
+							if fr.Name == f.AName && (fr.StreamName == streamName || isPrecedingAlias) {
 								fr.StreamName = ast.AliasStream
 								fr.AliasRef = ar
 							}

--- a/internal/topo/planner/analyzer_test.go
+++ b/internal/topo/planner/analyzer_test.go
@@ -204,7 +204,8 @@ func TestLeadUntilPlan(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, kvStore.Set("lead_src", string(encoded)))
 
-	sql := `SELECT latest(ts) OVER (WHEN a < 5 AND isNull(b)) AS candidate_t2 INVISIBLE,
+	sql := `SELECT ts AS input_ts INVISIBLE,
+		latest(input_ts) OVER (WHEN a < 5 AND isNull(b)) AS candidate_t2 INVISIBLE,
 		lead(candidate_t2) OVER (WHEN isNull(b) = false UNTIL ts - current_row(ts) > 5) AS t2
 		FROM lead_src`
 	stmt, err := xsql.NewParser(strings.NewReader(sql)).Parse()
@@ -238,6 +239,14 @@ func TestLeadUntilPlan(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "latest", latest.Name)
 	require.True(t, latest.Cached)
+	inputAlias, ok := latest.Args[0].(*ast.FieldRef)
+	require.True(t, ok)
+	require.True(t, inputAlias.IsAlias())
+	require.NotNil(t, inputAlias.AliasRef)
+	rawInput, ok := inputAlias.AliasRef.Expression.(*ast.FieldRef)
+	require.True(t, ok)
+	require.Equal(t, ast.StreamName("lead_src"), rawInput.StreamName)
+	require.Equal(t, "ts", rawInput.Name)
 
 	for _, invalid := range []string{
 		`SELECT latest(lead(ts)) FROM lead_src`,
@@ -248,6 +257,64 @@ func TestLeadUntilPlan(t *testing.T) {
 		_, err = CreateLogicalPlan(stmt, &def.RuleOption{SendError: true}, kvStore)
 		require.ErrorContains(t, err, "lead output cannot feed")
 	}
+}
+
+func TestSchemalessDirectFieldAliasBinding(t *testing.T) {
+	kvStore, err := store.GetKV("stream")
+	require.NoError(t, err)
+	streamSQL := `CREATE STREAM schemaless_alias_src () WITH (DATASOURCE="schemaless_alias_src", FORMAT="json");`
+	encoded, err := json.Marshal(&xsql.StreamInfo{StreamType: ast.TypeStream, Statement: streamSQL})
+	require.NoError(t, err)
+	require.NoError(t, kvStore.Set("schemaless_alias_src", string(encoded)))
+
+	sql := `SELECT temp AS input_temp INVISIBLE,
+		CASE WHEN input_temp > 26 THEN 1 ELSE 0 END AS state_condition INVISIBLE,
+		latest(state_condition, 0) AS state
+		FROM schemaless_alias_src`
+	stmt, err := xsql.NewParser(strings.NewReader(sql)).Parse()
+	require.NoError(t, err)
+	plan, err := CreateLogicalPlan(stmt, &def.RuleOption{SendError: true}, kvStore)
+	require.NoError(t, err)
+
+	var project *ProjectPlan
+	var findProject func(LogicalPlan)
+	findProject = func(current LogicalPlan) {
+		if value, ok := current.(*ProjectPlan); ok {
+			project = value
+			return
+		}
+		for _, child := range current.Children() {
+			findProject(child)
+		}
+	}
+	findProject(plan)
+	require.NotNil(t, project)
+
+	var conditionAlias *ast.FieldRef
+	for _, field := range project.fields {
+		if field.AName == "state_condition" {
+			conditionAlias, _ = field.Expr.(*ast.FieldRef)
+			break
+		}
+	}
+	require.NotNil(t, conditionAlias)
+	require.True(t, conditionAlias.IsAlias())
+	require.NotNil(t, conditionAlias.AliasRef)
+
+	var inputAlias *ast.FieldRef
+	ast.WalkFunc(conditionAlias.AliasRef.Expression, func(node ast.Node) bool {
+		if field, ok := node.(*ast.FieldRef); ok && field.Name == "input_temp" {
+			inputAlias = field
+		}
+		return true
+	})
+	require.NotNil(t, inputAlias)
+	require.True(t, inputAlias.IsAlias())
+	require.NotNil(t, inputAlias.AliasRef)
+	rawInput, ok := inputAlias.AliasRef.Expression.(*ast.FieldRef)
+	require.True(t, ok)
+	require.Equal(t, ast.StreamName("schemaless_alias_src"), rawInput.StreamName)
+	require.Equal(t, "temp", rawInput.Name)
 }
 
 func Test_validation(t *testing.T) {

--- a/internal/topo/topotest/rule_test.go
+++ b/internal/topo/topotest/rule_test.go
@@ -1747,7 +1747,7 @@ func TestWindowSQL(t *testing.T) {
 }
 
 func TestAliasSQL(t *testing.T) {
-	streamList := []string{"demo"}
+	streamList := []string{"demo", "demoE2"}
 	HandleStream(false, streamList, t)
 	tests := []RuleTest{
 		{
@@ -1854,6 +1854,30 @@ func TestAliasSQL(t *testing.T) {
 					{
 						"a": 1,
 						"b": int64(2),
+					},
+				},
+			},
+		},
+		{
+			Name: "TestSchemalessInvisibleRawAliasInAnalytic",
+			Sql: `SELECT temp AS input_temp INVISIBLE,
+				CASE WHEN input_temp > 26 THEN 1 ELSE 0 END AS state_condition INVISIBLE,
+				latest(state_condition, 0) AS state
+				FROM demoE2`,
+			R: [][]map[string]interface{}{
+				{
+					{
+						"state": int64(1),
+					},
+				},
+				{
+					{
+						"state": int64(0),
+					},
+				},
+				{
+					{
+						"state": int64(0),
 					},
 				},
 			},


### PR DESCRIPTION
## Summary
- Fix planner binding for unqualified references to preceding direct field aliases.
- Preserve qualified source-field references in multi-stream queries.
- Add planner and runtime coverage for schema-less, INVISIBLE, latest, and lead alias chains.

## Why
- In a schema-less stream, a direct alias such as `temp AS input_temp` is bound to the physical stream, while a later unqualified `input_temp` reference can remain unbound.
- The reference is therefore not rewritten as an `AliasRef`. Analytic operators run before projection and read it as a missing source field, producing `nil` and incorrect state transitions.
- SELECT alias reuse is documented behavior, so the planner must resolve this chain before runtime.

## Changes In This PR
- Track unqualified references that intentionally skip source binding because they target a preceding SELECT alias.
- Bind those references to the alias in the second alias-resolution pass without relying on stream-name equality.
- Keep explicitly qualified fields bound to their original streams, including JOIN queries with same-named columns.
- Extend planner tests for a direct field alias feeding `latest` and `lead`.
- Add a runtime regression for a schema-less INVISIBLE alias chain feeding analytic state.

## Notes
- No SQL syntax, stream configuration, or operator ordering changes are required.
- Validation:
  - `go test -tags test ./internal/topo/planner ./internal/topo/operator -count=1`
  - `go test -tags test ./internal/topo/topotest -run '^TestAliasSQL$' -count=1`